### PR TITLE
【確認待ち】input,textareaでエスケープ文字が増殖する

### DIFF
--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -586,7 +586,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						$option[ $key ] = 'random';
 					} else {
 						if ( 'hook_point' === $key ) {
-							$option[ $key ] = sanitize_text_field( $value );
+							$option[ $key ] = stripslashes( sanitize_text_field( $value ) );
 						} else {
 							$option[ $key ] = ( is_numeric( $value ) ) ? $value : 0;
 						}

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -303,6 +303,7 @@ class VkExUnit_Contact {
 		$option['button_text']  = stripslashes( $option['button_text'] );
 		$option['button_text_small']  = stripslashes( $option['button_text_small'] );
 		$option['short_text']  = stripslashes( $option['short_text'] );
+		$option['contact_image']  = esc_url( $option['contact_image'] );
 		$option['contact_html'] = stripslashes( $option['contact_html'] );
 		return $option;
 	}

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -295,6 +295,14 @@ class VkExUnit_Contact {
 	}
 
 	public function option_sanitaize( $option ) {
+		$option['contact_txt']  = stripslashes( $option['contact_txt'] );
+		$option['tel_number']  = stripslashes( $option['tel_number'] );
+		$option['tel_icon']  = stripslashes( $option['tel_icon'] );
+		$option['contact_time']  = stripslashes( $option['contact_time'] );
+		$option['contact_link']  = stripslashes( $option['contact_link'] );
+		$option['button_text']  = stripslashes( $option['button_text'] );
+		$option['button_text_small']  = stripslashes( $option['button_text_small'] );
+		$option['short_text']  = stripslashes( $option['short_text'] );
 		$option['contact_html'] = stripslashes( $option['contact_html'] );
 		return $option;
 	}

--- a/inc/google_analytics/google_analytics.php
+++ b/inc/google_analytics/google_analytics.php
@@ -55,7 +55,7 @@ function vkExUnit_ga_options_validate( $input ) {
 	$input = wp_parse_args( $input, $defaults );
 
 	// 入力値をサニタイズ
-	$output['gaId']   = esc_html( $input['gaId'] );
+	$output['gaId']   = stripslashes( esc_html( $input['gaId'] ) );
 	$output['gaType'] = esc_html( $input['gaType'] );
 
 	return apply_filters( 'vkExUnit_ga_options_validate', $output, $input, $defaults );

--- a/inc/insert-ads.php
+++ b/inc/insert-ads.php
@@ -147,7 +147,7 @@ class vExUnit_Ads {
 		$option                               = $input;
 		$option['google-ads-active']          = ( isset( $input['google-ads-active'] ) ) ? esc_attr( $input['google-ads-active'] ) : '';
 		$option['google-ads-overlays-bottom'] = ( isset( $input['google-ads-overlays-bottom'] ) ) ? esc_attr( $input['google-ads-overlays-bottom'] ) : '';
-		$option['google-pub-id']              = ( isset( $input['google-pub-id'] ) ) ? esc_attr( $input['google-pub-id'] ) : '';
+		$option['google-pub-id']              = ( isset( $input['google-pub-id'] ) ) ? stripslashes( esc_attr( $input['google-pub-id'] ) ) : '';
 		$option['before'][0]                  = stripslashes( $input['before'][0] );
 		$option['before'][1]                  = stripslashes( $input['before'][1] );
 		$option['more'][0]                    = stripslashes( $input['more'][0] );

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -253,7 +253,7 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output = $defaults = veu_get_sns_options_default();
 
 	$output['fbAppId']                     = stripslashes( esc_attr( $input['fbAppId'] ) );
-	$output['fbPageUrl']                   = stripslashes( esc_url( $input['fbPageUrl'] ) );
+	$output['fbPageUrl']                   = esc_url( $input['fbPageUrl'] );
 	$output['fbAccessToken']               = stripslashes( esc_attr( $input['fbAccessToken'] ) );
 	$output['ogImage']                     = esc_url( $input['ogImage'] );
 	$output['twitterId']                   = stripslashes( esc_attr( $input['twitterId'] ) );

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -252,11 +252,11 @@ function veu_get_the_sns_title( $post_id = '' ) {
 function vkExUnit_sns_options_validate( $input ) {
 	$output = $defaults = veu_get_sns_options_default();
 
-	$output['fbAppId']                     = esc_attr( $input['fbAppId'] );
-	$output['fbPageUrl']                   = esc_url( $input['fbPageUrl'] );
-	$output['fbAccessToken']               = esc_attr( $input['fbAccessToken'] );
+	$output['fbAppId']                     = stripslashes( esc_attr( $input['fbAppId'] ) );
+	$output['fbPageUrl']                   = stripslashes( esc_url( $input['fbPageUrl'] ) );
+	$output['fbAccessToken']               = stripslashes( esc_attr( $input['fbAccessToken'] ) );
 	$output['ogImage']                     = esc_url( $input['ogImage'] );
-	$output['twitterId']                   = esc_attr( $input['twitterId'] );
+	$output['twitterId']                   = stripslashes( esc_attr( $input['twitterId'] ) );
 	$output['snsBtn_ignorePosts']          = preg_replace( '/[^0-9,]/', '', $input['snsBtn_ignorePosts'] );
 	$output['snsTitle_use_only_postTitle'] = ( isset( $input['snsTitle_use_only_postTitle'] ) && $input['snsTitle_use_only_postTitle'] ) ? true : false;
 	$output['enableOGTags']                = ( isset( $input['enableOGTags'] ) && $input['enableOGTags'] ) ? true : false;
@@ -265,7 +265,7 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output['snsBtn_exclude_post_types']   = ( isset( $input['snsBtn_exclude_post_types'] ) ) ? $input['snsBtn_exclude_post_types'] : '';
 	$output['snsBtn_position']             = ( isset( $input['snsBtn_position'] ) ) ? $input['snsBtn_position'] : '';
 	$output['enableFollowMe']              = ( isset( $input['enableFollowMe'] ) && $input['enableFollowMe'] ) ? true : false;
-	$output['followMe_title']              = $input['followMe_title'];
+	$output['followMe_title']              = stripslashes( $input['followMe_title'] );
 	$output['useFacebook']                 = ( isset( $input['useFacebook'] ) && $input['useFacebook'] == 'true' );
 	$output['useTwitter']                  = ( isset( $input['useTwitter'] ) && $input['useTwitter'] == 'true' );
 	$output['useHatena']                   = ( isset( $input['useHatena'] ) && $input['useHatena'] == 'true' );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://wordpress.org/support/topic/inputtextarea%e3%81%a7%e3%82%a8%e3%82%b9%e3%82%b1%e3%83%bc%e3%83%97%e6%96%87%e5%ad%97%e3%81%8c%e5%a2%97%e6%ae%96%e3%81%99%e3%82%8b-2/

## どういう変更をしたか？
下記でエスケープ文字が増殖しないようにしました。
URL が入力されるべきところは URL が入力されるようにしました。

■トップページの<title>タグ
トップページの<title>タグ

■SNS Settings
facebookアプリケーションID
Facebook アクセストークン
Twitter ID
Follow me box > Follow me box の見出しテキスト

■Google Analytics設定
Google Analytics設定

■連絡先情報
メッセージ
電話番号
電話アイコン
営業時間
お問い合わせ先URL
お問い合わせボタンに表示するテキスト
お問い合わせボタンに表示するテキスト2（オプション）
お問い合わせボタンウィジェットに表示するテキスト
お問い合わせバナー画像

■Call To Action
表示場所（オプション）

■広告の挿入
Google自動広告 > サイト運営者ID

## 確認事項

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど
上記テキストエリア等で \m\n と入力し設定を保存しました。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワー確認方法・確認内容など
上記テキストエリア等全てでエスケープ文字を含む文字列をと入力し設定を保存。

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
