### PR TITLE
【カスタム投稿タイプマネージャー 】リライトをオフにするオプションを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.phpunit.result.cache

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -155,7 +155,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			 * Enable / Disable Rewrite.
 			 * パーマリンクのリライトを有効にするかどうか.
 			 */
-			echo '<h4>' . esc_html__( 'Enable / Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</h4>';
+			echo '<h4>' . esc_html__( 'Rewrite permalink (optional)', 'vk-all-in-one-expansion-unit' ) . '</h4>';
 			$post_type_rewrite_value = get_post_meta( $post->ID, 'veu_post_type_rewrite', true );
 			if ( 'false' !== $post_type_rewrite_value  && 'true' !== $post_type_rewrite_value  ) {
 				$post_type_rewrite_value = 'true';
@@ -241,7 +241,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 					$taxonomy_rewrite_value = 'true';
 				}
 				echo '<tr>';
-				echo '<td>' . esc_html__( 'Enable / Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</td>';
+				echo '<td>' . esc_html__( 'Rewrite permalink (optional)', 'vk-all-in-one-expansion-unit' ) . '</td>';
 				echo '<td>';
 				echo '<label><input type="radio" id="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" name="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" value="true"' . checked( $taxonomy_rewrite_value , 'true', false ) . '> ' . esc_html__( 'Enable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
 				echo '<br />';

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -409,6 +409,10 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 									'name' => $taxonomy['label'],
 								);
 
+								// $taxonomy['rewrite'] が存在し、値が false だった場合は $rewrite に false を、
+								// それ以外の場合は true を入れる.
+								$rewrite = ( isset( $taxonomy['rewrite'] ) && 'false' === $taxonomy['rewrite'] ) ? false : true;
+
 								$args = array(
 									'hierarchical'      => $hierarchical_true,
 									'update_count_callback' => '_update_post_term_count',
@@ -417,7 +421,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 									'show_ui'           => true,
 									'show_in_rest'      => $rest_api_true,
 									'show_admin_column' => true,
-									'rewrite'           => $taxonomy['rewrite'] === 'false' ? false : true,
+									'rewrite'           => $rewrite,
 								);
 
 								if ( $rest_api_true ) {

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -149,6 +149,21 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			echo '<label><input type="radio" id="veu_post_type_export_to_api" name="veu_post_type_export_to_api" value="false"' . checked( $export_to_api_value, 'false', false ) . '> ' . esc_html__( 'Does not correspond to the block editor', 'vk-all-in-one-expansion-unit' ) . '</label>';
 
 			echo '<p>' . esc_html__( 'If you want to use the block editor that, you have to use the REST API.', 'vk-all-in-one-expansion-unit' ) . '</p>';
+			echo '<hr>';			
+
+			/**
+			 * Enable / Disable Rewrite.
+			 * パーマリンクのリライトを有効にするかどうか.
+			 */
+			echo '<h4>' . esc_html__( 'Enable / Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</h4>';
+			$post_type_rewrite_value = get_post_meta( $post->ID, 'veu_post_type_rewrite', true );
+			if ( 'false' !== $post_type_rewrite_value  && 'true' !== $post_type_rewrite_value  ) {
+				$post_type_rewrite_value = 'true';
+			}
+			echo '<label><input type="radio" id="veu_post_type_rewrite" name="veu_post_type_rewrite" value="true"' . checked( $post_type_rewrite_value , 'true', false ) . '> ' . esc_html__( 'Enable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
+			echo '<br />';
+			echo '<label><input type="radio" id="veu_post_type_rewrite" name="veu_post_type_rewrite" value="false"' . checked( $post_type_rewrite_value , 'false', false ) . '> ' . esc_html__( 'Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
+
 			echo '<hr>';
 
 			/*******************************************
@@ -167,7 +182,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			// カスタム分類の情報は カスタムフィールドの veu_taxonomy に連想配列で格納している.
 			$taxonomy = get_post_meta( $post->ID, 'veu_taxonomy', true );
 
-			for ( $i = 1; $i <= 5; $i++ ) {
+			for ( $i = 1; $i <= apply_filters( 'veu_post_type_taxonomies', 5 ); $i++ ) {
 
 				$slug     = ( isset( $taxonomy[ $i ]['slug'] ) ) ? $taxonomy[ $i ]['slug'] : '';
 				$label    = ( isset( $taxonomy[ $i ]['label'] ) ) ? $taxonomy[ $i ]['label'] : '';
@@ -176,7 +191,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 
 				echo '<tr>';
 
-				echo '<th rowspan="4">' . esc_attr( $i ) . '</th>';
+				echo '<th rowspan="5">' . esc_attr( $i ) . '</th>';
 
 				// slug.
 				echo '<td>' . esc_html__( 'Custon taxonomy name(slug)', 'vk-all-in-one-expansion-unit' ) . '</td>';
@@ -219,6 +234,20 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				echo '</td>';
 				echo '</tr>';
 
+				// Rewrite.
+				// 普段は有効なので、デフォルトは true にしておく.
+				$taxonomy_rewrite_value = ( isset( $taxonomy[ $i ]['rewrite'] ) ) ? $taxonomy[ $i ]['rewrite'] : 'true';
+				if ( 'false' !== $taxonomy_rewrite_value  && 'true' !== $taxonomy_rewrite_value  ) {
+					$taxonomy_rewrite_value = 'true';
+				}
+				echo '<tr>';
+				echo '<td>' . esc_html__( 'Enable / Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</td>';
+				echo '<td>';
+				echo '<label><input type="radio" id="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" name="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" value="true"' . checked( $taxonomy_rewrite_value , 'true', false ) . '> ' . esc_html__( 'Enable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
+				echo '<br />';
+				echo '<label><input type="radio" id="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" name="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" value="false"' . checked( $taxonomy_rewrite_value , 'false', false ) . '> ' . esc_html__( 'Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
+				echo '</td>';
+				echo '</tr>';
 			}
 			echo '</table>';
 
@@ -251,6 +280,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				'veu_post_type_items',
 				'veu_menu_position',
 				'veu_post_type_export_to_api',
+				'veu_post_type_rewrite',
 				'veu_taxonomy',
 			);
 
@@ -286,6 +316,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				'order'            => 'ASC',
 				'orderby'          => 'menu_order',
 				'suppress_filters' => true,
+				
 			);
 			$custom_post_types = get_posts( $args );
 			if ( $custom_post_types ) {
@@ -308,6 +339,8 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 						$supports[] = $key;
 					}
 
+					$rewrite = get_post_meta( $post->ID, 'veu_post_type_rewrite', true );
+
 					// カスタム投稿タイプのスラッグ.
 					$post_type_id = mb_strimwidth( mb_convert_kana( mb_strtolower( esc_html( get_post_meta( $post->ID, 'veu_post_type_id', true ) ) ), 'a' ), 0, 20, '', 'UTF-8' );
 
@@ -317,12 +350,14 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 						if ( ! $menu_position ) {
 							$menu_position = 5;
 						}
+
 						$args = array(
 							'labels'        => $labels,
 							'public'        => true,
 							'has_archive'   => true,
 							'menu_position' => $menu_position,
 							'supports'      => $supports,
+							'rewrite'       => $rewrite === 'false' ? false : true,
 						);
 
 						// REST API に出力するかどうかをカスタムフィールドから取得.
@@ -382,6 +417,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 									'show_ui'           => true,
 									'show_in_rest'      => $rest_api_true,
 									'show_admin_column' => true,
+									'rewrite'           => $taxonomy['rewrite'] === 'false' ? false : true,
 								);
 
 								if ( $rest_api_true ) {

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,8 @@ e.g.
 
 == Changelog ==
 
+[ Other ][ PostTypeManager ] Add Rewrite option of Post Type / Taxonomy.
+
 = 9.94.2 =
 [ Add filter ][ HTML Sitemap ] veu_sitemap_exclude_post_types
 [ Bug Fix ] Update CSS Optimizer 0.2.2


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

[[ カスタム投稿タイプマネージャー ] リライトをオフにするオプションを追加して欲しい by あんどうさん](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1066)

## どういう変更をしたか？

- カスタム投稿タイプマネージャー の リライトをオフにするオプションを追加

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [x] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [x] 情報意味を考慮した意味グルーピング・余白になっているか？
- [x] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ 
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？
⇒投稿タイプの設定項目の話なので省略

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. カスタム投稿タイプを適当に作成
2.  /news/%postname%/ にパーマリンクを設定
3. リライトが ON だと /news/event/%postname%/  になる
4. リライトが OFF だとリライトが一切発動しない


## 確認URL

ローカル環境

## レビュワーの確認方法・確認する内容など

1. カスタム投稿タイプを適当に作成
2.  /news/%postname%/ にパーマリンクを設定
3. リライトが ON だと /news/event/%postname%/  になる
4. リライトが OFF だとリライトが一切発動しない

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
