### PR TITLE
[ カスタム投稿タイプマネージャー ] 設定から解説記事やベクトレへのリンクを追加

### DIFF
--- a/admin/admin-active-setting-page.php
+++ b/admin/admin-active-setting-page.php
@@ -66,9 +66,11 @@ foreach ( $vkExUnit_packages as $package ) :
 				?>
 				<?php echo ( $count > 1 && $i >= 1 ) ? ' | ' : ''; ?>
 				<span>
-				<a href="<?php echo ( $att['url'] ) ? esc_html( $att['url'] ) : admin_url() . 'admin.php?page=vkExUnit_main_setting'; ?>">
-				<?php echo esc_html( $att['name'] ); ?>
-				</a></span>
+				<a href="<?php echo ( $att['url'] ) ? esc_url( $att['url'] ) : admin_url() . 'admin.php?page=vkExUnit_main_setting'; ?>"
+					<?php echo ( isset( $att['target'] ) && $att['target'] === '_blank' ) ? 'target="_blank"' : ''; ?>>
+					<?php echo esc_html( $att['name'] ); ?>
+				</a>
+				</span>
 
 				<?php
 					endif;

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -57,6 +57,55 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			$role->add_cap( 'publish_others_' . $post_type_name . 's' );
 		}
 
+		/**
+		 * ヘルプ通知
+		 *
+		 * @return string
+		 */
+		public static function get_help_notice() {
+			// サイトの言語が日本語 (ja) であるかどうかを判定
+			if ( get_locale() !== 'ja' ) {
+				return ''; // 日本語以外の場合は何も返さない
+			}
+
+			$dismiss_url = esc_url(
+				wp_nonce_url(
+					add_query_arg('vkblocks-dismiss-pro', 'dismiss_admin_notice'),
+					'vkblocks-dismiss-pro-' . get_current_user_id()
+				)
+			);
+
+			// ヘルプ通知のHTMLを生成して返す
+			return wp_kses_post(
+				'<div class="notice notice-info is-dismissible">
+					<p style="margin-top: 10px;"><strong>' . __( 'Help and Documentation', 'vk-all-in-one-expansion-unit' ) . ':</strong> ' . __( 'Learn more about custom post type settings by visiting the following resources:', 'vk-all-in-one-expansion-unit' ) . '</p>
+					<ul style="list-style-type: disc; margin-top: 0; margin-left: 20px;">
+						<li><a href="https://ex-unit.nagoya/ja/about/custom_post_type_manager" target="_blank">' . __( 'ExUnit Site: Custom Post Type Manager', 'vk-all-in-one-expansion-unit' ) . '</a></li>
+						<li><a href="https://training.vektor-inc.co.jp/courses/x-t9-custom-post-type/" target="_blank">' . __( 'Vektor Training: X-T9 Setup Guide for Custom Post Types', 'vk-all-in-one-expansion-unit' ) . '</a></li>
+						<li><a href="https://training.vektor-inc.co.jp/courses/lightning-basic-settings/lessons/lightning-custom-post-type-lightning/" target="_blank">' . __( 'Vektor Training: Lightning Basic Settings for Custom Post Types', 'vk-all-in-one-expansion-unit' ) . '</a></li>
+					</ul>
+					<p><a href="' . $dismiss_url . '" target="_parent">' . esc_html__( 'Dismiss this notice', 'vk-blocks' ) . '</a></p>
+				</div>'
+			);
+		}
+		
+		/**
+		 * Display help notice on specific page
+		 *
+		 * @return void
+		 */
+		public static function display_help_notice() {
+			// 現在のページを取得
+			global $pagenow;
+
+			// 特定のページのみ通知を表示する
+			if ($pagenow === 'edit.php' && isset($_GET['post_type']) && $_GET['post_type'] === 'post_type_manage') {
+				// 通知のHTMLを取得して表示
+				echo self::get_help_notice();
+			}
+
+		}
+
 		/*******************************************
 		 * カスタムフィールドの meta box を作成.
 		 */
