### PR TITLE
[ 不具合修正 ][ タイトルタグ書き換え ] カスタム投稿タイプで入力欄が表示されない不具合を修正 #915

### DIFF
--- a/admin/class-veu-metabox.php
+++ b/admin/class-veu-metabox.php
@@ -2,6 +2,16 @@
 
 class VEU_Metabox {
 
+	/**
+	 * @var array {
+	 *  slug : string
+	 *  cf_name : string
+	 *  title : string
+	 *  priority : int
+	 *  individual : bool
+	 *  poat_types : array
+	 * } $args
+	 */
 	public $args;
 	public $veu_get_common_options;
 
@@ -52,7 +62,7 @@ class VEU_Metabox {
 
 	public function add_sub_parent_metabox_insert_items() {
 		// 子ページリストやサイトマップなど「挿入アイテムの設定」を読み込むための子metaboxを読み込む
-		require_once( dirname( __FILE__ ) . '/class-veu-metabox-insert-items.php' );
+		require_once dirname( __FILE__ ) . '/class-veu-metabox-insert-items.php';
 	}
 
 

--- a/inc/wp-title/config.php
+++ b/inc/wp-title/config.php
@@ -5,5 +5,17 @@
  * @package WP Title
  */
 require dirname( __FILE__ ) . '/package/wp-title.php';
-require dirname( __FILE__ ) . '/package/class-veu-metabox-head-title.php';
-$VEU_Metabox_Head_Title = new VEU_Metabox_Head_Title();
+/*
+VEU_Metabox 内の get_post_type が実行タイミングによっては
+カスタム投稿タイプマネージャーで作成した投稿タイプが取得できず、
+カスタム投稿タイプの投稿の編集画面で設定欄が表示されないために
+admin_menu のタイミングで読み込んでいる
+ */
+add_action(
+	'admin_menu',
+	function() {
+		require_once dirname( __FILE__ ) . '/package/class-veu-metabox-head-title.php';
+		$VEU_Metabox_Head_Title = new VEU_Metabox_Head_Title();
+	}
+);
+

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ e.g.
 [ Bug fix ][ CTA ] Fix Error under no CTA Registered
 [ Bug fix ][ CSS Optimize ] Fix Tree Shaking and Preload.
 [ Bug fix ][ wp title ] Fix separator filter not work ( vkExUnit_get_wp_head_title_sep )
+[ Bug fix ][ wp title ] Fix cope with custom post types
 
 = 9.85.0.1 =
 [ Specification Change ][ SNS : Share button ] Changed show/hide settings to only affect the_content and action hooks


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/915

## どういう変更をしたか？

そもそもカスタム投稿タイプで入力欄が表示されないのが不具合だった

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？
→ 書きたいがいろいろ間に合わないので別途 
https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/918


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* ExUnit でカスタム投稿タイプを作成
* 記事の編集欄でタイトルを指定
* タイトルタグに反映される事を確認