### PR TITLE
デバッグ用の出力が多くなりすぎで逆に見えなくなったのでコメントアウト

### DIFF
--- a/tests/test-add-plugin-link-to-adminbar.php
+++ b/tests/test-add-plugin-link-to-adminbar.php
@@ -43,10 +43,10 @@ class addPluginLinkToAdminbarTest extends WP_UnitTestCase {
 			// 現在表示中のURLを取得
 			$acutual = veu_is_add_plugin_link_to_adminbar( $test_value['wp_version'], $test_value['is_admin'] );
 
-			print PHP_EOL;
-			print 'title    :' . $test_value['title'] . PHP_EOL;
-			print 'actual   :' . $acutual . PHP_EOL;
-			print 'expected :' . $test_value['expected'] . PHP_EOL;
+			// print PHP_EOL;
+			// print 'title    :' . $test_value['title'] . PHP_EOL;
+			// print 'actual   :' . $acutual . PHP_EOL;
+			// print 'expected :' . $test_value['expected'] . PHP_EOL;
 
 			// PHPunit
 			$this->assertEquals( $test_value['expected'], $acutual );

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -115,12 +115,12 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			$return = VK_Article_Srtuctured_Data::get_author_array( $user_id );
 			$correct = $test_value['correct'];
 
-			print PHP_EOL;
+			// print PHP_EOL;
 
-			print 'correct ::::' . PHP_EOL;
-			var_dump( $correct );
-			print 'return  ::::' . PHP_EOL;
-			var_dump( $return );
+			// print 'correct ::::' . PHP_EOL;
+			// var_dump( $correct );
+			// print 'return  ::::' . PHP_EOL;
+			// var_dump( $return );
 			$this->assertEquals( $correct, $return );
 		}
 

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -282,8 +282,7 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			$return = VK_Article_Srtuctured_Data::get_article_structure_array();
 			$correct = $test_value['correct'];
 
-			print PHP_EOL;
-
+			// print PHP_EOL;
 			// print 'correct ::::' . $test_value['correct'] . PHP_EOL;
 			// print 'return  ::::' . $return['author'] . PHP_EOL;
 

--- a/tests/test-change-old-options.php
+++ b/tests/test-change-old-options.php
@@ -57,11 +57,11 @@ class ChangeOldOptionsTest extends WP_UnitTestCase {
 
 			$this->assertEquals( $correct, $return );
 
-			print PHP_EOL;
-			print 'correct ::::' . PHP_EOL;
-			var_dump( $correct );
-			print 'return  ::::' . PHP_EOL;
-			var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct ::::' . PHP_EOL;
+			// var_dump( $correct );
+			// print 'return  ::::' . PHP_EOL;
+			// var_dump( $return );
 
 		}
     }

