### PR TITLE
VK 最近の投稿 ウィジェットに Add veu_widget_new_posts_query フィルター追加

### DIFF
--- a/inc/other-widget/widget-new-posts.php
+++ b/inc/other-widget/widget-new-posts.php
@@ -48,6 +48,9 @@ class WP_Widget_vkExUnit_post_list extends WP_Widget {
 		return $title;
 	}
 
+	/*
+	  Widget
+	/*-------------------------------------------*/
 	function widget( $args, $instance ) {
 		$instance = static::get_options( $instance );
 		$title    = $this->get_widget_title( $instance );
@@ -74,7 +77,7 @@ class WP_Widget_vkExUnit_post_list extends WP_Widget {
 		$is_modified = ( isset( $instance['orderby'] ) && $instance['orderby'] == 'modified' );
 		$orderby     = ( isset( $instance['orderby'] ) ) ? $instance['orderby'] : 'date';
 
-		$p_args = array(
+		$args = array(
 			'order'          => 'DESC',
 			'post_type'      => $post_type,
 			'posts_per_page' => $count,
@@ -84,12 +87,12 @@ class WP_Widget_vkExUnit_post_list extends WP_Widget {
 
 		if ( isset( $instance['terms'] ) && $instance['terms'] ) {
 			$taxonomies          = get_taxonomies( array() );
-			$p_args['tax_query'] = array(
+			$args['tax_query'] = array(
 				'relation' => 'OR',
 			);
 			$terms_array         = explode( ',', $instance['terms'] );
 			foreach ( $taxonomies as $taxonomy ) {
-				$p_args['tax_query'][] = array(
+				$args['tax_query'][] = array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'id',
 					'terms'    => $terms_array,
@@ -97,7 +100,9 @@ class WP_Widget_vkExUnit_post_list extends WP_Widget {
 			}
 		}
 
-		$post_loop = new WP_Query( $p_args );
+		$widget_area_id = $args['id'];
+		$args = apply_filters( 'veu_widget_new_posts_query', $args, $widget_area_id );
+		$post_loop = new WP_Query( $args );
 
 		if ( $post_loop->have_posts() ) :
 			if ( ! $instance['format'] ) {

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Add filter ][ New Posts Widget ] Add veu_widget_new_posts_query filter
+
 = 9.89.1.0 =
 [ Bug fix ] Fix media uploader not work
 [ Bug fix ][ CTA ] Fixed the display in the site editor.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://vws.vektor-inc.co.jp/forums/topic/exclude-specific-term-from-veu-new-posts-widget

## どういう変更をしたか？

VK 最近の投稿 ウィジェットに Add veu_widget_new_posts_query フィルター追加

## Example

```
 /**
  * VK All in One Expansion Unit の「VK 最新の投稿」ウィジェットの新着記事一覧のクエリを改変する
  *
  * @param array $widget_area_id 該当のウィジェットエリア.
  * @param array $query_args クエリの引数.
  */
function my_veu_widget_new_posts_query_custom( $query_args, $widget_area_id ){

	// 特定のウィジェットエリアでのみ改変する場合はウィジェットエリア名を指定
	if ( 'post-side-widget-area' === $widget_area_id ){
		// クエリを改変する処理を記述
		$query_args['tax_query'][] = array(
            'taxonomy' => 'category',
            'field' => 'slug',
            'terms' => 'event',
            'operator' => 'NOT IN'
		);
	}

	return $query_args;
}
 add_filter( 'veu_widget_new_posts_query', 'my_veu_widget_new_posts_query_custom', 10, 2 );
```

## 追記

変数間違ってた。以下で修正。

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/976