### PR TITLE
【確認待ち】有効化設定画面で warning が表示されないように

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -36,16 +36,17 @@ function veu_setting_menu_parent() {
 	$menu_title = veu_get_little_short_name();
 	$capability_required = 'activate_plugins';
 	$menu_slug = 'vkExUnit_setting_page';
-	$icon_url = 'none';
 	$callback_function = 'veu_add_setting_page';
+	$icon_url = 'none';	
 
 	$custom_page = add_menu_page(
 		$page_title,
 		$menu_title,
 		$capability_required,
 		$menu_slug,
+		$callback_function,
 		$icon_url,
-		$callback_function
+		
 	);
 	if ( ! $custom_page ) {
 		return; }

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -45,9 +45,9 @@ function veu_setting_menu_parent() {
 		$capability_required,
 		$menu_slug,
 		$callback_function,
-		$icon_url,
-		
+		$icon_url,		
 	);
+	
 	if ( ! $custom_page ) {
 		return; }
 }

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -47,9 +47,10 @@ function veu_setting_menu_parent() {
 		$callback_function,
 		$icon_url,		
 	);
-	
+
 	if ( ! $custom_page ) {
-		return; }
+		return; 
+	}
 }
 
 add_action( 'admin_menu', 'veu_active_setting_menu', 10 );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/794
https://vws.vektor-inc.co.jp/forums/topic/exunit-activate-setting-warning

## どういう変更をしたか？

有効化設定画面で warning が表示されないようにしました。
add_menu_page の使い方が間違っていたのを修正しました。
https://developer.wordpress.org/reference/functions/add_menu_page/


## 確認事項

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

有効化設定画面で warning が表示されないのを確認しました。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワー確認方法・確認内容など

ExUnit の有効化設定画面を開いて Warning が表示されないのを確認する

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
