### PR TITLE
【確認待ち】アクションフックで SNS ボタンを出力できるように

### DIFF
--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -4,11 +4,27 @@
  *
  * @package vk-all-in-one-expantion-unit
  */
-
-if ( 'content' === veu_content_filter_state() ) {
+$options = veu_get_sns_options();
+if ( ! empty( $options['hook_point'] ) ) {
+	$hook_points = explode( "\n", $options['hook_point'] );
+	foreach ( $hook_points as $hook_point ) {
+		add_action( $hook_point, 'veu_add_sns_btns_hook' );
+	}
+} elseif ( 'content' === veu_content_filter_state() ) {
 	add_filter( 'the_content', 'veu_add_sns_btns', 200, 1 );
 } else {
 	add_action( 'loop_end', 'veu_add_sns_btns_loopend' );
+}
+
+
+/**
+ * Display share button on hook point
+ *
+ * @param object $query : main query.
+ * @return void
+ */
+function veu_add_sns_btns_hook( $query ) {
+	echo veu_get_sns_btns();
 }
 
 /**

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -8,7 +8,7 @@ $options = veu_get_sns_options();
 if ( ! empty( $options['hook_point'] ) ) {
 	$hook_points = explode( "\n", $options['hook_point'] );
 	foreach ( $hook_points as $hook_point ) {
-		add_action( $hook_point, 'veu_add_sns_btns_hook' );
+		add_action( $hook_point, 'veu_the_sns_btns' );
 	}
 } elseif ( 'content' === veu_content_filter_state() ) {
 	add_filter( 'the_content', 'veu_add_sns_btns', 200, 1 );
@@ -23,7 +23,7 @@ if ( ! empty( $options['hook_point'] ) ) {
  * @param object $query : main query.
  * @return void
  */
-function veu_add_sns_btns_hook( $query ) {
+function veu_the_sns_btns( $query ) {
 	echo veu_get_sns_btns();
 }
 

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -113,6 +113,7 @@ function veu_get_sns_options_default() {
 		'useLine'                     => true,
 		'useCopy'                     => true,
 		'entry_count'                 => 'get',
+		'hook_point'                  => '',
 	);
 	return apply_filters( 'vkExUnit_sns_options_default', $default_options );
 }

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -270,10 +270,17 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output['useTwitter']                  = ( isset( $input['useTwitter'] ) && $input['useTwitter'] == 'true' );
 	$output['useHatena']                   = ( isset( $input['useHatena'] ) && $input['useHatena'] == 'true' );
 	$output['usePocket']                   = ( isset( $input['usePocket'] ) && $input['usePocket'] == 'true' );
-	$output['useCopy']                   = ( isset( $input['useCopy'] ) && $input['useCopy'] == 'true' );
+	$output['useCopy']                     = ( isset( $input['useCopy'] ) && $input['useCopy'] == 'true' );
 	$output['useLine']                     = ( isset( $input['useLine'] ) && $input['useLine'] == 'true' );
 	$output['entry_count']                 = esc_attr( $input['entry_count'] );
 
+
+	$output['hook_point'] = esc_html( $input['hook_point'] );
+	$output['hook_point'] = str_replace( array("\r\n", "\r", "\n"), "\n", $output['hook_point'] );
+	$output['hook_point'] = str_replace( ' ', '', $output['hook_point'] );
+	$output['hook_point'] = str_replace( "\t", '', $output['hook_point'] );
+	$output['hook_point'] = str_replace( ',', '', $output['hook_point'] );
+	
 	/*
 	SNSボタンの塗りつぶし関連は管理画面に値がないので、カスタマイザーで保存された値を入れる必要がある
 	既に保存されている値をアップデート用にそのまま返すだけなのでサニタイズしていない

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -276,11 +276,8 @@ function vkExUnit_sns_options_validate( $input ) {
 
 
 	$output['hook_point'] = esc_html( $input['hook_point'] );
-	$output['hook_point'] = str_replace( ' ', '', $output['hook_point'] );
-	$output['hook_point'] = str_replace( '　', '', $output['hook_point'] );
-	$output['hook_point'] = str_replace( "\t", '', $output['hook_point'] );
-	$output['hook_point'] = str_replace( array( "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
-
+	$output['hook_point'] = str_replace( array( ' ', '　', "\t", "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
+	$output['hook_point'] = str_replace( "\n\n",  "\n", $output['hook_point'] );
 	
 	/*
 	SNSボタンの塗りつぶし関連は管理画面に値がないので、カスタマイザーで保存された値を入れる必要がある

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -277,6 +277,7 @@ function vkExUnit_sns_options_validate( $input ) {
 
 	$output['hook_point'] = esc_html( $input['hook_point'] );
 	$output['hook_point'] = str_replace( ' ', '', $output['hook_point'] );
+	$output['hook_point'] = str_replace( '　', '', $output['hook_point'] );
 	$output['hook_point'] = str_replace( "\t", '', $output['hook_point'] );
 	$output['hook_point'] = str_replace( array( "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
 

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -276,10 +276,10 @@ function vkExUnit_sns_options_validate( $input ) {
 
 
 	$output['hook_point'] = esc_html( $input['hook_point'] );
-	$output['hook_point'] = str_replace( array("\r\n", "\r", "\n"), "\n", $output['hook_point'] );
 	$output['hook_point'] = str_replace( ' ', '', $output['hook_point'] );
 	$output['hook_point'] = str_replace( "\t", '', $output['hook_point'] );
-	$output['hook_point'] = str_replace( ',', '', $output['hook_point'] );
+	$output['hook_point'] = str_replace( array( "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
+
 	
 	/*
 	SNSボタンの塗りつぶし関連は管理画面に値がないので、カスタマイザーで保存された値を入れる必要がある

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -199,7 +199,8 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 <td>
 <p>
 <?php _e( 'By default, it is output at the bottom of the content.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
-<?php _e( 'If you want to change the location of any action hook, enter the action hook name separated by line breaks.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
+<?php _e( 'If you want to change the location of share buttons, please enter the action hook name.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
+<?php _e( 'If you want to multiple display that, input action hook name separated by line breaks.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
 <?php _e( 'Ex) lightning_comment_before', 'POST', 'vk-all-in-one-expansion-unit' ); ?>
 </p>	
 <textarea name="vkExUnit_sns_options[hook_point]" id="hook_point" style="width:100%;" rows="2"><?php echo esc_html( $options['hook_point'] ); ?></textarea>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -200,7 +200,7 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 <p>
 <?php _e( 'By default, it is output at the bottom of the content.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
 <?php _e( 'If you want to change the location of any action hook, enter the action hook name separated by line breaks.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
-<?php _e( 'Ex) lightning_site_footer_before', 'POST', 'vk-all-in-one-expansion-unit' ); ?>
+<?php _e( 'Ex) lightning_comment_before', 'POST', 'vk-all-in-one-expansion-unit' ); ?>
 </p>	
 <textarea name="vkExUnit_sns_options[hook_point]" id="hook_point" style="width:100%;" rows="2"><?php echo esc_html( $options['hook_point'] ); ?></textarea>
 </td>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -194,6 +194,18 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 </td>
 </tr>
 
+<tr>
+	<th><label ><?php _e( 'Output action hook (optional)', 'POST', 'vk-all-in-one-expansion-unit' ); ?></label></th>
+<td>
+<p>
+<?php _e( 'By default, it is output at the bottom of the content.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
+<?php _e( 'If you want to change the location of any action hook, enter the action hook name separated by line breaks.', 'POST', 'vk-all-in-one-expansion-unit' ); ?><br>
+<?php _e( 'Ex) lightning_site_footer_before', 'POST', 'vk-all-in-one-expansion-unit' ); ?>
+</p>	
+<textarea name="vkExUnit_sns_options[hook_point]" id="hook_point" style="width:100%;" rows="2"><?php echo esc_html( $options['hook_point'] ); ?></textarea>
+</td>
+</tr>
+
 </table>
 
 <?php submit_button(); ?>

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ e.g.
 
 == Changelog ==
 
+[ Add function ][ SNS ] Add function of change out put action hook.
 [ Specification Change ][ Page list from ancestor block ] change icon
 
 = 9.77.0.0 =


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/712

## どういう変更をしたか？

* SNS ボタンをアクションフックを指定して出力できるように変更しました。

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. テーマを Lightning に変更
2. 設定画面で「lightning_entry_body_before」「lightning_comment_before」を改行区切りで入力
3. 任意の投稿の表示画面で SNS ボタンが２つ出力されているのを確認


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

1. テーマを Lightning に変更
2. 設定画面で「lightning_entry_body_before」「lightning_comment_before」を改行区切りで入力
3. 任意の投稿の表示画面で SNS ボタンが２つ出力されているのを確認

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
