### PR TITLE
[ CTA ] Change escape to only last / エスケープを return 直前だけに変更

### DIFF
--- a/inc/call-to-action/package/blocks/index.php
+++ b/inc/call-to-action/package/blocks/index.php
@@ -135,7 +135,7 @@ function veu_cta_block_callback( $attributes, $content ) {
 					$class_name .= ' ' . $attributes['className'];
 				}
 
-				$content .= '<div class="' . esc_attr( $class_name  ) . '">';
+				$content .= '<div class="' . $class_name  . '">';
 
 				// 本文に入力がある場合は本文を表示.
 				$cta_content = $cta_post->post_content;

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -112,7 +112,7 @@ class CTATest extends WP_UnitTestCase {
 					'postId'    => $test_posts['cta_post_id'],
 					'className' => '" onmouseover="alert(/XSS/)" style="background:red;"',
 				),
-				'expected'   => '<div class="veu-cta-block &quot; onmouseover=&quot;alert(/XSS/)&quot; style=&quot;background:red;&quot;">CTA content</div>',
+				'expected'   => '<div class="veu-cta-block ">CTA content</div>',
 			),
 		);
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/902 の追加対応

return 以前でエスケープ入れると

* 基本的には出力の直前でやるのが良いです。途中でやると、それこそ中途半端にエスケープされたり２重にされたりで脆弱性に繋がりやすいですね。by とろゆにさん
* テストの時に &amp;amp; とか書かないといけない by しずみさん and 僕