### PR TITLE
【確認待ち】Google Analyticsのタグはログイン時は出力しない

### DIFF
--- a/inc/google_analytics/ga_admin.php
+++ b/inc/google_analytics/ga_admin.php
@@ -34,6 +34,8 @@ foreach ( $vkExUnit_gaTypes as $vkExUnit_gaTypeValue => $vkExUnit_gaTypeLavel ) 
 ?>
     </dd>
     </dl>
+	<label>
+<input type="checkbox" name="vkExUnit_ga_options[disableLoggedin]" id="disableLoggedin" value="true" <?php echo ( $options['disableLoggedin'] ) ? 'checked' : ''; ?> /><?php _e( 'Disable tracking of logged in user', 'vk-all-in-one-expansion-unit' ); ?></label>
 </td>
 </tr>
 </table>

--- a/inc/google_analytics/ga_customizer.php
+++ b/inc/google_analytics/ga_customizer.php
@@ -79,4 +79,25 @@ function veu_customize_register_ga( $wp_customize ) {
 		)
 	);
 
+	// Disable Logged in
+	$wp_customize->add_setting(
+		'vkExUnit_ga_options[disableLoggedin]',
+		array(
+			'default'           => '',
+			'type'              => 'option', // 保存先 option or theme_mod
+			'capability'        => 'edit_theme_options',
+			'sanitize_callback' => 'veu_sanitize_boolean',
+		)
+	);
+
+	$wp_customize->add_control(
+		'enableOGTags',
+		array(
+			'label'        => __( 'Disable tracking of logged in user', 'vk-all-in-one-expansion-unit' ),
+			'section'      => 'veu_ga_setting',
+			'settings'     => 'vkExUnit_ga_options[disableLoggedin]',
+			'type'         => 'checkbox',
+		)
+	);
+
 } // function veu_customize_register_ga( $wp_customize )

--- a/inc/google_analytics/google_analytics.php
+++ b/inc/google_analytics/google_analytics.php
@@ -84,7 +84,7 @@ function vkExUnit_googleAnalytics() {
 	$options = vkExUnit_get_ga_options();
 	$gaId    = esc_html( $options['gaId'] );
 	$gaType  = esc_html( $options['gaType'] );
-	$disableLoggedin  = esc_html( $options['disableLoggedin'] );
+	$disableLoggedin  = ($options['disableLoggedin'] ) ? true : false;
 	if ( $gaId && !$disableLoggedin) {
 
 		if ( $gaType == 'gaType_universal' ) {

--- a/inc/google_analytics/google_analytics.php
+++ b/inc/google_analytics/google_analytics.php
@@ -39,8 +39,9 @@ function vkExUnit_get_ga_options() {
 
 function vkExUnit_get_ga_options_default() {
 	$default_options = array(
-		'gaId'   => '',
-		'gaType' => 'gaType_gtag',
+		'gaId'             => '',
+		'gaType'           => 'gaType_gtag',
+		'disableLoggedin'  => false,
 	);
 	return apply_filters( 'vkExUnit_ga_options_default', $default_options );
 }
@@ -57,6 +58,7 @@ function vkExUnit_ga_options_validate( $input ) {
 	// 入力値をサニタイズ
 	$output['gaId']   = stripslashes( esc_html( $input['gaId'] ) );
 	$output['gaType'] = esc_html( $input['gaType'] );
+	$output['disableLoggedin'] = ($input['disableLoggedin'] ) ? true : false;
 
 	return apply_filters( 'vkExUnit_ga_options_validate', $output, $input, $defaults );
 }
@@ -69,6 +71,7 @@ add_action( 'init', 'vkExUnit_googleAnalytics_load' );
 function vkExUnit_googleAnalytics_load() {
 	$options = vkExUnit_get_ga_options();
 	$gaType  = esc_html( $options['gaType'] );
+	$disableLoggedin  = ($options['disableLoggedin'] ) ? true : false;
 	if ( $gaType == 'gaType_gtag' ) {
 		$priority = 0;
 	} else {
@@ -81,7 +84,8 @@ function vkExUnit_googleAnalytics() {
 	$options = vkExUnit_get_ga_options();
 	$gaId    = esc_html( $options['gaId'] );
 	$gaType  = esc_html( $options['gaType'] );
-	if ( $gaId ) {
+	$disableLoggedin  = esc_html( $options['disableLoggedin'] );
+	if ( $gaId && !$disableLoggedin) {
 
 		if ( $gaType == 'gaType_universal' ) {
 			$domainUrl = home_url();

--- a/inc/google_analytics/google_analytics.php
+++ b/inc/google_analytics/google_analytics.php
@@ -85,7 +85,7 @@ function vkExUnit_googleAnalytics() {
 	$gaId    = esc_html( $options['gaId'] );
 	$gaType  = esc_html( $options['gaType'] );
 	$disableLoggedin  = ($options['disableLoggedin'] ) ? true : false;
-	if ( $gaId && !$disableLoggedin) {
+	if ( $gaId && !( $disableLoggedin && is_user_logged_in())) {
 
 		if ( $gaType == 'gaType_universal' ) {
 			$domainUrl = home_url();

--- a/readme.txt
+++ b/readme.txt
@@ -927,7 +927,7 @@ Restore version 9
 
 = 6.1.0 =
 * [ Add Function ] Add Page Top Button
-* [ a ][ Add function ] Add customizer setting
+* [ Google Analytics ][ Add function ] Add customizer setting
 
 = 6.0.0 =
 * [ Add Widget ] Add Twitter Widget.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+* [ Google Analytics ][ Add function ] Add option for disable tracking of logged in user
+
 = 9.73.3.0 =
 * [ Bug fix ] Fix Admin Fatal Error 
 
@@ -925,7 +927,7 @@ Restore version 9
 
 = 6.1.0 =
 * [ Add Function ] Add Page Top Button
-* [ Google Analytics ][ Add function ] Add customizer setting
+* [ a ][ Add function ] Add customizer setting
 
 = 6.0.0 =
 * [ Add Widget ] Add Twitter Widget.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
[ Google Analyticsのタグはログイン時は出力しないでほしい #800 ](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/800)

## どういう変更をしたか？
Google Analytics設定にチェックボックス「Disable tracking of logged in user」を追加し、ログインしている状態のときにもGoogle Analytics を出力するか？しないか？選べるようにしました

* このプルリクで変更した事を記載してください

- [x] Google Analytics設定にチェックボックス「Disable tracking of logged in user」を追加
- [x] チェックなし: Google Analyticsを常に出力(いままでどおり)
- [x] チェックあり: ログインしていない状態であればGoogle Analyticsを出力
- [x] チェックあり: ログインしている状態であればGoogle Analyticsを出力しない
- [x] [外観]-[カスタマイズ]-[ExUnit設定]にも、同じ設定項目を追加


## 確認事項

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワー確認方法・確認内容など


### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