--- a/tests/test-child-page-index.php
+++ b/tests/test-child-page-index.php
@@ -159,9 +159,9 @@ class WidgetChildPageIndexTest extends WP_UnitTestCase {
 			$return = preg_replace( '/\s(?=\s)/', '', $return );
 			$expected = $value['expected'];
 
-			print  PHP_EOL;
-			print 'return  :' . $return . PHP_EOL;
-			print 'correct :' . $expected  . PHP_EOL;
+			// print  PHP_EOL;
+			// print 'return  :' . $return . PHP_EOL;
+			// print 'correct :' . $expected  . PHP_EOL;
 
 			// 返ってきた抜粋値と期待する結果が同じかどうかテスト
 			$this->assertEquals( $expected , $return );

--- a/tests/test-css-customize.php
+++ b/tests/test-css-customize.php
@@ -57,9 +57,9 @@ class CssCustomizeTest extends WP_UnitTestCase {
 		foreach ( $tests as $key => $test_value ) {
 			update_option( 'vkExUnit_css_customize', $test_value['option'] );
 			$return = veu_css_customize::css_customize_get_the_css_min();
-			print PHP_EOL;
-			print 'return    :' . $return . PHP_EOL;
-			print 'correct   :' . $test_value['correct'] . PHP_EOL;
+			// print PHP_EOL;
+			// print 'return    :' . $return . PHP_EOL;
+			// print 'correct   :' . $test_value['correct'] . PHP_EOL;
 			$this->assertEquals( $test_value['correct'], $return );
 		} // foreach ( $tests as $key => $test_value ) {
 			$before_option = update_option( 'vkExUnit_css_customize', $before_option );

--- a/tests/test-css-customize.php
+++ b/tests/test-css-customize.php
@@ -140,8 +140,8 @@ class CssCustomizeTest extends WP_UnitTestCase {
 			// 返ってきた値と期待する結果が同じかどうかテスト
 			$this->assertEquals( $value['correct'], $return );
 
-			print 'return  :' . $return . PHP_EOL;
-			print 'correct :' . $value['correct'] . PHP_EOL;
+			// print 'return  :' . $return . PHP_EOL;
+			// print 'correct :' . $value['correct'] . PHP_EOL;
 
 			// テスト用データを消去
 			wp_delete_post( $post_id, true );

--- a/tests/test-cta-default-display.php
+++ b/tests/test-cta-default-display.php
@@ -46,8 +46,8 @@ class CTADiaplayTest extends WP_UnitTestCase {
 			$return = Vk_Call_To_Action::get_option();
 
 			$this->assertEquals( $test_value['correct'], $return[$test_value['target_post_type']] );
-			print 'correct ::::' . $test_value['correct'] . PHP_EOL;
-			print 'return  ::::' . $return[$test_value['target_post_type']] . PHP_EOL;
+			// print 'correct ::::' . $test_value['correct'] . PHP_EOL;
+			// print 'return  ::::' . $return[$test_value['target_post_type']] . PHP_EOL;
 		}
 
 	} // function test_chlild_page_excerpt() {

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -81,8 +81,8 @@ class CTATest extends WP_UnitTestCase {
 			if ( isset( $return->post_title ) ) {
 				$return = $return->post_title;
 			}
-			print 'correct ::::' . esc_attr( $test_value['correct'] ) . PHP_EOL;
-			print 'return  ::::' . esc_attr( $return ) . PHP_EOL;
+			// print 'correct ::::' . esc_attr( $test_value['correct'] ) . PHP_EOL;
+			// print 'return  ::::' . esc_attr( $return ) . PHP_EOL;
 			$this->assertEquals( $test_value['correct'], $return );
 
 		}
@@ -176,8 +176,8 @@ class CTATest extends WP_UnitTestCase {
 			}
 			$actual = '';
 			$actual = veu_cta_block_callback( $test_value['attributes'], $content );
-			print 'expected ::' . $test_value['expected'] . PHP_EOL;
-			print 'actual ::::' . $actual . PHP_EOL;
+			// print 'expected ::' . $test_value['expected'] . PHP_EOL;
+			// print 'actual ::::' . $actual . PHP_EOL;
 			$this->assertEquals( $test_value['expected'], $actual );
 		}
 	}
@@ -261,8 +261,8 @@ class CTATest extends WP_UnitTestCase {
 			}
 
 			$actual = Vk_Call_To_Action::render_cta_content( $test_posts['cta_post_id'] );
-			print 'expected ::' . $value['expected'] . PHP_EOL;
-			print 'actual ::::' . $actual . PHP_EOL;
+			// print 'expected ::' . $value['expected'] . PHP_EOL;
+			// print 'actual ::::' . $actual . PHP_EOL;
 			$this->assertEquals( $value['expected'], $actual );
 		}
 	}

--- a/tests/test-get-common-options-default.php
+++ b/tests/test-get-common-options-default.php
@@ -126,11 +126,11 @@ class VeuGetCommonOptionsDefaultTest extends WP_UnitTestCase {
 			$return  = veu_get_common_options_default( $test_value['is_block_theme'] );
 			$correct = $test_value['correct'];
 
-			print PHP_EOL;
-			print 'correct :' . PHP_EOL;
-			var_dump( $correct );
-			print 'return  :' . PHP_EOL;
-            var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct :' . PHP_EOL;
+			// var_dump( $correct );
+			// print 'return  :' . PHP_EOL;
+            // var_dump( $return );
 
 			// 取得できたHTMLが、意図したHTMLと等しいかテスト
 			$this->assertEquals( $correct, $return );

--- a/tests/test-icon-accessibility.php
+++ b/tests/test-icon-accessibility.php
@@ -62,9 +62,9 @@ class IconAccessibilityTest extends WP_UnitTestCase {
 
 			$this->assertEquals( $test_value['correct'], $return );
 
-			print PHP_EOL;
-			print 'correct :' . $test_value['correct'] . PHP_EOL;
-			print 'return  :' . $return . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct :' . $test_value['correct'] . PHP_EOL;
+			// print 'return  :' . $return . PHP_EOL;
 		}
 	}
 

