### PR TITLE
【確認待ち】VK Blocksの余白設定をExUnit内のブロックに追加

### DIFF
--- a/inc/child-page-index/child-page-index.php
+++ b/inc/child-page-index/child-page-index.php
@@ -40,8 +40,8 @@ function veu_childPageIndex_block_callback( $attributes = array() ) {
 		$classes .= ' ' . $attributes['className'];
 	}
 
-	if ( function_exists( 'veu_add_hidden_class' ) ) {
-		$classes .= ' ' . veu_add_hidden_class( $classes, $attributes );
+	if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+		$classes .= ' ' . veu_add_common_attributes_class( $classes, $attributes );
 	}
 
 	$postId = ( $attributes['postId'] > 0 ) ? $attributes['postId'] : get_the_ID();

--- a/inc/common-block.php
+++ b/inc/common-block.php
@@ -94,17 +94,25 @@ function veu_common_attributes() {
 			'type'    => 'boolean',
 			'default' => false,
 		),
+		'marginTop'        => array(
+			'type'    => 'string',
+			'default' => '',
+		),
+		'marginBottom'     => array(
+			'type'    => 'string',
+			'default' => '',
+		),
 	);
 	return $common_attributes;
 }
 
 /**
- * Hidden Class Options
+ * Common Class Options
  *
  * @param string $classes added classes.
  * @param string $attributes attributes.
  */
-function veu_add_hidden_class( $classes, $attributes ) {
+function veu_add_common_attributes_class( $classes, $attributes ) {
 
 	if ( isset( $attributes['vkb_hidden'] ) && $attributes['vkb_hidden'] ) {
 		$classes .= ' vk_hidden';
@@ -126,6 +134,12 @@ function veu_add_hidden_class( $classes, $attributes ) {
 	}
 	if ( isset( $attributes['vkb_hidden_xs'] ) && $attributes['vkb_hidden_xs'] ) {
 		$classes .= ' vk_hidden-xs';
+	}
+	if ( isset( $attributes['marginTop'] ) && $attributes['marginTop'] ) {
+		$classes .= ' ' . $attributes['marginTop'];
+	}
+	if ( isset( $attributes['marginBottom'] ) && $attributes['marginBottom'] ) {
+		$classes .= ' ' . $attributes['marginBottom'];
 	}
 
 	return $classes;

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -149,8 +149,8 @@ class VkExUnit_Contact {
 		if ( isset($attributes['className']) ) {
 			$classes .= ' ' . $attributes['className'];
 		}
-		if ( function_exists( 'veu_add_hidden_class' ) ) {
-			$classes .= ' ' . veu_add_hidden_class( $classes, $attributes );
+		if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+			$classes .= ' ' . veu_add_common_attributes_class( $classes, $attributes );
 		}
 
 		$r = self::render_contact_section_html( $classes, false );

--- a/inc/page-list-ancestor/page-list-ancestor.php
+++ b/inc/page-list-ancestor/page-list-ancestor.php
@@ -172,8 +172,8 @@ function veu_pageListAncestor_block_callback( $attr=array() ) {
 		$classes .= ' ' . $attr['className'];
 	}
 
-	if( function_exists( 'veu_add_hidden_class' ) ){
-		$classes .= ' ' . veu_add_hidden_class($classes, $attr);
+	if( function_exists( 'veu_add_common_attributes_class' ) ){
+		$classes .= ' ' . veu_add_common_attributes_class($classes, $attr);
 	}
 	
 	$r = vkExUnit_pageList_ancestor_shortcode( $classes, true );

--- a/inc/sitemap-page/sitemap-page.php
+++ b/inc/sitemap-page/sitemap-page.php
@@ -90,9 +90,9 @@ function veu_show_sitemap( $content ) {
 function vkExUnit_sitemap( $attr ) {
 
 	$classes = '';
-	if ( function_exists( 'veu_add_hidden_class' ) ) {
-		if ( veu_add_hidden_class( $classes, $attr ) ) {
-			$classes .= ' ' . veu_add_hidden_class( $classes, $attr );
+	if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+		if ( veu_add_common_attributes_class( $classes, $attr ) ) {
+			$classes .= ' ' . veu_add_common_attributes_class( $classes, $attr );
 		}
 	}
 

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -190,8 +190,8 @@ function veu_get_sns_btns( $attr = array() ) {
 	$page_title = rawurlencode( veu_get_the_sns_title() );
 
 	$classes = '';
-	if ( function_exists( 'veu_add_hidden_class' ) ) {
-		$classes .= veu_add_hidden_class( $classes, $attr );
+	if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+		$classes .= veu_add_common_attributes_class( $classes, $attr );
 	}
 
 	if ( isset( $attr['position'] ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+* [ Bug fix ] Fixed add common attributes ( attribute from VK Blocks 1.29 - )
+
 = 9.74.1.0 =
 * [ Bug fix ] Fixed ExUnit icon appearing in other menus
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

ExUnit内のブロックで共通余白を設定しても公開画面でクラス名が設定されない、もしくは編集画面でブロックにエラーが生じるため
関連 https://github.com/vektor-inc/vk-blocks-pro/pull/1105

## どういう変更をしたか？

共通のattribute変数に余白を追加
その変数を追加する関数名の変更

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

確認用HTML
```HTML
<!-- wp:heading -->
<h2>ExUnitのブロック一覧</h2>
<!-- /wp:heading -->

<!-- wp:vk-blocks/share-button /-->

<!-- wp:vk-blocks/child-page-index {"postId":1} /-->

<!-- wp:vk-blocks/contact-section /-->

<!-- wp:vk-blocks/page-list-ancestor /-->

<!-- wp:vk-blocks/sitemap /-->
```

1. VK BlocksとExUnitを有効化した環境を用意する
2. 配布済みバージョンでExUnitのブロックを配置
3. ExUnitのブロックの共通余白機能の挙動を確認
公開画面でクラス名が付かないor編集画面でエラーが発生する
4. このブランチでExUnitのブロックを配置し共通余白機能が通常のブロックと同様に同様に使用できることを確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

上記確認方法と同じ、他なにか気になる箇所があればご指摘お願いします。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
