### PR TITLE
公開画面側にプラグイン画面へのリンクを追加しないように変更

### DIFF
--- a/inc/add_plugin_link_to_adminbar.php
+++ b/inc/add_plugin_link_to_adminbar.php
@@ -41,7 +41,7 @@ function veu_is_add_plugin_link_to_adminbar( $wp_version, $is_admin = false ){
 		return true;
 	}  else {
 		// 公開画面
-		if ( version_compare( $wp_version, '6.5', '>=' ) ) {
+		if ( version_compare( get_bloginfo( 'version' ), '6.5', '>=' ) ) {
 			// WordPress 6.5 以上の場合はコアが追加してくるので何もしない
 			return false;
 		} else {

--- a/inc/add_plugin_link_to_adminbar.php
+++ b/inc/add_plugin_link_to_adminbar.php
@@ -3,7 +3,7 @@
 add_action( 'admin_bar_menu', 'veu_plugin_link_to_adminbar',100 );
 function veu_plugin_link_to_adminbar( $wp_admin_bar ) {
 
-	if ( ! veu_is_add_plugin_link_to_adminbar( $GLOBALS['wp_version'], is_admin() ) ){
+	if ( ! veu_is_add_plugin_link_to_adminbar( get_bloginfo( 'version' ), is_admin() ) ){
 		return;
 	}
 
@@ -41,7 +41,7 @@ function veu_is_add_plugin_link_to_adminbar( $wp_version, $is_admin = false ){
 		return true;
 	}  else {
 		// 公開画面
-		if ( version_compare( get_bloginfo( 'version' ), '6.5', '>=' ) ) {
+		if ( version_compare( $wp_version, '6.5', '>=' ) ) {
 			// WordPress 6.5 以上の場合はコアが追加してくるので何もしない
 			return false;
 		} else {

--- a/inc/add_plugin_link_to_adminbar.php
+++ b/inc/add_plugin_link_to_adminbar.php
@@ -3,6 +3,10 @@
 add_action( 'admin_bar_menu', 'veu_plugin_link_to_adminbar',100 );
 function veu_plugin_link_to_adminbar( $wp_admin_bar ) {
 
+	if ( ! veu_is_add_plugin_link_to_adminbar( $GLOBALS['wp_version'], is_admin() ) ){
+		return;
+	}
+
 	// 「有効化設定」は edit_theme_options 権限にはアクセスさせない
 	if ( current_user_can( 'activate_plugins' ) ) {
 
@@ -16,5 +20,32 @@ function veu_plugin_link_to_adminbar( $wp_admin_bar ) {
 		);
 		wp_admin_bar_appearance_menu( $wp_admin_bar );
 
+	}
+}
+
+/**
+ * プラグインページへのリンクを追加するかどうか
+ * Whether or not to add a link to the plugin page.
+ * 
+ * これくらい veu_plugin_link_to_adminbar に書きたいところだが、PHPUnit でテストするために関数化
+ * 
+ * @param string $wp_version
+ * @param bool $is_admin
+ *
+ * @return bool
+ */
+function veu_is_add_plugin_link_to_adminbar( $wp_version, $is_admin = false ){
+
+	if ( $is_admin ){
+		// 管理画面ではバージョンに関係なく追加
+		return true;
+	}  else {
+		// 公開画面
+		if ( version_compare( $wp_version, '6.5', '>=' ) ) {
+			// WordPress 6.5 以上の場合はコアが追加してくるので何もしない
+			return false;
+		} else {
+			return true;
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ e.g.
 
 == Changelog ==
 
+= 9.97.2 =
+[ Bug fix ] In WordPress 6.5, a link to the plugin page has been added to the admin bar on the front end by default. Consequently, ExUnit has been modified to no longer add this link on the front end.
+
 = 9.97.1 =
 [ Bug fix ][ Child page index ] In the case of automatically inserting the child page list without using a block, the issue where all pages were displayed in WordPress 6.5 has been fixed.
 [ Design Bug Fix ][ Faq ] Fix stitching styles in Group blocks.

--- a/tests/test-add-plugin-link-to-adminbar.php
+++ b/tests/test-add-plugin-link-to-adminbar.php
@@ -34,19 +34,19 @@ class addPluginLinkToAdminbarTest extends WP_UnitTestCase {
 
 		);
 
-		// print PHP_EOL;
-		// print '------------------------------------' . PHP_EOL;
-		// print 'test_veu_is_add_plugin_link_to_adminbar' . PHP_EOL;
-		// print '------------------------------------' . PHP_EOL;
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_veu_is_add_plugin_link_to_adminbar' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
 		foreach ( $tests as $key => $test_value ) {
 
 			// 現在表示中のURLを取得
 			$acutual = veu_is_add_plugin_link_to_adminbar( $test_value['wp_version'], $test_value['is_admin'] );
 
-			// print PHP_EOL;
-			// print 'title    :' . $test_value['title'] . PHP_EOL;
-			// print 'actual   :' . $acutual . PHP_EOL;
-			// print 'expected :' . $test_value['expected'] . PHP_EOL;
+			print PHP_EOL;
+			print 'title    :' . $test_value['title'] . PHP_EOL;
+			print 'actual   :' . $acutual . PHP_EOL;
+			print 'expected :' . $test_value['expected'] . PHP_EOL;
 
 			// PHPunit
 			$this->assertEquals( $test_value['expected'], $acutual );

--- a/tests/test-add-plugin-link-to-adminbar.php
+++ b/tests/test-add-plugin-link-to-adminbar.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class InsertPluginLinkToAdminbarTest
+ *
+ * @package vektor-inc\vk-all-in-one-expansion-unit
+ */
+
+/**
+ * 
+ */
+class addPluginLinkToAdminbarTest extends WP_UnitTestCase {
+
+	function test_veu_is_add_plugin_link_to_adminbar() {
+
+		$tests = array(
+			array(
+				'title'  => '6.5 / 公開画面',
+				'wp_version' => '6.5',
+				'is_admin' => false,
+				'expected' => false,
+			),
+			array(
+				'title'  => '6.5 / 管理画面',
+				'wp_version' => '6.5',
+				'is_admin' => true,
+				'expected' => true,
+			),
+			array(
+				'title'  => '6.4 / 公開画面',
+				'wp_version' => '6.4',
+				'is_admin' => false,
+				'expected' => true,
+			),
+
+		);
+
+		// print PHP_EOL;
+		// print '------------------------------------' . PHP_EOL;
+		// print 'test_veu_is_add_plugin_link_to_adminbar' . PHP_EOL;
+		// print '------------------------------------' . PHP_EOL;
+		foreach ( $tests as $key => $test_value ) {
+
+			// 現在表示中のURLを取得
+			$acutual = veu_is_add_plugin_link_to_adminbar( $test_value['wp_version'], $test_value['is_admin'] );
+
+			// print PHP_EOL;
+			// print 'title    :' . $test_value['title'] . PHP_EOL;
+			// print 'actual   :' . $acutual . PHP_EOL;
+			// print 'expected :' . $test_value['expected'] . PHP_EOL;
+
+			// PHPunit
+			$this->assertEquals( $test_value['expected'], $acutual );
+		}
+	}
+}

--- a/vkExUnit.php
+++ b/vkExUnit.php
@@ -3,7 +3,7 @@
  * Plugin Name: VK All in One Expansion Unit
  * Plugin URI: https://ex-unit.nagoya
  * Description: This plug-in is an integrated plug-in with a variety of features that make it powerful your web site. Many features can be stopped individually. Example Facebook Page Plugin,Social Bookmarks,Print OG Tags,Print Twitter Card Tags,Print Google Analytics tag,New post widget,Insert Related Posts and more!
- * Version: 9.97.1.1
+ * Version: 9.97.2.0
  * Requires PHP: 7.4
  * Requires at least: 5.9
  * Author: Vektor,Inc.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://vws.vektor-inc.co.jp/forums/topic/90184

WordPress 6.5 で公開画面の管理バーにプラグインページへのリンクが表示されるようになった。
その都合上 ExUnit が追加するプラグインへのリンクと合わせて二重で表示されるようになってしまった。

![スクリーンショット 2024-04-18 1 48 06](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/assets/3272660/49a68f1b-c5f8-4d59-841e-ede545f51aef)

## どういう変更をしたか？

* WordPress 6.5 以上の公開画面の場合は管理バーにプラグインへのリンクを追加しないように変更

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [x] 書けそうなテストは書いたか？
- [x] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* ExUnit > 有効化設定 > 管理画面機能 で 「管理バーにプラグインリンク追加」が有効になっている事を確認
* WordPress 6.5  & マスターブランチで管理バーを見ると先に掲載のSSのように「プラグイン」が二つ表示される
* このブランチに切り替え
* プラグインのリンクは一つしか出力されない事を確認
* 管理画面側でも同様に プラグイン ページへのリンクが管理バーに追加される事を確認


---

* wp-content/plugins/vk-all-in-one-expansion-unit/ のディレクトリで `wp-env start`
* `npm run phpunit` を叩いてテストが通る事を確認

## 確認URL

ローカルでよろしくお願いいたします。

## レビュワーの確認方法・確認する内容など

実装者に同じ

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
