### PR TITLE
【確認中】[ CTA ] ブロックで作成したCTAがエスケープされまくって崩れる不具合を修正

### DIFF
--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -406,8 +406,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 <tr><th><label for="vkExUnit_cta_text"><?php _e( 'Text message', 'vk-all-in-one-expansion-unit' ); ?>
 </th>
 <td>
-<?php $allowed_html = Vk_Call_To_Action::allowed_html(); ?>
-<textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ), $allowed_html ); ?></textarea>
+<textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses_post( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ) ); ?></textarea>
 </td></tr>
 </table>
 <a href="<?php echo admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ); ?>" class="button button-default" target="_blank"><?php _e( 'CTA setting', 'vk-all-in-one-expansion-unit' ); ?></a>
@@ -434,127 +433,6 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			$target = $query->posts[0];
 			wp_reset_postdata();
 			return $target;
-		}
-
-		/**
-		 * 許可する HTML
-		 */
-		public static function allowed_html() {
-			$allowed_html = array(
-				'section'  => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-					'style'     => array(),
-				),
-				'div'  => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-					'style'     => array(),
-				),
-				'h1' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'style'     => array(),
-				),
-				'h2' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'style'     => array(),
-				),
-				'h3' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'style'     => array(),
-				),
-				'h4' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'style'     => array(),
-				),
-				'h5' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'style'     => array(),
-				),
-				'h6' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'style'     => array(),
-				),
-				'p'    => array(
-					'id'    => array(),
-					'class' => array(),
-					'style'     => array(),
-				),
-				'ul'   => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-					'style'     => array(),
-				),
-				'ol'   => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-					'style'     => array(),
-				),
-				'li'   => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-					'style'     => array(),
-				),
-				'a'    => array(
-					'id'       => array(),
-					'class'    => array(),
-					'href'     => array(),
-					'target'   => array(),
-					'itemprop' => array(),
-					'style'    => array(),
-					'role'     => array(),
-					'rel'      => array(),
-				),
-				'span' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-					'style'     => array(),
-				),
-				'i'    => array(
-					'id'          => array(),
-					'class'       => array(),
-					'aria-hidden' => array()
-				),
-				'style'    => array(
-					'type'          => array(),
-				),
-				'svg'    => array(
-					'xmlns' 	   => array(),
-					'viewBox' 	   => array(),
-					'preserveAspectRatio' 	   => array(),
-				),
-				'path'    => array(
-					'd' 	   => array(),
-					'fill' 	   => array(),
-					'class' 	   => array(),
-					'stroke-width' 	   => array(),
-				),
-			);
-			return $allowed_html;
 		}
 
 		/**

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -513,12 +513,30 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 		 */
 		public static function cta_allow_html() {
 			$allowed_html = array(
+				'section'  => array(
+					'id'        => array(),
+					'class'     => array(),
+					'itemprop'  => array(),
+					'itemscope' => array(),
+					'itemtype'  => array(),
+					'style'     => array(),
+				),
 				'div'  => array(
 					'id'        => array(),
 					'class'     => array(),
 					'itemprop'  => array(),
 					'itemscope' => array(),
 					'itemtype'  => array(),
+					'style'     => array(),
+				),
+				'h1' => array(
+					'id'        => array(),
+					'class'     => array(),
+					'style'     => array(),
+				),
+				'h2' => array(
+					'id'        => array(),
+					'class'     => array(),
 					'style'     => array(),
 				),
 				'h3' => array(
@@ -576,7 +594,9 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 					'href'     => array(),
 					'target'   => array(),
 					'itemprop' => array(),
-					'style'     => array(),
+					'style'    => array(),
+					'role'     => array(),
+					'rel'      => array(),
 				),
 				'span' => array(
 					'id'        => array(),
@@ -641,7 +661,8 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			wp_reset_postdata();
 
 			// wp_kses_post でエスケープすると outerブロックが出力するstyle属性を無効化される.
-			return do_blocks( do_shortcode( wp_kses( $content, array( __CLASS__, 'cta_allow_html' ) ) ) );
+			$allow_html = Vk_Call_To_Action::cta_allow_html();
+			return wp_kses( do_blocks( do_shortcode(  $content ) ), $allow_html );
 		}
 
 		/**

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -406,85 +406,13 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 <tr><th><label for="vkExUnit_cta_text"><?php _e( 'Text message', 'vk-all-in-one-expansion-unit' ); ?>
 </th>
 <td>
-	<?php
-	$allowed_html    = array(
-		'div'  => array(
-			'id'        => array(),
-			'class'     => array(),
-			'itemprop'  => array(),
-			'itemscope' => array(),
-			'itemtype'  => array(),
-		),
-		'h3' => array(
-			'id'        => array(),
-			'class'     => array(),
-		),
-		'h4' => array(
-			'id'        => array(),
-			'class'     => array(),
-		),
-		'h5' => array(
-			'id'        => array(),
-			'class'     => array(),
-		),
-		'h6' => array(
-			'id'        => array(),
-			'class'     => array(),
-		),
-		'p'    => array(
-			'id'    => array(),
-			'class' => array(),
-		),
-		'ul'   => array(
-			'id'        => array(),
-			'class'     => array(),
-			'itemprop'  => array(),
-			'itemscope' => array(),
-			'itemtype'  => array(),
-		),
-		'ol'   => array(
-			'id'        => array(),
-			'class'     => array(),
-			'itemprop'  => array(),
-			'itemscope' => array(),
-			'itemtype'  => array(),
-		),
-		'li'   => array(
-			'id'        => array(),
-			'class'     => array(),
-			'itemprop'  => array(),
-			'itemscope' => array(),
-			'itemtype'  => array(),
-		),
-		'a'    => array(
-			'id'       => array(),
-			'class'    => array(),
-			'href'     => array(),
-			'target'   => array(),
-			'itemprop' => array(),
-		),
-		'span' => array(
-			'id'        => array(),
-			'class'     => array(),
-			'itemprop'  => array(),
-			'itemscope' => array(),
-			'itemtype'  => array(),
-		),
-		'i'    => array(
-			'id'          => array(),
-			'class'       => array(),
-			'aria-hidden' => array()
-		),
-	);
-	?>
+<?php $allowed_html = Vk_Call_To_Action::allowed_html(); ?>
 <textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ), $allowed_html ); ?></textarea>
 </td></tr>
 </table>
 <a href="<?php echo admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ); ?>" class="button button-default" target="_blank"><?php _e( 'CTA setting', 'vk-all-in-one-expansion-unit' ); ?></a>
 			<?php
 		}
-
-
 
 		/**
 		 * Get CTA Post
@@ -511,7 +439,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 		/**
 		 * 許可する HTML
 		 */
-		public static function cta_allow_html() {
+		public static function allowed_html() {
 			$allowed_html = array(
 				'section'  => array(
 					'id'        => array(),
@@ -604,12 +532,28 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 					'itemprop'  => array(),
 					'itemscope' => array(),
 					'itemtype'  => array(),
-					'style'     => array(),
+					'style'     => array(
+						'opacity' => array(),
+					),
 				),
 				'i'    => array(
 					'id'          => array(),
 					'class'       => array(),
 					'aria-hidden' => array()
+				),
+				'style'    => array(
+					'type'          => array(),
+				),
+				'svg'    => array(
+					'xmlns' 	   => array(),
+					'viewBox' 	   => array(),
+					'preserveAspectRatio' 	   => array(),
+				),
+				'path'    => array(
+					'd' 	   => array(),
+					'fill' 	   => array(),
+					'class' 	   => array(),
+					'stroke-width' 	   => array(),
 				),
 			);
 			return $allowed_html;
@@ -660,9 +604,10 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// リセットしないと$postが改変されたままでコメント欄が表示されなくなるなどの弊害が発生する.
 			wp_reset_postdata();
 
-			// wp_kses_post でエスケープすると outerブロックが出力するstyle属性を無効化される.
-			$allow_html = Vk_Call_To_Action::cta_allow_html();
-			return wp_kses( do_blocks( do_shortcode(  $content ) ), $allow_html );
+			// wp_kses_post でエスケープすると outerブロックが出力するstyle属性を無効化されるので使わないように.
+			// 出力時にエスケープしたいが、wp_kses_post だと style属性が無効化される / wp_kses でも allow_html で opacity を許可しても無視・削除される。
+			// 結局本文欄はどのみち HTML ブロックで <script>alert(0)</script> 入れられ標準でXSSは実行可能なので、ここでは処理していない。
+			return do_blocks( do_shortcode(  $content ) );
 		}
 
 		/**

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -532,9 +532,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 					'itemprop'  => array(),
 					'itemscope' => array(),
 					'itemtype'  => array(),
-					'style'     => array(
-						'opacity' => array(),
-					),
+					'style'     => array(),
 				),
 				'i'    => array(
 					'id'          => array(),

--- a/inc/call-to-action/package/view-actionbox.php
+++ b/inc/call-to-action/package/view-actionbox.php
@@ -57,7 +57,7 @@ $content .= '</div>';
 if ( $url && $btn_text ) {
 	$content .= '<div class="cta_body_link">';
 	$content .= '<a href="' . $url . '" class="btn btn-primary btn-block btn-lg"' . $target . '>';
-	$content .= $btn_before . $btn_text . $btn_after;
+	$content .= wp_kses_post( $btn_before . $btn_text . $btn_after );
 	$content .= '</a>';
 	$content .= '</div>';
 }

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -227,6 +227,16 @@ class CTATest extends WP_UnitTestCase {
 				),
 				'expected'   => '<section class="veu_cta" id="veu_cta-'. $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">Read more</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
+			'classic CTA XSS test'                    => array(
+				'cta_title' => 'Classic Title',
+				'cta_content' => '',
+				'post_meta' => array(
+					'vkExUnit_cta_text' => '"><script>alert(0)</script>',
+					'vkExUnit_cta_button_text' => '"><script>alert(0)</script>',
+					'vkExUnit_cta_url' => 'https://example.com'
+				),
+				'expected'   => '<section class="veu_cta" id="veu_cta-'. $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">"&gt;alert(0)</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">"&gt;alert(0)</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+			),
 		);
 
 		print PHP_EOL;

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -201,13 +201,31 @@ class CTATest extends WP_UnitTestCase {
 
 		// テスト配列
 		$test_array = array(
-			'normal text'                    => array(
+			'post_content text'                    => array(
 				'cta_content' => 'cta',
 				'expected'   => 'cta',
 			),
-			'xss test'                    => array(
+			'post_content html simple'                    => array(
+				'cta_content' => '<!-- wp:heading --><h2 class="wp-block-heading">テストタイトル</h2><!-- /wp:heading -->',
+				'expected'   => '<h2 class="wp-block-heading">テストタイトル</h2>',
+			),
+			'post_content html middle'                    => array(
+				'cta_content' => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"backgroundColor":"black","layout":{"type":"constrained"}} --><div class="wp-block-group has-black-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"textAlign":"center","className":"vkp-title-short-border\u002d\u002dcenter is-style-vk-heading-plain vk_block-margin-0\u002d\u002dmargin-bottom vk_custom_css","style":{"typography":{"fontSize":"2.2rem","letterSpacing":"2px"}},"textColor":"white"} --><h2 class="wp-block-heading has-text-align-center vkp-title-short-border--center is-style-vk-heading-plain vk_block-margin-0--margin-bottom vk_custom_css has-white-color has-text-color" style="font-size:2.2rem;letter-spacing:2px">テストタイトル</h2><!-- /wp:heading --><!-- wp:vk-blocks/button {"buttonUrl":"https://demo.dev3.biz/architect/recruit/","buttonType":"1","buttonColor":"custom","buttonColorCustom":"white","buttonAlign":"center","blockId":"e6f30732-b8f9-435d-8f9d-27d691e7d303","className":"vkp_button-through-arrow vk_custom_css"} --><div class="wp-block-vk-blocks-button vk_button vk_button-color-custom vk_button-align-center vkp_button-through-arrow vk_custom_css"><a href="https://demo.dev3.biz/architect/recruit/" class="vk_button_link btn has-text-color is-style-outline has-white-color btn-md" role="button" aria-pressed="true" rel="noopener"><div class="vk_button_link_caption"><span class="vk_button_link_txt">ボタン</span></div></a></div><!-- /wp:vk-blocks/button --></div><!-- /wp:group -->',
+				'expected'   => '<div class="wp-block-group has-black-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><div class="wp-block-group__inner-container is-layout-constrained wp-block-group-is-layout-constrained"><h2 class="wp-block-heading has-text-align-center vkp-title-short-border--center is-style-vk-heading-plain vk_block-margin-0--margin-bottom vk_custom_css has-white-color has-text-color" style="font-size:2.2rem;letter-spacing:2px">テストタイトル</h2><div class="wp-block-vk-blocks-button vk_button vk_button-color-custom vk_button-align-center vkp_button-through-arrow vk_custom_css"><a href="https://demo.dev3.biz/architect/recruit/" class="vk_button_link btn has-text-color is-style-outline has-white-color btn-md" role="button" rel="noopener"><div class="vk_button_link_caption"><span class="vk_button_link_txt">ボタン</span></div></a></div></div></div>',
+			),
+			'post_content xss test'                    => array(
 				'cta_content' => '"><script>alert(0)</script>',
 				'expected'   => '"&gt;alert(0)',
+			),
+			'classic CTA test'                    => array(
+				'cta_title' => 'Classic Title',
+				'cta_content' => '',
+				'post_meta' => array(
+					'vkExUnit_cta_text' => 'cta',
+					'vkExUnit_cta_button_text' => 'Read more',
+					'vkExUnit_cta_url' => 'https://example.com'
+				),
+				'expected'   => '<section class="veu_cta" id="veu_cta-'. $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">Read more</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 		);
 
@@ -218,12 +236,19 @@ class CTATest extends WP_UnitTestCase {
 		$content = '';
 		foreach ( $test_array as $key => $value ) {
 			// $test_posts['cta_post_id'] の投稿の post_content の中身を $value['cta_content'] で上書きする
-			wp_update_post(
-				array(
-					'ID'           => $test_posts['cta_post_id'],
-					'post_content' => $value['cta_content'],
-				)
+			$post_args = array(
+				'ID'           => $test_posts['cta_post_id'],
+				'post_content' => $value['cta_content'],
 			);
+			if  ( ! empty( $value['cta_title'] ) ) {
+				$post_args['post_title'] = $value['cta_title'];
+			}
+			wp_update_post( $post_args );
+			if ( ! empty( $value['post_meta'] ) ) {
+				foreach ( $value['post_meta'] as $meta_key => $meta_value ) {
+					update_post_meta( $test_posts['cta_post_id'], $meta_key, $meta_value );
+				}
+			}
 
 			$actual = Vk_Call_To_Action::render_cta_content( $test_posts['cta_post_id'] );
 			print 'expected ::' . $value['expected'] . PHP_EOL;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1101 でエスケープを追加したが、
厳しすぎてかなり表示が崩れてしまう

## どういう変更をしたか？

* CTA 出力時の wp_kses の解除
* PHPUnitテスト追加
* 入力欄に使っていた wp_kses の allowed_html をメソッド使用に変更

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [x] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [x] 情報意味を考慮した意味グルーピング・余白になっているか？
- [x] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [x] 書けそうなテストは書いたか？
- [x] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

## レビュワーの確認方法・確認する内容など

* master に切り替え
* CTA に https://patterns.vektor-inc.co.jp/vk-patterns/cta-pr-contents-free-full-width/ を登録
* 固定ページなどで ↑ を表示 -> エスケープされる
* このブランチに切り替え
* 適切に表示される事を確認

その他コードに問題があるかどうか

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
