### PR TITLE
Revert "[ CTA ] Change escape to only last"

### DIFF
--- a/inc/call-to-action/package/blocks/index.php
+++ b/inc/call-to-action/package/blocks/index.php
@@ -135,6 +135,8 @@ function veu_cta_block_callback( $attributes, $content ) {
 					$class_name .= ' ' . $attributes['className'];
 				}
 
+				// 最後に wp_kses_post でエスケープはしているが、wp_kses_post は style は通してしまうので、
+				// クラス名入力欄に " style="background-color:red" など入力されると通してしまうため esc_attr でエスケープ.
 				$content .= '<div class="' . esc_attr( $class_name  ) . '">';
 
 				// 本文に入力がある場合は本文を表示.

--- a/inc/call-to-action/package/blocks/index.php
+++ b/inc/call-to-action/package/blocks/index.php
@@ -135,7 +135,7 @@ function veu_cta_block_callback( $attributes, $content ) {
 					$class_name .= ' ' . $attributes['className'];
 				}
 
-				$content .= '<div class="' . $class_name  . '">';
+				$content .= '<div class="' . esc_attr( $class_name  ) . '">';
 
 				// 本文に入力がある場合は本文を表示.
 				$cta_content = $cta_post->post_content;

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -112,7 +112,7 @@ class CTATest extends WP_UnitTestCase {
 					'postId'    => $test_posts['cta_post_id'],
 					'className' => '" onmouseover="alert(/XSS/)" style="background:red;"',
 				),
-				'expected'   => '<div class="veu-cta-block ">CTA content</div>',
+				'expected'   => '<div class="veu-cta-block &quot; onmouseover=&quot;alert(/XSS/)&quot; style=&quot;background:red;&quot;">CTA content</div>',
 			),
 		);
 


### PR DESCRIPTION
This reverts commit 0018dc53e9c0c96571cd3652e7d3c3fd3d0960ec.

## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

esc_attr() を通さない場合、ブロックのCSS入力欄に

`" onmouseover="alert(/XSS/)" style="background:red;" `

と入れるとスタイルは wp_kses_post が通してしまうため、やはり esc_attr() を通す方式に戻し