### PR TITLE
【引き続き作業待ち】バックスラッシュが増殖するバグを修正

### DIFF
--- a/inc/wp-title/package/wp-title.php
+++ b/inc/wp-title/package/wp-title.php
@@ -146,6 +146,6 @@ function vkExUnit_get_wp_title_default() {
 
 function vkExUnit_wp_title_validate( $input ) {
 	$output                      = array();
-	$output['extend_frontTitle'] = htmlspecialchars( $input['extend_frontTitle'] );
+	$output['extend_frontTitle'] = stripslashes( htmlspecialchars( $input['extend_frontTitle'] ) );
 	return $output;
 }


### PR DESCRIPTION
https://wordpress.org/support/topic/inputtextarea%e3%81%a7%e3%82%a8%e3%82%b9%e3%82%b1%e3%83%bc%e3%83%97%e6%96%87%e5%ad%97%e3%81%8c%e5%a2%97%e6%ae%96%e3%81%99%e3%82%8b-2/

上記の件の修正が終わりました。
エスケープ文字を入力するのが個人的にはまれだと思うので上記で指摘された部分のみ修正しました。
[stripslashes](https://www.php.net/manual/ja/function.stripslashes.php) で何故か増えるバックスラッシュを消す処理をしています