@@ -70,11 +119,15 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		 * @return void
 		 */
 		public static function add_meta_box_action() {
+
 			global $post;
 
 			// CSRF対策の設定（フォームにhiddenフィールドとして追加するためのnonceを「'noncename__post_type_manager」として設定）.
 			wp_nonce_field( wp_create_nonce( __FILE__ ), 'noncename__post_type_manager' );
 
+			// 通知メッセージを取得して表示
+			echo self::get_help_notice();
+			
 			?>
 			<style type="text/css">
 			table.table { border-collapse: collapse; border-spacing: 0;width:100%; }
@@ -170,24 +223,25 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			echo '<hr>';
 
 			// JavaScript to update icon selection and validate input
-			echo '<script>
-function updateIconSelection(icon) {
-    document.getElementById("veu_menu_icon").value = icon;
-}
+			echo '
+			<script>
+				function updateIconSelection(icon) {
+					document.getElementById("veu_menu_icon").value = icon;
+				}
 
-document.addEventListener("DOMContentLoaded", function () {
-    var inputField = document.getElementById("veu_menu_icon");
-    
-    // `change` イベントを使用して、フォーカスが外れたときにチェックする
-    inputField.addEventListener("change", function() {
-        // SVGデータURI、\'none\'、または\'dashicons-\'で始まる値を許可
-        if (!this.value.startsWith("dashicons-") && !this.value.startsWith("data:image/svg+xml;base64,") && this.value !== \'none\') {
-            alert("' . __( 'Please enter a valid input. You can enter a Dashicon class, a base64-encoded SVG, or \'none\' to leave it blank for CSS customization.', 'vk-all-in-one-expansion-unit' ) . '");
-            this.value = ""; // 不正な入力をクリア
-        }
-    });
-});
-</script>';
+				document.addEventListener("DOMContentLoaded", function () {
+					var inputField = document.getElementById("veu_menu_icon");
+					
+					// `change` イベントを使用して、フォーカスが外れたときにチェックする
+					inputField.addEventListener("change", function() {
+						// SVGデータURI、\'none\'、または\'dashicons-\'で始まる値を許可
+						if (!this.value.startsWith("dashicons-") && !this.value.startsWith("data:image/svg+xml;base64,") && this.value !== \'none\') {
+							alert("' . __( 'Please enter a valid input. You can enter a Dashicon class, a base64-encoded SVG, or \'none\' to leave it blank for CSS customization.', 'vk-all-in-one-expansion-unit' ) . '");
+							this.value = ""; // 不正な入力をクリア
+						}
+					});
+				});
+			</script>';
 
 			/*******************************************
 			 * Export to Rest api
@@ -567,5 +621,7 @@ document.addEventListener("DOMContentLoaded", function () {
 	} // class VK_Post_Type_Manager
 
 	$VK_Post_Type_Manager = new VK_Post_Type_Manager(); // phpcs:ignore
+
+	add_action('admin_notices', array('VK_Post_Type_Manager', 'display_help_notice'), 20);
 
 }

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -68,6 +68,11 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				return ''; // 日本語以外の場合は何も返さない
 			}
 
+			// ユーザーが通知を無視したフラグが保存されているかをチェック
+			if ( get_user_meta( get_current_user_id(), 'vkblocks_dismissed_notice', true ) ) {
+				return ''; // 通知を無視している場合は何も返さない
+			}
+
 			$dismiss_url = esc_url(
 				wp_nonce_url(
 					add_query_arg('vkblocks-dismiss-pro', 'dismiss_admin_notice'),
@@ -88,7 +93,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				</div>'
 			);
 		}
-		
+
 		/**
 		 * Display help notice on specific page
 		 *
@@ -104,6 +109,11 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				echo self::add_post_type_get_help_notice();
 			}
 
+			// 通知の無視パラメーターをチェック
+			if ( isset( $_GET['vkblocks-dismiss-pro'] ) && $_GET['vkblocks-dismiss-pro'] === 'dismiss_admin_notice' ) {
+				check_admin_referer( 'vkblocks-dismiss-pro-' . get_current_user_id() );
+				update_user_meta( get_current_user_id(), 'vkblocks_dismissed_notice', true );
+			}
 		}
 
 		/*******************************************

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -95,24 +95,41 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		}
 
 		/**
-		 * Display help notice on specific page
+		 * Check if the help notice should be displayed on the current page.
 		 *
-		 * @return void
+		 * @return bool
 		 */
-		public static function display_help_notice() {
+		public static function is_display_help_notice() {
 			// 現在のページを取得
 			global $pagenow;
 
 			// 特定のページのみ通知を表示する
 			if ($pagenow === 'edit.php' && isset($_GET['post_type']) && $_GET['post_type'] === 'post_type_manage') {
+				// 通知の無視パラメーターが保存されていないかどうかを確認
+				if (!get_user_meta(get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
+		 * Display help notice on specific page
+		 *
+		 * @return void
+		 */
+		public static function display_help_notice() {
+			// 通知を表示するかどうかの判定
+			if (self::is_display_help_notice()) {
 				// 通知のHTMLを取得して表示
 				echo self::add_post_type_get_help_notice();
 			}
 
 			// 通知の無視パラメーターをチェック
-			if ( isset( $_GET['vk-all-in-one-expansion-unit-dismiss'] ) && $_GET['vk-all-in-one-expansion-unit-dismiss'] === 'dismiss_admin_notice' ) {
-				check_admin_referer( 'vk-all-in-one-expansion-unit-dismiss-' . get_current_user_id() );
-				update_user_meta( get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true );
+			if (isset($_GET['vk-all-in-one-expansion-unit-dismiss']) && $_GET['vk-all-in-one-expansion-unit-dismiss'] === 'dismiss_admin_notice') {
+				check_admin_referer('vk-all-in-one-expansion-unit-dismiss-' . get_current_user_id());
+				update_user_meta(get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true);
 			}
 		}
 

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		 *
 		 * @return string
 		 */
-		public static function get_help_notice() {
+		public static function add_post_type_get_help_notice() {
 			// サイトの言語が日本語 (ja) であるかどうかを判定
 			if ( get_locale() !== 'ja' ) {
 				return ''; // 日本語以外の場合は何も返さない
@@ -101,7 +101,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			// 特定のページのみ通知を表示する
 			if ($pagenow === 'edit.php' && isset($_GET['post_type']) && $_GET['post_type'] === 'post_type_manage') {
 				// 通知のHTMLを取得して表示
-				echo self::get_help_notice();
+				echo self::add_post_type_get_help_notice();
 			}
 
 		}
@@ -126,7 +126,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			wp_nonce_field( wp_create_nonce( __FILE__ ), 'noncename__post_type_manager' );
 
 			// 通知メッセージを取得して表示
-			echo self::get_help_notice();
+			echo self::add_post_type_get_help_notice();
 			
 			?>
 			<style type="text/css">

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -100,12 +100,9 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		 * @return bool
 		 */
 		public static function is_display_help_notice() {
-			// 現在のページを取得
 			global $pagenow;
 
-			// 特定のページのみ通知を表示する
 			if ($pagenow === 'edit.php' && isset($_GET['post_type']) && $_GET['post_type'] === 'post_type_manage') {
-				// 通知の無視パラメーターが保存されていないかどうかを確認
 				if (!get_user_meta(get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true)) {
 					return true;
 				}
@@ -120,13 +117,12 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		 * @return void
 		 */
 		public static function display_help_notice() {
-			// 通知を表示するかどうかの判定
+
 			if (self::is_display_help_notice()) {
-				// 通知のHTMLを取得して表示
+
 				echo self::add_post_type_get_help_notice();
 			}
 
-			// 通知の無視パラメーターをチェック
 			if (isset($_GET['vk-all-in-one-expansion-unit-dismiss']) && $_GET['vk-all-in-one-expansion-unit-dismiss'] === 'dismiss_admin_notice') {
 				check_admin_referer('vk-all-in-one-expansion-unit-dismiss-' . get_current_user_id());
 				update_user_meta(get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true);

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -69,16 +69,16 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			}
 
 			// ユーザーが通知を無視したフラグが保存されているかをチェック
-			if ( get_user_meta( get_current_user_id(), 'vkblocks_dismissed_notice', true ) ) {
+			if ( get_user_meta( get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true ) ) {
 				return ''; // 通知を無視している場合は何も返さない
 			}
 
 			$dismiss_url = esc_url(
 				wp_nonce_url(
-					add_query_arg('vkblocks-dismiss-pro', 'dismiss_admin_notice'),
-					'vkblocks-dismiss-pro-' . get_current_user_id()
+					add_query_arg('vk-all-in-one-expansion-unit-dismiss', 'dismiss_admin_notice'),
+					'vk-all-in-one-expansion-unit-dismiss-' . get_current_user_id()
 				)
-			);
+			);			
 
 			// ヘルプ通知のHTMLを生成して返す
 			return wp_kses_post(
@@ -110,9 +110,9 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			}
 
 			// 通知の無視パラメーターをチェック
-			if ( isset( $_GET['vkblocks-dismiss-pro'] ) && $_GET['vkblocks-dismiss-pro'] === 'dismiss_admin_notice' ) {
-				check_admin_referer( 'vkblocks-dismiss-pro-' . get_current_user_id() );
-				update_user_meta( get_current_user_id(), 'vkblocks_dismissed_notice', true );
+			if ( isset( $_GET['vk-all-in-one-expansion-unit-dismiss'] ) && $_GET['vk-all-in-one-expansion-unit-dismiss'] === 'dismiss_admin_notice' ) {
+				check_admin_referer( 'vk-all-in-one-expansion-unit-dismiss-' . get_current_user_id() );
+				update_user_meta( get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true );
 			}
 		}
 

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -63,15 +63,6 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		 * @return string
 		 */
 		public static function add_post_type_get_help_notice() {
-			// サイトの言語が日本語 (ja) であるかどうかを判定
-			if ( get_locale() !== 'ja' ) {
-				return ''; // 日本語以外の場合は何も返さない
-			}
-
-			// ユーザーが通知を無視したフラグが保存されているかをチェック
-			if ( get_user_meta( get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true ) ) {
-				return ''; // 通知を無視している場合は何も返さない
-			}
 
 			$dismiss_url = esc_url(
 				wp_nonce_url(
@@ -102,13 +93,17 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		public static function is_display_help_notice() {
 			global $pagenow;
 
+			if ( get_locale() !== 'ja' ) {
+				return false;
+			}
+		
+			// 特定のページのみ通知を表示する
 			if ($pagenow === 'edit.php' && isset($_GET['post_type']) && $_GET['post_type'] === 'post_type_manage') {
+				// ユーザーが通知を無視したフラグが保存されているかどうかを確認
 				if (!get_user_meta(get_current_user_id(), 'vk-all-in-one-expansion-unit_dismissed_notice', true)) {
 					return true;
 				}
 			}
-
-			return false;
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Add function ][ Post Type Manager ] Added links to explanatory articles and Vectre from the custom post type settings.
+
 = 9.99.6 =
 [ Bug fix ][ Child Page List ] Fixed an issue related to a PHP error.
 

--- a/veu-packages.php
+++ b/veu-packages.php
@@ -547,6 +547,12 @@ function veu_get_packages( $is_block_theme = null ) {
 				'url'         => admin_url() . 'edit.php?post_type=post_type_manage',
 				'enable_only' => 1,
 			),
+			( get_locale() === 'ja' ) ? array(
+				'name'        => __( 'Learn more', 'vk-all-in-one-expansion-unit' ),
+				'url'         => 'https://ex-unit.nagoya/ja/about/custom_post_type_manager',
+				'target'      => '_blank',
+				'enable_only' => false,
+			) : null,
 		),
 		'default'     => true,
 		'include'     => 'post-type-manager/post-type-manager-config.php',


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#1099 

## どういう変更をしたか？

- カスタム投稿タイプ設定に関する記事やベクトレへのリンクを含む通知やテキストリンクを追加しました。
- 有効化一覧の中にカスタム投稿タイプ設定に関する記事を入れるためにtarget="_blank"にできるように設定を変更しました。(veu-packages.php のarrayに`'target'  => '_blank',`がない場合は、テキストリンククリック後、リンクURLが同一タブで開きます。)
- 管理画面でのヘルプ通知を、サイトの言語設定に基づいて動的に切り替え、日本語設定時にのみ表示されるようにしました。

![image](https://github.com/user-attachments/assets/09f088df-e436-43d8-999d-e0faea578cd5)
![スクリーンショット 2024-10-24 12 08 32](https://github.com/user-attachments/assets/d3fd85a8-e69c-415b-a0de-f963a1b306e3)
![スクリーンショット 2024-10-24 12 08 38](https://github.com/user-attachments/assets/ab17c112-e263-441e-9fea-e72f9dd0f18c)

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [x] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [x] 情報意味を考慮した意味グルーピング・余白になっているか？
- [x] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ → 必要かわからずスキップしました。もし必要でしたらチャレンジしてみます。
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [ ] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

WordPressの言語設定が日本語の場合、以下を確認しました。

- ダッシュボードから ExUnit > 有効化 > カスタム投稿タイプマネージャーに「Learm more」が追加されていること&Learm moreをクリックすると別タブで https://ex-unit.nagoya/ja/about/custom_post_type_manager が表示されることを確認。
- カスタム投稿タイプ設定やカスタム投稿タイプ設定で新規に追加したカスタム投稿タイプの編集画面で、「Help and Documentation」のヘルプ通知ボックスが表示されていることを確認。
- 右上のxや通知を無視をクリックすると表示されなくなることを確認。(xの時はページを再読み込みするとヘルプ通知が表示されます。)
- Help and Documentationの中のリンクが以下と同じかを確認。
1. ExUnit サイト：[カスタム投稿タイプマネージャー](https://ex-unit.nagoya/ja/about/custom_post_type_manager)
2. ベクトレ：[X-T9 設定ガイド カスタム投稿タイプ編](https://training.vektor-inc.co.jp/courses/x-t9-custom-post-type/)
3. ベクトレ：[Lightning 基本設定解説 カスタム投稿タイプの設定](https://training.vektor-inc.co.jp/courses/lightning-basic-settings/lessons/lightning-custom-post-type-lightning/)
- WordPressの言語設定が日本語以外の場合、上記の表示がなくなることを確認しました。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
