### PR TITLE
VK 最新記事で複数投稿タイプを扱えるように

### DIFF
--- a/inc/other-widget/widget-new-posts.php
+++ b/inc/other-widget/widget-new-posts.php
@@ -63,7 +63,7 @@ class WP_Widget_vkExUnit_post_list extends WP_Widget {
 		}
 
 		$count       = ( isset( $instance['count'] ) && $instance['count'] ) ? $instance['count'] : 10;
-		$post_type   = ( isset( $instance['post_type'] ) && $instance['post_type'] ) ? $instance['post_type'] : 'post';
+		$post_type   = ( isset( $instance['post_type'] ) && $instance['post_type'] ) ? explode( ',', $instance['post_type'] ) : 'post';
 		$is_modified = ( isset( $instance['orderby'] ) && $instance['orderby'] == 'modified' );
 		$orderby     = ( isset( $instance['orderby'] ) ) ? $instance['orderby'] : 'date';
 


### PR DESCRIPTION
VK 最新記事で複数投稿タイプを扱えるように widget-new-posts.php を編集しました。
（投稿タイプの欄でカンマ区切リで入力することで複数投稿タイプを指定可能に）
説明文は書き方がよくわからなかったので付加していません。