--- a/tests/test-insert-item-meta-box-display.php
+++ b/tests/test-insert-item-meta-box-display.php
@@ -93,9 +93,9 @@ class InsertItemMetaBoxDisplayTest extends WP_UnitTestCase {
 
 			print PHP_EOL;
 
-			print $_SERVER['REQUEST_URI'] . PHP_EOL;
-			print 'correct ::::' . $test_value['correct'] . PHP_EOL;
-			print 'return  ::::' . $return . PHP_EOL;
+			// print $_SERVER['REQUEST_URI'] . PHP_EOL;
+			// print 'correct ::::' . $test_value['correct'] . PHP_EOL;
+			// print 'return  ::::' . $return . PHP_EOL;
 
 			// テスト用投稿を削除
 			if ( ! empty( $posted_id ) ) {

--- a/tests/test-isert-ads.php
+++ b/tests/test-isert-ads.php
@@ -57,7 +57,7 @@ class InsertAdsTest extends WP_UnitTestCase {
 
 			// PHPunit
 			$this->assertEquals( $test_value['correct'], $return['post_types'] );
-			print PHP_EOL;
+			// print PHP_EOL;
 			// 帰り値が配列だから print してもエラーになるだけなのでコメントアウト
 			// print 'return    :' . $return['post_types'] . PHP_EOL;
 			// print 'correct   :' . $test_value['correct'] . PHP_EOL;

--- a/tests/test-make-ga-script.php
+++ b/tests/test-make-ga-script.php
@@ -92,10 +92,10 @@ class MakeGAScriptTest extends WP_UnitTestCase {
 			$return = make_ga_script();
 
 			// PHPunit
-            print 'correct ::::' . $test_value['correct'] . PHP_EOL;
-			print 'return  ::::' . $return . PHP_EOL;
+            // print 'correct ::::' . $test_value['correct'] . PHP_EOL;
+			// print 'return  ::::' . $return . PHP_EOL;
+			// print PHP_EOL;
 			$this->assertEquals( $test_value['correct'], $return );
-			print PHP_EOL;
 			delete_option( 'vkExUnit_ga_options' );
 		}
 		delete_option( 'vkExUnit_ga_options' );

--- a/tests/test-package_manager.php
+++ b/tests/test-package_manager.php
@@ -38,9 +38,9 @@ class PackageManagerTest extends WP_UnitTestCase {
 			// 取得できた値と、想定する値が等しいかテスト
 			$this->assertEquals( $test_value['correct'], $result );
 
-			print PHP_EOL;
-			print 'Package         :' . $result . PHP_EOL;
-			print 'Package Correct :' . $test_value['correct'] . PHP_EOL;
+			// print PHP_EOL;
+			// print 'Package         :' . $result . PHP_EOL;
+			// print 'Package Correct :' . $test_value['correct'] . PHP_EOL;
 		}
 
 	}
@@ -79,9 +79,9 @@ class PackageManagerTest extends WP_UnitTestCase {
 			// 判定結果
 			$output = veu_common_options_validate( $test_value );
 
-			print PHP_EOL;
-			print 'options_validate         :' . $output['active_pagetop_button'] . PHP_EOL;
-			print 'options_validate Correct :' . $test_value['correct'] . PHP_EOL;
+			// print PHP_EOL;
+			// print 'options_validate         :' . $output['active_pagetop_button'] . PHP_EOL;
+			// print 'options_validate Correct :' . $test_value['correct'] . PHP_EOL;
 
 			// 取得できた値と、想定する値が等しいかテスト
 			$this->assertEquals( $test_value['correct'], $output['active_pagetop_button'] );
@@ -112,9 +112,9 @@ class PackageManagerTest extends WP_UnitTestCase {
 			// 判定結果
 			$output = veu_common_options_validate( $options );
 
-			print PHP_EOL;
-			print 'options_validate 2         :' . $output[ $key ] . PHP_EOL;
-			print 'options_validate Correct 2 :' . $value['correct'] . PHP_EOL;
+			// print PHP_EOL;
+			// print 'options_validate 2         :' . $output[ $key ] . PHP_EOL;
+			// print 'options_validate Correct 2 :' . $value['correct'] . PHP_EOL;
 
 			// 取得できた値と、想定する値が等しいかテスト
 			$this->assertEquals( $value['correct'], $output[ $key ] );

--- a/tests/test-page-list-ancestor.php
+++ b/tests/test-page-list-ancestor.php
@@ -180,11 +180,11 @@ class PageListAncestorTest extends WP_UnitTestCase {
         foreach ( $test_array as $title => $test ) {
             $return  = str_replace( "'", '"' , str_replace( array( "\r\n", "\r", "\n", "\t" ), "", veu_page_list_ancestor_block_callback( $test['attr'], '' ) ) );
             $correct = $test['correct'];
-            print '[' . $title . ']' . PHP_EOL;
-            print 'return------------------------------------' . PHP_EOL;
-			print $return . PHP_EOL;
-			print 'correct------------------------------------' . PHP_EOL;
-			print $correct . PHP_EOL;
+            // print '[' . $title . ']' . PHP_EOL;
+            // print 'return------------------------------------' . PHP_EOL;
+			// print $return . PHP_EOL;
+			// print 'correct------------------------------------' . PHP_EOL;
+			// print $correct . PHP_EOL;
             $this->assertEquals( $correct, $return );
         }
 

--- a/tests/test-parent-meta-box-display.php
+++ b/tests/test-parent-meta-box-display.php
@@ -92,10 +92,9 @@ class ParentMetaBoxDisplayManualTest extends WP_UnitTestCase {
 
 			$this->assertEquals( $test_value['correct'], $return );
 
-			print PHP_EOL;
-
-			print 'correct ::::' . $test_value['correct'] . PHP_EOL;
-			print 'return  ::::' . $return . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct ::::' . $test_value['correct'] . PHP_EOL;
+			// print 'return  ::::' . $return . PHP_EOL;
 
 		}
 

--- a/tests/test-promotion-alert.php
+++ b/tests/test-promotion-alert.php
@@ -364,9 +364,9 @@ class PromotionAlertTest extends WP_UnitTestCase {
 
 			$this->assertEquals( $correct, $return );
 
-			print PHP_EOL;
-			print 'correct ::::' . $correct . PHP_EOL;
-			print 'return  ::::' . $return . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct ::::' . $correct . PHP_EOL;
+			// print 'return  ::::' . $return . PHP_EOL;
 
 		}
 
@@ -475,16 +475,17 @@ class PromotionAlertTest extends WP_UnitTestCase {
 			$this->go_to( get_permalink( $data['post_id_01'] ) );
 
 			$options = get_option( 'vkExUnit_common_options' );
-			var_dump($options['active_icon_accessibility']);
+
+			// var_dump($options['active_icon_accessibility']);
 
 			$return  = VEU_Promotion_Alert::get_alert_content();
 			$correct = $test_value['correct'];
 
 			$this->assertEquals( $correct, $return );
 
-			print PHP_EOL;
-			print 'correct ::::' . $correct . PHP_EOL;
-			print 'return  ::::' . $return . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct ::::' . $correct . PHP_EOL;
+			// print 'return  ::::' . $return . PHP_EOL;
 
 		}
 

--- a/tests/test-sns-btn-style.php
+++ b/tests/test-sns-btn-style.php
@@ -66,9 +66,9 @@ class SnsBtnsStyle extends WP_UnitTestCase {
 
 			$this->assertEquals( $test_value['correct'], $return );
 
-			print PHP_EOL;
-			print 'correct :' . esc_attr( $test_value['correct'] ) . PHP_EOL;
-			print 'return  :' . esc_attr( $return ) . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct :' . esc_attr( $test_value['correct'] ) . PHP_EOL;
+			// print 'return  :' . esc_attr( $return ) . PHP_EOL;
 		}
 	}
 
@@ -107,9 +107,9 @@ class SnsBtnsStyle extends WP_UnitTestCase {
 
 			$this->assertEquals( $test_value['correct'], $return );
 
-			print PHP_EOL;
-			print 'correct :' . esc_attr( $test_value['correct'] ) . PHP_EOL;
-			print 'return  :' . esc_attr( $return ) . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct :' . esc_attr( $test_value['correct'] ) . PHP_EOL;
+			// print 'return  :' . esc_attr( $return ) . PHP_EOL;
 		}
 	}
 

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -384,10 +384,10 @@ class SnsBtnsTest extends WP_UnitTestCase {
 
 			$this->assertEquals( $correct, $return );
 
-			print PHP_EOL;
-			print 'url     ::::' . $test_value['target_url'] . PHP_EOL;
-			print 'correct ::::' . $correct . PHP_EOL;
-			print 'return  ::::' . $return . PHP_EOL;
+			// print PHP_EOL;
+			// print 'url     ::::' . $test_value['target_url'] . PHP_EOL;
+			// print 'correct ::::' . $correct . PHP_EOL;
+			// print 'return  ::::' . $return . PHP_EOL;
 
 		}
 	}

--- a/tests/test-sns-title.php
+++ b/tests/test-sns-title.php
@@ -1269,10 +1269,9 @@ class SnsTitleTest extends WP_UnitTestCase {
 			// 取得できたHTMLが、意図したHTMLと等しいかテスト
 			$this->assertEquals( $test_value['correct'], $return );
 
-			print PHP_EOL;
-
-			print 'correct ::::' . $test_value['correct'] . PHP_EOL;
-			print 'return  ::::' . $return . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct ::::' . $test_value['correct'] . PHP_EOL;
+			// print 'return  ::::' . $return . PHP_EOL;
 
 
 		}

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -603,11 +603,11 @@ class TemplateTagsTest extends WP_UnitTestCase {
 			$this->go_to( $test['target_url'] );
 			$return  = vk_get_page_description();
 			$correct = $test['correct'];
-			print PHP_EOL;
-			print 'Name    : ' . $test['test_name'] . PHP_EOL;
-			print 'url     : ' . $test['target_url'] . PHP_EOL;
-			print 'return  : ' . $return . PHP_EOL;
-			print 'correct : ' . $correct . PHP_EOL;
+			// print PHP_EOL;
+			// print 'Name    : ' . $test['test_name'] . PHP_EOL;
+			// print 'url     : ' . $test['target_url'] . PHP_EOL;
+			// print 'return  : ' . $return . PHP_EOL;
+			// print 'correct : ' . $correct . PHP_EOL;
 
 			$this->assertEquals( $correct, $return );
 

--- a/tests/test-website-structure.php
+++ b/tests/test-website-structure.php
@@ -42,12 +42,11 @@ class Website_Structure_Test extends WP_UnitTestCase {
 			$actual = VK_WebSite_Srtuctured_Data::get_website_structure_array();
 			$correct = $test_value['correct'];
 
-			print PHP_EOL;
-
-			print 'correct ::::' . PHP_EOL;
-			var_dump( $correct );
-			print 'return  ::::' . PHP_EOL;
-			var_dump( $actual );
+			// print PHP_EOL;
+			// print 'correct ::::' . PHP_EOL;
+			// var_dump( $correct );
+			// print 'return  ::::' . PHP_EOL;
+			// var_dump( $actual );
 
 			$this->assertEquals( $correct, $actual );
 

--- a/tests/test-widget-btn.php
+++ b/tests/test-widget-btn.php
@@ -47,9 +47,9 @@ class WidgetBtnTest extends WP_UnitTestCase {
 			$return = WP_Widget_Button::get_btn_options( $test_value );
 			$this->assertEquals( $test_value['correct'], $return['title'] );
 
-			print PHP_EOL;
-			print 'return    :' . $return['title'] . PHP_EOL;
-			print 'correct   :' . $test_value['correct'] . PHP_EOL;
+			// print PHP_EOL;
+			// print 'return    :' . $return['title'] . PHP_EOL;
+			// print 'correct   :' . $test_value['correct'] . PHP_EOL;
 		}
 	}
 

--- a/tests/test-widget-new-post.php
+++ b/tests/test-widget-new-post.php
@@ -60,9 +60,9 @@ class WidgetNewPostsTest extends WP_UnitTestCase {
 			// 取得できたHTMLが、意図したHTMLと等しいかテスト
 			$this->assertEquals( $test_value['correct_more_link_html'], $more_link_html );
 
-			print PHP_EOL;
-			print 'correct_more_link_html :' . $test_value['correct_more_link_html'] . PHP_EOL;
-			print 'more_link_html         :' . $more_link_html . PHP_EOL;
+			// print PHP_EOL;
+			// print 'correct_more_link_html :' . $test_value['correct_more_link_html'] . PHP_EOL;
+			// print 'more_link_html         :' . $more_link_html . PHP_EOL;
 		}
 
 		$this->assertTrue( true );

--- a/tests/test-widget-page.php
+++ b/tests/test-widget-page.php
@@ -149,11 +149,11 @@ class WidgetPage extends WP_UnitTestCase {
 
 			// widget_title() で タイトル情報を取得
 			$widget_title = WP_Widget_vkExUnit_widget_page::widget_title( $instance );
-			print PHP_EOL;
-			print 'widget_title         :'.$widget_title['title'].PHP_EOL;
-			print 'widget_title correct :'.$test_value['title_correct'].PHP_EOL;
-			print 'widget_display         :'.$widget_title['display'].PHP_EOL;
-			print 'widget_display_correct :'.$test_value['display_correct'].PHP_EOL;
+			// print PHP_EOL;
+			// print 'widget_title         :'.$widget_title['title'].PHP_EOL;
+			// print 'widget_title correct :'.$test_value['title_correct'].PHP_EOL;
+			// print 'widget_display         :'.$widget_title['display'].PHP_EOL;
+			// print 'widget_display_correct :'.$test_value['display_correct'].PHP_EOL;
 			// 取得できたタイトルの値と、想定する正しいタイトル名が等しいかテスト
 			$this->assertEquals( $test_value['title_correct'], $widget_title['title'] );
 			$this->assertEquals( $test_value['display_correct'], $widget_title['display'] );

--- a/tests/test-widget-profile.php
+++ b/tests/test-widget-profile.php
@@ -105,9 +105,10 @@ class WidgetProfileTest extends WP_UnitTestCase {
 			$image_outer_size_css = WP_Widget_vkExUnit_profile::image_outer_size_css( $test_value );
 			$this->assertEquals( $test_value['correct_media_outer_size_css'], $image_outer_size_css );
 
-			print PHP_EOL;
-			print 'image_outer_size_css        :'.$image_outer_size_css.PHP_EOL;
-			print 'correct_media_outer_size_css:'.$test_value['correct_media_outer_size_css'].PHP_EOL;
+			// print PHP_EOL;
+			// print 'image_outer_size_css        :'.$image_outer_size_css.PHP_EOL;
+			// print 'correct_media_outer_size_css:'.$test_value['correct_media_outer_size_css'].PHP_EOL;
+
 		} // foreach ( $test_image_round as $key => $test_value) {
 	} // function test_image_outer_size_css() {
 
@@ -168,11 +169,11 @@ class WidgetProfileTest extends WP_UnitTestCase {
 			$this->assertEquals( $test_value['correct_outer_css'], $outer_css );
 			$this->assertEquals( $test_value['correct_icon_css'], $icon_css );
 
-			print PHP_EOL;
-			print 'outer_css_correct :'.$test_value['correct_outer_css'].PHP_EOL;
-			print 'outer_css         :'.$outer_css.PHP_EOL;
-			print 'icon_css_correct  :'.$test_value['correct_icon_css'].PHP_EOL;
-			print 'icon_css          :'.$icon_css.PHP_EOL;
+			// print PHP_EOL;
+			// print 'outer_css_correct :'.$test_value['correct_outer_css'].PHP_EOL;
+			// print 'outer_css         :'.$outer_css.PHP_EOL;
+			// print 'icon_css_correct  :'.$test_value['correct_icon_css'].PHP_EOL;
+			// print 'icon_css          :'.$icon_css.PHP_EOL;
 
 		} // foreach ( $test_array as $key => $test_value) {
 	} // function test_icon_color() {

--- a/tests/test-widget-title.php
+++ b/tests/test-widget-title.php
@@ -42,9 +42,9 @@ class WP_Widget_vkExUnit_post_list_Test extends WP_UnitTestCase {
 			$return = WP_Widget_vkExUnit_post_list::get_widget_title( $test_value );
 			$this->assertEquals( $test_value['correct'], $return );
 
-			print PHP_EOL;
-			print 'return    :' . $return . PHP_EOL;
-			print 'correct   :' . $test_value['correct'] . PHP_EOL;
+			// print PHP_EOL;
+			// print 'return    :' . $return . PHP_EOL;
+			// print 'correct   :' . $test_value['correct'] . PHP_EOL;
 		}
 	}
 

--- a/tests/test-wp-title.php
+++ b/tests/test-wp-title.php
@@ -281,11 +281,10 @@ class WpTitleTest extends WP_UnitTestCase {
 
 			$actual = vkExUnit_get_wp_head_title();
 
-			print PHP_EOL;
-
-			print $value['target_url'] . PHP_EOL;
-			print 'expected::::' . $value['expected'] . PHP_EOL;
-			print 'actual  ::::' . $actual . PHP_EOL;
+			// print PHP_EOL;
+			// print $value['target_url'] . PHP_EOL;
+			// print 'expected::::' . $value['expected'] . PHP_EOL;
+			// print 'actual  ::::' . $actual . PHP_EOL;
 
 			$this->assertEquals( $value['expected'], $actual );
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

PHPUnit を走らせたときに表示されるデバッグが多くなりすぎて見にくいのでコメントアウトしました。
必要なときにコメントアウト解除すれば良いかなと。