### PR TITLE
[ Post Type Manager ] Change so that "with_front" can be specified as false in permalink settings

### DIFF
--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -152,14 +152,25 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			 * パーマリンクのリライトを有効にするかどうか.
 			 */
 			echo '<h4>' . esc_html__( 'Rewrite permalink (optional)', 'vk-all-in-one-expansion-unit' ) . '</h4>';
-			$post_type_rewrite_value = get_post_meta( $post->ID, 'veu_post_type_rewrite', true );
-			if ( 'false' !== $post_type_rewrite_value && 'true' !== $post_type_rewrite_value ) {
-				$post_type_rewrite_value = 'true';
-			}
-			echo '<label><input type="radio" id="veu_post_type_rewrite" name="veu_post_type_rewrite" value="true"' . checked( $post_type_rewrite_value, 'true', false ) . '> ' . esc_html__( 'Enable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
-			echo '<br />';
-			echo '<label><input type="radio" id="veu_post_type_rewrite" name="veu_post_type_rewrite" value="false"' . checked( $post_type_rewrite_value, 'false', false ) . '> ' . esc_html__( 'Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
 
+			$post_type_rewrite_value = get_post_meta( $post->ID, 'veu_post_type_rewrite', true );
+			// post_type_rewrite_value の値が with_front_false だった場合はチェックを入れる.
+			$checked = ( 'with_front_false' === $post_type_rewrite_value ) ? ' checked' : '';
+
+			echo '<label><input type="checkbox" id="veu_post_type_rewrite" name="veu_post_type_rewrite" value="with_front_false"' . esc_attr( $checked ) . '> ' . esc_html( __( 'Disable the permalink settings specified in Custom Structure.（ Set with_front to false ）', 'vk-all-in-one-expansion-unit' ) ) . '</label>';
+
+			echo '<p>';
+			echo wp_kses_post(
+				sprintf(
+					__( 'For example, if "news/%%postname%%/" is set in the Custom Structure of the <a href="%1$s" target="_blank">Permalink Settings</a>, the URL for the custom post type "event" will also include "news", resulting in a URL like https://xxxx.xxx/news/event/%%postname%%/.', 'vk-all-in-one-expansion-unit' ),
+					admin_url( 'options-permalink.php' )
+				)
+			);
+			echo '<br>';
+			echo esc_html__( 'By setting with_front to false, you can ensure the URL is formatted as https://xxxx.xxx/event/%postname%/ without being affected by the Custom Structure settings.', 'vk-all-in-one-expansion-unit' );
+			echo '<br>';
+			echo esc_html__( 'It is not affected if you do not add strings like "news" to the Custom Structure.', 'vk-all-in-one-expansion-unit' );
+			echo '</p>';
 			echo '<hr>';
 
 			/*******************************************
@@ -187,7 +198,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 
 				echo '<tr>';
 
-				echo '<th rowspan="5">' . esc_attr( $i ) . '</th>';
+				echo '<th rowspan="4">' . esc_attr( $i ) . '</th>';
 
 				// slug.
 				echo '<td>' . esc_html__( 'Custon taxonomy name (slug)', 'vk-all-in-one-expansion-unit' ) . '</td>';
@@ -227,21 +238,6 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				echo '<label><input type="radio" id="veu_taxonomy[' . esc_attr( $i ) . '][rest_api]" name="veu_taxonomy[' . esc_attr( $i ) . '][rest_api]" value="true"' . checked( $checked, 'true', false ) . '> ' . esc_html__( 'Corresponds to the block editor ( Export to REST API / optional )', 'vk-all-in-one-expansion-unit' ) . '</label>';
 				echo '<br />';
 				echo '<label><input type="radio" id="veu_taxonomy[' . esc_attr( $i ) . '][rest_api]" name="veu_taxonomy[' . esc_attr( $i ) . '][rest_api]" value="false"' . checked( $checked, 'false', false ) . '> ' . esc_html__( 'Does not correspond to the block editor', 'vk-all-in-one-expansion-unit' ) . '</label>';
-				echo '</td>';
-				echo '</tr>';
-
-				// Rewrite.
-				// 普段は有効なので、デフォルトは true にしておく.
-				$taxonomy_rewrite_value = ( isset( $taxonomy[ $i ]['rewrite'] ) ) ? $taxonomy[ $i ]['rewrite'] : 'true';
-				if ( 'false' !== $taxonomy_rewrite_value && 'true' !== $taxonomy_rewrite_value ) {
-					$taxonomy_rewrite_value = 'true';
-				}
-				echo '<tr>';
-				echo '<td>' . esc_html__( 'Rewrite permalink (optional)', 'vk-all-in-one-expansion-unit' ) . '</td>';
-				echo '<td>';
-				echo '<label><input type="radio" id="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" name="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" value="true"' . checked( $taxonomy_rewrite_value, 'true', false ) . '> ' . esc_html__( 'Enable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
-				echo '<br />';
-				echo '<label><input type="radio" id="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" name="veu_taxonomy[' . esc_attr( $i ) . '][rewrite]" value="false"' . checked( $taxonomy_rewrite_value, 'false', false ) . '> ' . esc_html__( 'Disable Permalink Rewrite', 'vk-all-in-one-expansion-unit' ) . '</label>';
 				echo '</td>';
 				echo '</tr>';
 			}
@@ -334,8 +330,6 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 						$supports[] = $key;
 					}
 
-					$rewrite = get_post_meta( $post->ID, 'veu_post_type_rewrite', true );
-
 					// カスタム投稿タイプのスラッグ.
 					$post_type_id = mb_strimwidth( mb_convert_kana( mb_strtolower( esc_html( get_post_meta( $post->ID, 'veu_post_type_id', true ) ) ), 'a' ), 0, 20, '', 'UTF-8' );
 
@@ -346,13 +340,29 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 							$menu_position = 5;
 						}
 
+						$veu_post_type_rewrite = get_post_meta( $post->ID, 'veu_post_type_rewrite', true );
+
+						if ( 'with_front_false' === $veu_post_type_rewrite ) {
+							$rewrite = array(
+								'slug'       => $post_type_id,
+								'with_front' => false,
+								// 'rewrite_slug' => false,
+							);
+						} elseif ( 'false' === $veu_post_type_rewrite ) {
+							// 'false' の設定は旧バージョンのもので、9.96 で廃止したが、
+							// 設定しているユーザーがいるかもしれないので、一応残してある
+							$rewrite = 'false';
+						} else {
+							$rewrite = true;
+						}
+
 						$args = array(
 							'labels'        => $labels,
 							'public'        => true,
 							'has_archive'   => true,
 							'menu_position' => $menu_position,
 							'supports'      => $supports,
-							'rewrite'       => $rewrite === 'false' ? false : true,
+							'rewrite'       => $rewrite,
 						);
 
 						// REST API に出力するかどうかをカスタムフィールドから取得.
@@ -404,9 +414,21 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 									'name' => $taxonomy['label'],
 								);
 
-								// $taxonomy['rewrite'] が存在し、値が false だった場合は $rewrite に false を、
-								// それ以外の場合は true を入れる.
-								$rewrite = ( isset( $taxonomy['rewrite'] ) && 'false' === $taxonomy['rewrite'] ) ? false : true;
+								// リライトルールの設定 //////////////////////////////////////
+								// 投稿タイプのリライトルールを反映させる
+								if ( 'with_front_false' === $veu_post_type_rewrite ) {
+									$rewrite = array(
+										'slug'       => $taxonomy['slug'],
+										'with_front' => false,
+										// 'rewrite_slug' => false,
+									);
+								} elseif ( isset( $taxonomy['rewrite'] ) && 'false' === $taxonomy['rewrite'] ) {
+									// 'false' の設定は旧バージョンのもので、9.96 で廃止したが、
+									// 設定しているユーザーがいるかもしれないので、一応残してある
+									$rewrite = 'false';
+								} else {
+									$rewrite = true;
+								}
 
 								$args = array(
 									'hierarchical'      => $hierarchical_true,

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -351,6 +351,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 						} elseif ( 'false' === $veu_post_type_rewrite ) {
 							// 'false' の設定は旧バージョンのもので、9.96 で廃止したが、
 							// 設定しているユーザーがいるかもしれないので、一応残してある
+							// この false による指定は 2024年9月以降に削除可
 							$rewrite = 'false';
 						} else {
 							$rewrite = true;

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -423,8 +423,10 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 										// 'rewrite_slug' => false,
 									);
 								} elseif ( isset( $taxonomy['rewrite'] ) && 'false' === $taxonomy['rewrite'] ) {
+									// 旧バージョンではカスタム分類毎でリライト設定があったのでその設定を参照
 									// 'false' の設定は旧バージョンのもので、9.96 で廃止したが、
 									// 設定しているユーザーがいるかもしれないので、一応残してある
+									// この $taxonomy['rewrite'] による指定は 2024年9月以降に削除可
 									$rewrite = 'false';
 								} else {
 									$rewrite = true;

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ e.g.
 == Changelog ==
 
 [ Add setting ][ Post Type Manager ] Add a custom field setting.
+[ Specification Change ][ Post Type Manager ] Change so that "with_front" can be specified as false in permalink settings
 [ Bug Fix ][ Contact Section ] Fixed an issue where icons do not display when input in <i> tag format. 
 [ Design Bug Fix ][ Child Page List ] Fixed an issue where a blank space appeared above the excerpt.
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1066

## どういう変更をしたか？

* リライトの設定で with_front を false に指定できるように変更
* それに伴い旧パーマリンクの書き換え廃止
* カスタム分類のパーマリンクの書き換え指定UIも廃止し、カスタム投稿タイプのパーマリンクの書き換えを踏襲するように変更（一般ユーザーがカスタム分類毎に項目を指定する可能性は低い。設定項目が多いと初心者が混乱するため）

■ Before
![post-type-namager-before](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/assets/3272660/8b112880-7412-4893-8913-822995fc277a)

■ After
![post-type-namager-after](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/assets/3272660/0fa85b2f-8269-4ce7-a43d-1cafd97829f4)

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [x] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [x] 情報意味を考慮した意味グルーピング・余白になっているか？
- [x] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

■ Before
* 設定 > パーマリンク > カスタム構造 で news/%postname%/ に指定
* ExUnit のカスタム投稿タイプマネージャーでカスタム投稿タイプ event を作成
* カスタム投稿タイプ event の投稿の詳細ページの公開URLが /news/event/ になってしまう。

■ After
* ExUnit のカスタム投稿タイプマネージャーの投稿タイプ event の設定画面で、with_front を false に指定
* カスタム投稿タイプ event の投稿の詳細ページの公開URLが /event/ になる（newsを除外できる）事を確認

## レビュワーの確認方法・確認する内容など

実装者に同じ

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
