### PR TITLE
【確認待ち】有効化設定の初期設定がブロックテーマの場合ブロックテーマ用の設定になるように 

### DIFF
--- a/inc/template-tags/package/template-tags-veu.php
+++ b/inc/template-tags/package/template-tags-veu.php
@@ -17,11 +17,16 @@ function veu_get_common_options() {
 	return apply_filters( 'vkExUnit_common_options', $options );
 }
 
-function veu_get_common_options_default() {
+function veu_get_common_options_default( $is_block_theme = null ) {
+
+	if ( null === $is_block_theme ) {
+		$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+
 	// hook veu_package_is_enable()
 	// パッケージの情報を取得してデフォルトの配列を作成
 	$defaults = array();
-	$packages = veu_get_packages();
+	$packages = veu_get_packages( $is_block_theme  );
 	foreach ( $packages as $key => $value ) {
 		$name                                 = $value['name'];
 		$default_options[ 'active_' . $name ] = $value['default'];

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Other ] Default setting corresponds to block theme
+
 = 9.78.1.0 =
 [ Bug Fix ][ Auto Eycatch ] Fix auto eyecatch do not display
 

--- a/tests/test-get-common-options-default.php
+++ b/tests/test-get-common-options-default.php
@@ -11,7 +11,7 @@
 class VeuGetCommonOptionsDefaultTest extends WP_UnitTestCase {
 
 	/**
-	 * SNSボタンの表示しないのチェックボックスを表示するかしないかのテスト
+	 * クラシックテーマとブロックテーマでの初期値テスト
 	 */
 	function test_veu_get_common_options_default() {
 

--- a/tests/test-get-common-options-default.php
+++ b/tests/test-get-common-options-default.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Class VeuGetPackage
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * Call to Action test case.
+ */
+class VeuGetCommonOptionsDefaultTest extends WP_UnitTestCase {
+
+	/**
+	 * SNSボタンの表示しないのチェックボックスを表示するかしないかのテスト
+	 */
+	function test_veu_get_common_options_default() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_veu_get_common_options_default' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$test_array = array(
+			array(
+				'is_block_theme' => true,
+				'correct'        => array(
+                    'active_fontawesome'                     => false,
+                    'active_wpTitle'                         => true,
+                    'active_addReusableBlockMenu'            => true,
+                    'active_add_plugin_link_to_admin_menu'   => true,
+                    'active_sns'                             => true,
+                    'active_ga'                              => true,
+                    'active_google-tag-manager'              => false,
+                    'active_metaDescription'                 => true,
+                    'active_breadcrumb'                      => false,
+                    'active_noindex'                         => true,
+                    'active_otherWidgets'                    => false,
+                    'active_archive_loop_before_widget_area' => false,
+                    'active_default_thumbnail'               => false,
+                    'active_css_customize'                   => true,
+                    'active_childPageIndex'                  => true,
+                    'active_pageList_ancestor'               => true,
+                    'active_contact_section'                 => false,
+                    'active_sitemap_page'                    => true,
+                    'active_call_to_action'                  => false,
+                    'active_insert_ads'                      => false,
+                    'active_relatedPosts'                    => true,
+                    'active_disable_ping-back'               => false,
+                    'active_disable_dashbord'                => false,
+                    'active_display_ie_alert'                => true,
+                    'active_disable_xml_sitemap'             => false,
+                    'active_disable_emoji'                   => false,
+                    'active_admin_bar'                       => true,
+                    'active_post_type_manager'               => true,
+                    'active_pagetop_button'                  => true,
+                    'active_smooth_scroll'                   => true,
+                    'active_add_body_class'                  => true,
+                    'active_nav_menu_class_custom'           => false,
+                    'active_css_optimize'                    => false,
+                    'active_auto_eyecatch'                   => false,
+                    'active_Contactform7AssetOptimize'       => false,
+                    'post_metabox_individual'                => false,
+                    'delete_options_at_deactivate'           => false,
+                    'content_filter_state'                   => 'content',
+                ),
+                array(
+                    'is_block_theme' => false,
+                    'correct'        => array(
+                        'active_fontawesome'                     => false,
+                        'active_wpTitle'                         => true,
+                        'active_addReusableBlockMenu'            => true,
+                        'active_add_plugin_link_to_admin_menu'   => true,
+                        'active_sns'                             => true,
+                        'active_ga'                              => true,
+                        'active_google-tag-manager'              => false,
+                        'active_metaDescription'                 => true,
+                        'active_breadcrumb'                      => false,
+                        'active_noindex'                         => true,
+                        'active_otherWidgets'                    => true,
+                        'active_archive_loop_before_widget_area' => false,
+                        'active_default_thumbnail'               => true,
+                        'active_css_customize'                   => true,
+                        'active_childPageIndex'                  => true,
+                        'active_pageList_ancestor'               => true,
+                        'active_contact_section'                 => true,
+                        'active_sitemap_page'                    => true,
+                        'active_call_to_action'                  => true,
+                        'active_insert_ads'                      => true,
+                        'active_relatedPosts'                    => true,
+                        'active_disable_ping-back'               => false,
+                        'active_disable_dashbord'                => false,
+                        'active_display_ie_alert'                => true,
+                        'active_disable_xml_sitemap'             => false,
+                        'active_disable_emoji'                   => false,
+                        'active_admin_bar'                       => true,
+                        'active_post_type_manager'               => true,
+                        'active_pagetop_button'                  => true,
+                        'active_smooth_scroll'                   => true,
+                        'active_add_body_class'                  => true,
+                        'active_nav_menu_class_custom'           => true,
+                        'active_css_optimize'                    => false,
+                        'active_auto_eyecatch'                   => false,
+                        'active_Contactform7AssetOptimize'       => false,
+                        'post_metabox_individual'                => false,
+                        'delete_options_at_deactivate'           => false,
+                        'content_filter_state'                   => 'content',
+                    ),
+                ),
+			),
+		);
+
+		foreach ( $test_array as $key => $test_value ) {
+
+			$return = veu_get_common_options_default( $test_value['is_block_theme'] );
+
+			// 取得できたHTMLが、意図したHTMLと等しいかテスト
+			$this->assertEquals( $test_value['correct'], $return );
+
+			print PHP_EOL;
+			var_dump( 'correct :' . $test_value['correct'] . PHP_EOL );
+			var_dump( 'return  :' . $return . PHP_EOL );
+		}
+	}
+}

--- a/tests/test-get-common-options-default.php
+++ b/tests/test-get-common-options-default.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class VeuGetPackage
+ * Class VeuGetCommonOptionsDefaultTest
  *
  * @package Vk_All_In_One_Expansion_Unit
  */

--- a/veu-packages.php
+++ b/veu-packages.php
@@ -1,7 +1,10 @@
 <?php
-function veu_get_packages() {
+function veu_get_packages( $is_block_theme = null ) {
 	$required_packages = array();
-	$is_block_theme    = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	if ( null === $is_block_theme ) {
+		$is_block_theme    = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+	
 	/*
 	Example :
 	$required_packages[] = array(

--- a/veu-packages.php
+++ b/veu-packages.php
@@ -1,6 +1,7 @@
 <?php
 function veu_get_packages() {
 	$required_packages = array();
+	$is_block_theme    = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 	/*
 	Example :
 	$required_packages[] = array(
@@ -224,7 +225,7 @@ function veu_get_packages() {
 				'enable_only' => 1,
 			),
 		),
-		'default'     => true,
+		'default'     => $is_block_theme ? false : true,
 		'include'     => 'other-widget/other-widget.php',
 	);
 
@@ -260,7 +261,7 @@ function veu_get_packages() {
 				'enable_only' => 1,
 			),
 		),
-		'default'     => true,
+		'default'     => $is_block_theme ? false : true,
 		'include'     => 'default-thumbnail/default-thumbnail.php',
 	);
 
@@ -323,7 +324,7 @@ function veu_get_packages() {
 				'enable_only' => 1,
 			),
 		),
-		'default'       => true,
+		'default'       => $is_block_theme ? false : true,
 		'include'       => 'contact-section/contact-section.php',
 		'use_ex_blocks' => true,
 	);
@@ -364,7 +365,7 @@ function veu_get_packages() {
 				'enable_only' => 1,
 			),
 		),
-		'default'     => true,
+		'default'     => $is_block_theme ? false : true,
 		'include'     => 'call-to-action/call-to-action-config.php',
 	);
 
@@ -382,7 +383,7 @@ function veu_get_packages() {
 				'enable_only' => 1,
 			),
 		),
-		'default'     => true,
+		'default'     => $is_block_theme ? false : true,
 		'include'     => 'insert-ads.php',
 	);
 	/*
@@ -530,7 +531,7 @@ function veu_get_packages() {
 		'name'        => 'nav_menu_class_custom',
 		'title'       => __( 'Navi menu class custom', 'vk-all-in-one-expansion-unit' ),
 		'description' => __( 'Current class tuning of navi menu.', 'vk-all-in-one-expansion-unit' ),
-		'default'     => true,
+		'default'     => $is_block_theme ? false : true,
 		'include'     => 'nav-menu-class-custom.php',
 	);
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/835

## どういう変更をしたか？

- 有効化設定の初期設定がブロックテーマの場合ブロックテーマ用の設定になるようにしました


## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- wp-env 環境で npx wp-env destroy 後に npx wp-env start を実行してから ExUnit > 有効化設定を確認しました
- その後 WordPress のバージョンを 5.8.4 にしてから同様に確認しました


## 確認URL

wp-env 環境で npx wp-env destroy 後に npx wp-env start を実行した環境

## レビュワーの確認方法・確認する内容など

- wp-env 環境で npx wp-env destroy 後に npx wp-env start を実行してから ExUnit > 有効化設定を確認
- その後 WordPress のバージョンを 5.8.4 にしてから同様に確認

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
