### PR TITLE
【確認中】[ Child Page List / Contact section / Page list from ancestor ] クラス名の重複を調整

### DIFF
--- a/inc/child-page-index/child-page-index.php
+++ b/inc/child-page-index/child-page-index.php
@@ -34,15 +34,14 @@ function veu_child_page_excerpt( $post ) {
 }
 
 function veu_childPageIndex_block_callback( $attributes = array() ) {
-	
-	$classes = '';
-	if ( function_exists( 'veu_add_common_attributes_class' ) ) {
-		$classes .= veu_add_common_attributes_class( $classes, $attributes );
-	}
-	
-	$classes .= 'veu_childPageIndex_block';
+	$classes = 'veu_childPageIndex_block';
+
 	if ( isset( $attributes['className'] ) ) {
 		$classes .= ' ' . $attributes['className'];
+	}
+
+	if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+		$classes = veu_add_common_attributes_class( $classes, $attributes );
 	}
 
 	$postId = ( $attributes['postId'] > 0 ) ? $attributes['postId'] : get_the_ID();

--- a/inc/child-page-index/child-page-index.php
+++ b/inc/child-page-index/child-page-index.php
@@ -34,14 +34,15 @@ function veu_child_page_excerpt( $post ) {
 }
 
 function veu_childPageIndex_block_callback( $attributes = array() ) {
-	$classes = 'veu_childPageIndex_block';
-
+	
+	$classes = '';
+	if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+		$classes .= veu_add_common_attributes_class( $classes, $attributes );
+	}
+	
+	$classes .= 'veu_childPageIndex_block';
 	if ( isset( $attributes['className'] ) ) {
 		$classes .= ' ' . $attributes['className'];
-	}
-
-	if ( function_exists( 'veu_add_common_attributes_class' ) ) {
-		$classes .= ' ' . veu_add_common_attributes_class( $classes, $attributes );
 	}
 
 	$postId = ( $attributes['postId'] > 0 ) ? $attributes['postId'] : get_the_ID();

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -142,18 +142,15 @@ class VkExUnit_Contact {
 
 	public static function block_callback( $attributes=array() ) {
 
-		$classes = '';
-		if ( function_exists( 'veu_add_common_attributes_class' ) ) {
-			$classes .= veu_add_common_attributes_class( $classes, $attributes );
-		}
-
-		$classes .= 'veu_contact_section_block';
-
+		$classes = 'veu_contact_section_block';
 		if ( empty( $attributes['vertical'] ) ) {
 			$classes .= ' veu_contact-layout-horizontal';
 		}
 		if ( isset($attributes['className']) ) {
 			$classes .= ' ' . $attributes['className'];
+		}
+		if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+			$classes = veu_add_common_attributes_class( $classes, $attributes );
 		}
 
 		$r = self::render_contact_section_html( $classes, false );

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -142,15 +142,18 @@ class VkExUnit_Contact {
 
 	public static function block_callback( $attributes=array() ) {
 
-		$classes = 'veu_contact_section_block';
+		$classes = '';
+		if ( function_exists( 'veu_add_common_attributes_class' ) ) {
+			$classes .= veu_add_common_attributes_class( $classes, $attributes );
+		}
+
+		$classes .= 'veu_contact_section_block';
+
 		if ( empty( $attributes['vertical'] ) ) {
 			$classes .= ' veu_contact-layout-horizontal';
 		}
 		if ( isset($attributes['className']) ) {
 			$classes .= ' ' . $attributes['className'];
-		}
-		if ( function_exists( 'veu_add_common_attributes_class' ) ) {
-			$classes .= ' ' . veu_add_common_attributes_class( $classes, $attributes );
 		}
 
 		$r = self::render_contact_section_html( $classes, false );

--- a/inc/page-list-ancestor/page-list-ancestor.php
+++ b/inc/page-list-ancestor/page-list-ancestor.php
@@ -167,11 +167,11 @@ function veu_page_list_ancestor_block_setup() {
 function veu_pageListAncestor_block_callback( $attr=array() ) {
 
 	$classes = 'veu_childPageIndex_block';
-	
+
 	if ( isset($attr['className']) ) {
 		$classes .= ' ' . $attr['className'];
 	}
-	
+
 	if( function_exists( 'veu_add_common_attributes_class' ) ){
 		$classes = veu_add_common_attributes_class($classes, $attr);
 	}

--- a/inc/page-list-ancestor/page-list-ancestor.php
+++ b/inc/page-list-ancestor/page-list-ancestor.php
@@ -166,17 +166,15 @@ function veu_page_list_ancestor_block_setup() {
 
 function veu_pageListAncestor_block_callback( $attr=array() ) {
 
-	$classes = '';
-	if( function_exists( 'veu_add_common_attributes_class' ) ){
-		$classes .= veu_add_common_attributes_class($classes, $attr);
-	}
-
-	$classes .= 'veu_childPageIndex_block';
-
+	$classes = 'veu_childPageIndex_block';
+	
 	if ( isset($attr['className']) ) {
 		$classes .= ' ' . $attr['className'];
 	}
-
+	
+	if( function_exists( 'veu_add_common_attributes_class' ) ){
+		$classes = veu_add_common_attributes_class($classes, $attr);
+	}
 	
 	$r = vkExUnit_pageList_ancestor_shortcode( $classes, true );
 

--- a/inc/page-list-ancestor/page-list-ancestor.php
+++ b/inc/page-list-ancestor/page-list-ancestor.php
@@ -166,15 +166,17 @@ function veu_page_list_ancestor_block_setup() {
 
 function veu_pageListAncestor_block_callback( $attr=array() ) {
 
-	$classes = 'veu_childPageIndex_block';
+	$classes = '';
+	if( function_exists( 'veu_add_common_attributes_class' ) ){
+		$classes .= veu_add_common_attributes_class($classes, $attr);
+	}
+
+	$classes .= 'veu_childPageIndex_block';
 
 	if ( isset($attr['className']) ) {
 		$classes .= ' ' . $attr['className'];
 	}
 
-	if( function_exists( 'veu_add_common_attributes_class' ) ){
-		$classes .= ' ' . veu_add_common_attributes_class($classes, $attr);
-	}
 	
 	$r = vkExUnit_pageList_ancestor_shortcode( $classes, true );
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+* [ Bug fix ][ Child Page List / Contact section / Page list from ancestor ] Fix duplicate Additional CSS classes.
+
 = 9.75.0.0 =
 * [ Bug fix ] Fixed add common attributes ( attribute from VK Blocks 1.29 - )
 * [ Specification Change ] Use composer vk-term-color


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

以下のプルリク確認中に見つかったクラス名の重複を修正
https://github.com/vektor-inc/vk-blocks-pro/pull/1149#issuecomment-1097856426

## どういう変更をしたか？

・子ページリスト
・お問い合わせ
・先祖階層からの子ページリスト
の追加CSS,非表示設定のクラス名の重複を調整

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？
コアでも似たようなバグを修正した時にユニットテストなどは無かったのでテストは追加していません
https://github.com/WordPress/gutenberg/pull/39777

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

・子ページリスト
・お問い合わせ
・先祖階層からの子ページリスト
を配置して追加CSSのクラス名追加,非表示設定を追加

追加CSS、非表示設定のクラス名が重複して表示されないことを確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
