### PR TITLE
広告アラートで意図したwp_ksesフィルタリングが適用されていなかったのを修正

### DIFF
--- a/inc/promotion-alert/package/class-veu-promotion-alert.php
+++ b/inc/promotion-alert/package/class-veu-promotion-alert.php
@@ -5,19 +5,36 @@
 
 class VEU_Promotion_Alert {
 
-    /**
-     * Constructor Define
-     */
-    public static function init() {
+	/**
+	 * Constructor Define
+	 */
+	public static function init() {
+		global $allowedposttags;
+		if ( isset( $allowedposttags['ins'] ) ) {
+			$allowedposttags['ins']['style'] = array();
+		}
 		add_action( 'veu_package_init', array( __CLASS__, 'option_init' ) );
 		add_action( 'save_post', array( __CLASS__, 'save_meta_box' ) );
-        // is_singular() で判定するため wp で実行
-        add_action( 'wp', array( __CLASS__, 'display_alert' ) );
-        add_action( 'wp_head', array( __CLASS__, 'inline_style' ), 5 );
-        add_action( 'after_setup_theme', array( __CLASS__, 'content_filter' ) );
+		// is_singular() で判定するため wp で実行
+		add_action( 'wp', array( __CLASS__, 'display_alert' ) );
+		add_action( 'wp_head', array( __CLASS__, 'inline_style' ), 5 );
+		add_action( 'after_setup_theme', array( __CLASS__, 'content_filter' ) );
+		add_filter( 'wp_kses_allowed_css', array( __CLASS__, 'promotion_alert_allowed_css' ) );
+		add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'modify_wp_kses_allowed_html' ), 99, 2 );
 	}
 
-    /**
+	/**
+	 * Allow data-nosnippet attribute on div tags for kses filtering.
+	 */
+	public static function modify_wp_kses_allowed_html( $allowed_tags, $context ) {
+		// 必要な属性やタグを追加
+		if ( 'post' === $context ) {
+			$allowed_tags['div']['data-nosnippet'] = true;
+		}
+		return $allowed_tags;
+	}
+
+	/**
 	 * HTML Allowed
 	 */
 	public static function kses_allowed() {
@@ -25,95 +42,79 @@ class VEU_Promotion_Alert {
 			'div'    => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
+				'style' => array(), // style属性の安全性を確保するためには`style`の値もチェックすることが重要
 			),
 			'h1'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'h2'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'h3'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'h4'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'h5'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'h6'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'p'      => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'ul'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'ol'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 			),
 			'li'     => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
-			),
-			'i'      => array(
-				'id'          => array(),
-				'class'       => array(),
-				'style'       => array(),
-				'aria-hidden' => array()
 			),
 			'a'      => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
 				'href'  => array(),
+				'target' => array('_blank'),
+				'rel'   => array('noopener', 'noreferrer'),
 			),
 			'span'   => array(
 				'id'    => array(),
 				'class' => array(),
-				'style' => array(),
+			),
+			'i'   => array(
+				'id'    => array(),
+				'class' => array(),
 			),
 			'button' => array(
 				'id'    => array(),
-				'type'  => array(),
 				'class' => array(),
-				'style' => array(),
-				'href'  => array(),
+				'type'  => array(),
 			),
-            'img'    => array(
-                'id'    => array(),
-                'class' => array(),
-                'style' => array(),
-                'src'   => array(),
-                'alt'   => array(),                
-            ),
-			'style'  => array(),
-            '!'    => array(),
+			'img'    => array(
+				'id'    => array(),
+				'class' => array(),
+				'src'   => array(),
+				'alt'   => array(),
+			),
+			'style'  => array(), // <style> タグ自体を許可しないことで、不正なスクリプトを防ぐ
 		);
 	}
-
-    	/**
+ 
+	/**
 	 * コンテンツにかけるフィルター
 	 */
 	public static function content_filter() {
@@ -128,140 +129,150 @@ class VEU_Promotion_Alert {
 		add_filter( 'veu_promotion_alert_content', 'wp_replace_insecure_home_url' );
 	}
 
-    /**
-     * Get Post Types
-     */
-    public static function get_post_types() {
+	/**
+	 * Get Post Types
+	 */
+	public static function get_post_types() {
 
-        // 投稿タイプの事前準備
-        $post_types_default = array( 
-            array(
-                'label' => get_post_type_object( 'post' )->label,
-                'name'  => 'post'
-            ),
-            array(
-                'label' =>  get_post_type_object( 'page' )->label,
-                'name'  => 'page',
-            ),
-        );
-        $post_types_extra = array();
-        $extra_post_types   = get_post_types(
-            array(
-                'public'   => true,
-                '_builtin' => false
-            ),
-            'objects'
-        );
-        foreach ( $extra_post_types as $post_type ) {
-            $post_types_extra[] = array(
-                'label' => $post_type->label,
-                'name'  => $post_type->name
-            );
-        }
-        $post_types = array_merge( $post_types_default, $post_types_extra );
-        return $post_types;
-    }
+		// 投稿タイプの事前準備
+		$post_types_default = array( 
+			array(
+				'label' => get_post_type_object( 'post' )->label,
+				'name'  => 'post'
+			),
+			array(
+				'label' =>  get_post_type_object( 'page' )->label,
+				'name'  => 'page',
+			),
+		);
+		$post_types_extra = array();
+		$extra_post_types   = get_post_types(
+			array(
+				'public'   => true,
+				'_builtin' => false
+			),
+			'objects'
+		);
+		foreach ( $extra_post_types as $post_type ) {
+			$post_types_extra[] = array(
+				'label' => $post_type->label,
+				'name'  => $post_type->name
+			);
+		}
+		$post_types = array_merge( $post_types_default, $post_types_extra );
+		return $post_types;
+	}
 
-    /**
-     * Get Options
-     */
-    public static function get_options() {
+	/**
+	 * Get Options
+	 */
+	public static function get_options() {
 
-        // デフォルト値
-        $default = array(
-            'alert-text'     => '',
-            'alert-content'  => '',
-            'alert-hook'     => '',
-        );
+		// デフォルト値
+		$default = array(
+			'alert-text'     => '',
+			'alert-content'  => '',
+			'alert-hook'     => '',
+		);
 
-        // オプション取得
-        $options = get_option( 'vkExUnit_PA' );      
-        $options = wp_parse_args( $options, $default );
+		// オプション取得
+		$options = get_option( 'vkExUnit_PA' );      
+		$options = wp_parse_args( $options, $default );
 
-        // 投稿タイプ毎に初期化
-        $post_types = self::get_post_types();
-        foreach ( $post_types as $post_type ) {
-            if ( empty( $options['alert-display'][ $post_type['name'] ] ) ) {
-                $options['alert-display'][ $post_type['name'] ] = 'hide';
-            }
-        }
+		// 投稿タイプ毎に初期化
+		$post_types = self::get_post_types();
+		foreach ( $post_types as $post_type ) {
+			if ( empty( $options['alert-display'][ $post_type['name'] ] ) ) {
+				$options['alert-display'][ $post_type['name'] ] = 'hide';
+			}
+		}
 
-        return $options;
-    }
+		return $options;
+	}
 
 
-    /**
-     * Add Setting Page
-     */
-    public static function option_init() {
-        vkExUnit_register_setting(
+	/**
+	 * Add Setting Page
+	 */
+	public static function option_init() {
+		vkExUnit_register_setting(
 			__( 'Promotion Alert', 'vk-all-in-one-expansion-unit' ),           // tab label.
 			'vkExUnit_PA',                         // name attr
 			array( __CLASS__, 'sanitize_setting' ),      // sanitaise function name
 			array( __CLASS__, 'render_setting' )     // setting_page function name
 		);
-    }
+	}
 
-    /**
-     * Sanitize Space 
-     */
-    public static function sanitize_space( $input ) {
-        if ( preg_match( '/^(\s)+$/u', $input ) ) {
-            return '';
-        }
-        return $input;
-    }
+	/**
+	 * Sanitize Space 
+	 */
+	public static function sanitize_space( $input ) {
+		if ( preg_match( '/^(\s)+$/u', $input ) ) {
+			return '';
+		}
+		return $input;
+	}
 
-    /**
-     * Sanitize Setting
-     */
-    public static function sanitize_setting( $input ) {
+	/**
+	 * Sanitize Setting
+	 */
+	public static function sanitize_setting( $input ) {
 
-        // 投稿タイプを取得
-        $post_types = self::get_post_types();
+		// 許可されたHTMLタグのリストを取得
+		$allowed_html = self::kses_allowed();
+		
+		// サニタイズ処理
+		$options = array();
+		$options['alert-text'] = ! empty( $input['alert-text'] ) ? self::sanitize_space( esc_html( $input['alert-text'] ) ) : '';
+		
+		// alert-contentを許可リストに基づいてサニタイズ
+		if ( ! empty( $input['alert-content'] ) ) {
+			// サニタイズ前のデバッグ出力
+			error_log( 'Before wp_kses: ' . print_r( stripslashes( $input['alert-content'] ), true ) );
+			$options['alert-content'] = wp_kses( stripslashes( $input['alert-content'] ), $allowed_html );
+			// サニタイズ後のデバッグ出力
+			error_log( 'After wp_kses: ' . print_r( $options['alert-content'], true ) );
+		} else {
+			$options['alert-content'] = '';
+		}
 
-        // 許可されたHTMLタグ
-        $allowed_html = self::kses_allowed();
+		// 投稿タイプごとの設定をサニタイズ
+		$post_types = self::get_post_types();
+		foreach ( $post_types as $post_type ) {
+			$options['alert-display'][ $post_type['name'] ] = ! empty( $input['alert-display'][ $post_type['name'] ] ) ? 'display' : 'hide';
+		}
 
-        // サニタイズ
-        $options = array();
-        $options['alert-text']    = ! empty( $input['alert-text'] ) ?  self::sanitize_space( esc_html( $input['alert-text'] ) ) : '';
-        $options['alert-content'] = ! empty( $input['alert-content'] ) ? self::sanitize_space( stripslashes( htmlspecialchars( $input['alert-content'] ) ) ) : '';
+		$options['alert-hook'] = ! empty( $input['alert-hook'] ) ? self::sanitize_space( esc_html( $input['alert-hook'] ) ) : '';
+		return $options;
+	}
 
-        foreach ( $post_types as $post_type ) {
-            $options['alert-display'][ $post_type['name'] ] = ! empty( $input['alert-display'][ $post_type['name'] ] ) ? 'display' : 'hide';
-        }
-        $options['alert-hook'] = ! empty( $input['alert-hook'] ) ? self::sanitize_space( esc_html( $input['alert-hook'] ) ) : '';
-        return $options;
-    }
+	/**
+	 * Render Setting Page
+	 */
+	public static function render_setting() {
 
-    /**
-     * Render Setting Page
-     */
-    public static function render_setting() {
+		// 投稿タイプを取得
+		$post_types = self::get_post_types();
 
-        // 投稿タイプを取得
-        $post_types = self::get_post_types();
+		// 許可されたHTMLタグ
+		$allowed_html = self::kses_allowed();
 
-        // 許可されたHTMLタグ
-        $allowed_html = self::kses_allowed();
-
-        // オプションを取得
-        $options = self::get_options();
-        ?>
-        <h3><?php _e( 'Promotion Alert', 'vk-all-in-one-expansion-unit' ); ?></h3>
-        <div id="vkExUnit_PA" class="sectionBox">
+		// オプションを取得
+		$options = self::get_options();
+		?>
+		<h3><?php _e( 'Promotion Alert', 'vk-all-in-one-expansion-unit' ); ?></h3>
+		<div id="vkExUnit_PA" class="sectionBox">
 			<P>
 			<?php _e( 'If the article contains advertisements, it\'s necessary to provide a clear notation for general consumers to recognize.', 'vk-all-in-one-expansion-unit' ); ?>
 			<br>
 			<?php _e( 'By inputting here, you can automatically insert it at the beginning of the article.', 'vk-all-in-one-expansion-unit' ); ?>
 			</p>
-            <table class="form-table">
-                <tr>
-                    <th><?php _e( 'Alert Text', 'vk-all-in-one-expansion-unit' ); ?></th>
-                    <td>
+			<table class="form-table">
+				<tr>
+					<th><?php _e( 'Alert Text', 'vk-all-in-one-expansion-unit' ); ?></th>
+					<td>
 						<p>
-                        <input type="text" name="vkExUnit_PA[alert-text]" value="<?php echo esc_attr( $options['alert-text'] ); ?>" class="large-text">
+						<input type="text" name="vkExUnit_PA[alert-text]" value="<?php echo esc_attr( $options['alert-text'] ); ?>" class="large-text">
 						</p>
 						<p>Ex)</p>
 						<ul>
@@ -269,69 +280,69 @@ class VEU_Promotion_Alert {
 						<li><?php _e( 'This article contains promotions.', 'vk-all-in-one-expansion-unit' ); ?></li>
 						<li><?php _e( 'This article is posted with products provided by ***.', 'vk-all-in-one-expansion-unit' ); ?></li>
 						</ul>
-                    </td>
-                </tr>
-                <tr>
-                    <th><?php _e( 'Custom Alert Content', 'vk-all-in-one-expansion-unit' ); ?></th>
-                    <td>
-                        <textarea name="vkExUnit_PA[alert-content]" style="width:100%;" rows="10"><?php echo $options['alert-content']; ?></textarea>
-                        <ul>
-                            <li><?php _e( 'If there is any input in "Custom Alert Content", "Alert Text" will not be displayed and will be overwritten by the content entered in "Custom Alert Content".', 'vk-all-in-one-expansion-unit' ); ?></li>
-                            <li><?php _e( 'You can insert HTML tags here. This is designed to be used by pasting content created in the Block Editor.', 'vk-all-in-one-expansion-unit' ); ?></li>
-                        </ul>
-                                
-                    </td>
-                </tr>
-                <tr>
-                    <th><?php _e( 'Display Post Types', 'vk-all-in-one-expansion-unit' ); ?></th>
-                    <td>
-                        <ul class="no-style">
-                        <?php foreach ( $post_types as $post_type ) : ?>
-                            <li>
-                                <label>
-                                    <input type="checkbox" name="vkExUnit_PA[alert-display][<?php echo esc_attr( $post_type['name'] ); ?>]" <?php checked( $options['alert-display'][ $post_type['name'] ], 'display' ); ?>>
-                                    <?php echo esc_html( $post_type['label'] ); ?>
-                                </label>
-                            </li>
-                        <?php endforeach; ?>
-                        </ul>
-                        <p><?php _e( 'Settings for individual articles take precedence over settings here.', 'vk-all-in-one-expansion-unit' ); ?></p>
-                    </td>
-                </tr>
-                </table>
-                <hr>
-                <table class="form-table">
-                <tr>
-                    <th><?php _e( 'Alert Hook ( Optional )', 'vk-all-in-one-expansion-unit' ); ?></th>
-                    <td>
-                        <p><?php _e( 'By default, it is output at the top of the content.', 'vk-all-in-one-expansion-unit' ); ?><br><?php _e( 'If you want to change the location of any action hook, enter the action hook name.', 'vk-all-in-one-expansion-unit' ); ?><br><?php _e( 'Ex) lightning_entry_body_prepend', 'vk-all-in-one-expansion-unit' ); ?></p>
-                        <input type="text" name="vkExUnit_PA[alert-hook]" value="<?php echo esc_attr( $options['alert-hook'] ); ?>" class="large-text">
-                    </td>                    
-                </tr>
-            </table>
-            <?php submit_button(); ?>
-        </div>
-        <?php
-    }
+					</td>
+				</tr>
+				<tr>
+					<th><?php _e( 'Custom Alert Content', 'vk-all-in-one-expansion-unit' ); ?></th>
+					<td>
+						<textarea name="vkExUnit_PA[alert-content]" style="width:100%;" rows="10"><?php echo $options['alert-content']; ?></textarea>
+						<ul>
+							<li><?php _e( 'If there is any input in "Custom Alert Content", "Alert Text" will not be displayed and will be overwritten by the content entered in "Custom Alert Content".', 'vk-all-in-one-expansion-unit' ); ?></li>
+							<li><?php _e( 'You can insert HTML tags here. This is designed to be used by pasting content created in the Block Editor.', 'vk-all-in-one-expansion-unit' ); ?></li>
+						</ul>
+								
+					</td>
+				</tr>
+				<tr>
+					<th><?php _e( 'Display Post Types', 'vk-all-in-one-expansion-unit' ); ?></th>
+					<td>
+						<ul class="no-style">
+						<?php foreach ( $post_types as $post_type ) : ?>
+							<li>
+								<label>
+									<input type="checkbox" name="vkExUnit_PA[alert-display][<?php echo esc_attr( $post_type['name'] ); ?>]" <?php checked( $options['alert-display'][ $post_type['name'] ], 'display' ); ?>>
+									<?php echo esc_html( $post_type['label'] ); ?>
+								</label>
+							</li>
+						<?php endforeach; ?>
+						</ul>
+						<p><?php _e( 'Settings for individual articles take precedence over settings here.', 'vk-all-in-one-expansion-unit' ); ?></p>
+					</td>
+				</tr>
+				</table>
+				<hr>
+				<table class="form-table">
+				<tr>
+					<th><?php _e( 'Alert Hook ( Optional )', 'vk-all-in-one-expansion-unit' ); ?></th>
+					<td>
+						<p><?php _e( 'By default, it is output at the top of the content.', 'vk-all-in-one-expansion-unit' ); ?><br><?php _e( 'If you want to change the location of any action hook, enter the action hook name.', 'vk-all-in-one-expansion-unit' ); ?><br><?php _e( 'Ex) lightning_entry_body_prepend', 'vk-all-in-one-expansion-unit' ); ?></p>
+						<input type="text" name="vkExUnit_PA[alert-hook]" value="<?php echo esc_attr( $options['alert-hook'] ); ?>" class="large-text">
+					</td>                    
+				</tr>
+			</table>
+			<?php submit_button(); ?>
+		</div>
+		<?php
+	}
 
-    /**
-     * Save Meta Box
-     */
-    public static function save_meta_box( $post_id ) {
+	/**
+	 * Save Meta Box
+	 */
+	public static function save_meta_box( $post_id ) {
 
-        // Check if our nonce is set.
-        if ( ! isset( $_POST['veu_promotion_alert_nonce'] ) ) {
+		// Check if our nonce is set.
+		if ( ! isset( $_POST['veu_promotion_alert_nonce'] ) ) {
 			return $post_id;
 		}
 
-        $nonce = $_POST['veu_promotion_alert_nonce'];
+		$nonce = $_POST['veu_promotion_alert_nonce'];
 
-        // Verify that the nonce is valid.
+		// Verify that the nonce is valid.
 		if ( ! wp_verify_nonce( $nonce, 'veu_promotion_alert' ) ) {
 			return $post_id;
 		}
 
-        /*
+		/*
 		 * If this is an autosave, our form has not been submitted,
 		 * so we don't want to do anything.
 		 */
@@ -339,7 +350,7 @@ class VEU_Promotion_Alert {
 			return $post_id;
 		}
 
-        // Check the user's permissions.
+		// Check the user's permissions.
 		if ( 'page' == $_POST['post_type'] ) {
 			if ( ! current_user_can( 'edit_page', $post_id ) ) {
 				return $post_id;
@@ -350,155 +361,157 @@ class VEU_Promotion_Alert {
 			}
 		}
 
-        /* OK, it's safe for us to save the data now. */
+		/* OK, it's safe for us to save the data now. */
 
 		// Sanitize the user input.
 		$mydata = sanitize_text_field( $_POST['veu_display_promotion_alert'] );
 
 		// Update the meta field.
 		update_post_meta( $post_id, 'veu_display_promotion_alert', $mydata );
-    }
+	}
 
-    /**
-     * Display Condition
-     */
-    public static function get_display_condition( $post_id ) {
+	/**
+	 * Display Condition
+	 */
+	public static function get_display_condition( $post_id ) {
 
-        // 通常は false
-        $return = false;
+		// 通常は false
+		$return = false;
 
-        // カスタムフィールドを取得
-        $meta = get_post_meta( $post_id, 'veu_display_promotion_alert', true );
-        $meta = ! empty( $meta ) ? $meta : 'common';
+		// カスタムフィールドを取得
+		$meta = get_post_meta( $post_id, 'veu_display_promotion_alert', true );
+		$meta = ! empty( $meta ) ? $meta : 'common';
 
-        // オプションを取得
-        $options = self::get_options();
+		// オプションを取得
+		$options = self::get_options();
 
-          // 投稿タイプを取得
-        $post_type = get_post_type( $post_id );
+		  // 投稿タイプを取得
+		$post_type = get_post_type( $post_id );
 
-        // 表示条件を判定
-        if ( 'display' === $meta ) {
-            // カスタムフィールドが display の場合は true
-            $return = true;
-        } elseif ( 'common' === $meta && ! empty( $options['alert-display'][ $post_type ] ) && 'display' === $options['alert-display'][ $post_type ] ) {
-            // カスタムフィールドが common でオプションが display の場合は true
-            $return = true;
-        }
+		// 表示条件を判定
+		if ( 'display' === $meta ) {
+			// カスタムフィールドが display の場合は true
+			$return = true;
+		} elseif ( 'common' === $meta && ! empty( $options['alert-display'][ $post_type ] ) && 'display' === $options['alert-display'][ $post_type ] ) {
+			// カスタムフィールドが common でオプションが display の場合は true
+			$return = true;
+		}
 
-        return $return;        
-    }
+		return $return;        
+	}
 
-    /**
-     * Alert Content
-     */
-    public static function get_alert_content() {
+	/**
+	 * Alert Content
+	 */
+	public static function get_alert_content() {
+		// アラートを初期化
+		$alert = '';
+		$alert_content = '';
+	
+		// 表示条件を判定
+		$display = self::get_display_condition( get_the_ID() );
+	
+		// 表示条件が true の場合はアラートを表示
+		if ( ! empty( $display ) ) {
+	
+			// オプションを取得
+			$options = self::get_options();
+	
+			// 許可されたHTMLタグ
+			$allowed_html = self::kses_allowed();
+	
+			// アラートの中身を作成
+			if ( ! empty( $options['alert-content'] ) ) {
+				$alert_content  = '<div class="veu_promotion-alert__content--custom">';
+				$alert_content .= wp_kses( $options['alert-content'], $allowed_html );
+				$alert_content .= '</div>';
+			} elseif ( ! empty( $options['alert-text'] ) ) {
+				$alert_content  = '<div class="veu_promotion-alert__content--text">';
+				$alert_content .= '<span class="veu_promotion-alert__icon"><i class="fa-solid fa-circle-info"></i></span>';
+				$alert_content .= '<span class="veu_promotion-alert__text">' . esc_html( $options['alert-text'] ) . '</span>';
+				$alert_content .= '</div>';
+			}
+	
+			if ( ! empty( $alert_content ) ) {
+				// wp_ksesを通した後にdata-nosnippetを追加
+				$alert = wp_kses( '<div class="veu_promotion-alert">' . $alert_content . '</div>', $allowed_html );
+				$alert = str_replace('<div class="veu_promotion-alert">', '<div class="veu_promotion-alert" data-nosnippet>', $alert);
+			}
+		}
+	
+		// 許可されたHTMLタグで再度サニタイズ
+		return apply_filters( 'veu_promotion_alert_content', $alert );
+	}	 
 
-        // アラートを初期化
-        $alert = '';
-        $alert_content = '';
+	/**
+	 * Display Alert Content Filter Hook
+	 */
+	public static function display_alert_filter( $content ) {
 
-        // 表示条件を判定
-        $display = self::get_display_condition( get_the_ID() );
+		// アラートを取得
+		$alert = self::get_alert_content();
 
-        // 表示条件が true の場合はアラートを表示
-        if ( ! empty( $display ) ) {
+		// 文頭にアラートを追加
+		$content = $alert . $content;
+	   
+		return $content;
+	}
 
-            // オプションを取得
-            $options = self::get_options();
+	/**
+	 * Display Alert Content Action Hook
+	 */
+	public static function display_alert_action() {
 
-            // アラートの中身を作成
-            if ( ! empty( $options['alert-content'] ) ) {
-                $alert_content  = '<div class="veu_promotion-alert__content--custom">';
-                $alert_content .= $options['alert-content'];
-                $alert_content .= '</div>';
-            } elseif ( ! empty( $options['alert-text'] ) ) {
-                $alert_content  = '<div class="veu_promotion-alert__content--text">';
-                $alert_content .= '<span class="veu_promotion-alert__icon"><i class="fa-solid fa-circle-info"></i></span>';
-                $alert_content .= '<span class="veu_promotion-alert__text">' . $options['alert-text'] . '</span>';
-                $alert_content .= '</div>';
-            }
+		// アラートを取得
+		$alert = self::get_alert_content();
+		// 許可されたHTMLタグ
+		$allowed_html = self::kses_allowed();
 
-            if ( ! empty( $alert_content ) ) {
-                $alert = '<div class="veu_promotion-alert" data-nosnippet>' . $alert_content . '</div>';
-            }
-        }
+		echo wp_kses( $alert, $allowed_html );       
+	}
 
-        return apply_filters( 'veu_promotion_alert_content', htmlspecialchars_decode( $alert ) );
-    }
+	/**
+	 * Display Alert
+	 */
+	public static function display_alert() {
 
-    /**
-     * Display Alert Content Filter Hook
-     */
-    public static function display_alert_filter( $content ) {
+		// オプションを取得
+		$options = self::get_options();
+		if ( is_singular() ) {
+			if ( ! empty( $options['alert-hook'] ) ) {
+				add_action( $options['alert-hook'], array( __CLASS__, 'display_alert_action' ) );
+			} else {
+				add_filter( 'the_content', array( __CLASS__, 'display_alert_filter' ) );           
+			}
+		}
+	}
 
-        // アラートを取得
-        $alert = self::get_alert_content();
+	/**
+	 * Inline Style
+	 */
+	public static function inline_style() {
 
-        // 文頭にアラートを追加
-        $content = $alert . $content;
-       
-        return $content;       
-    }
-
-    /**
-     * Display Alert Content Action Hook
-     */
-    public static function display_alert_action() {
-
-        // アラートを取得
-        $alert = self::get_alert_content();
-        // 許可されたHTMLタグ
-        $allowed_html = self::kses_allowed();
-
-        echo wp_kses( $alert, $allowed_html );       
-    }
-
-    /**
-     * Display Alert
-     */
-    public static function display_alert() {
-
-        // オプションを取得
-        $options = self::get_options();
-        if ( is_singular() ) {
-            if ( ! empty( $options['alert-hook'] ) ) {
-                add_action( $options['alert-hook'], array( __CLASS__, 'display_alert_action' ) );
-            } else {
-                add_filter( 'the_content', array( __CLASS__, 'display_alert_filter' ) );           
-            }
-        }
-    }
-
-    /**
-     * Inline Style
-     */
-    public static function inline_style() {
-
-        $dynamic_css = '
-        .veu_promotion-alert__content--text {
-            border: 1px solid rgba(0,0,0,0.125);
-            padding: 0.5em 1em;
-            border-radius: var(--vk-size-radius);
-            margin-bottom: var(--vk-margin-block-bottom);
-            font-size: 0.875rem;
-        }
-        /* Alert Content部分に段落タグを入れた場合に最後の段落の余白を0にする */
-        .veu_promotion-alert__content--text p:last-of-type{
-            margin-bottom:0;
-            margin-top: 0;
-        }
-        ';
-    
-        // delete before after space
-        $dynamic_css = trim( $dynamic_css );
-        // convert tab and br to space
-        $dynamic_css = preg_replace( '/[\n\r\t]/', '', $dynamic_css );
-        // Change multiple spaces to single space
-        $dynamic_css = preg_replace( '/\s(?=\s)/', '', $dynamic_css );
-        wp_add_inline_style( 'vkExUnit_common_style', $dynamic_css );
-    }
+		$dynamic_css = '
+		.veu_promotion-alert__content--text {
+			border: 1px solid rgba(0,0,0,0.125);
+			padding: 0.5em 1em;
+			border-radius: var(--vk-size-radius);
+			margin-bottom: var(--vk-margin-block-bottom);
+			font-size: 0.875rem;
+		}
+		/* Alert Content部分に段落タグを入れた場合に最後の段落の余白を0にする */
+		.veu_promotion-alert__content--text p:last-of-type{
+			margin-bottom:0;
+			margin-top: 0;
+		}
+		';
+	
+		// delete before after space
+		$dynamic_css = trim( $dynamic_css );
+		// convert tab and br to space
+		$dynamic_css = preg_replace( '/[\n\r\t]/', '', $dynamic_css );
+		// Change multiple spaces to single space
+		$dynamic_css = preg_replace( '/\s(?=\s)/', '', $dynamic_css );
+		wp_add_inline_style( 'vkExUnit_common_style', $dynamic_css );
+	}
 }
-
-
-


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

広告アラートで意図したwp_ksesフィルタリングが適用されていなかったため、iframe等の不要なタグが通過する問題が発生していました。

## どういう変更をしたか？

- wp_ksesフィルタリングを適切に適用し、許可リストに含まれないタグが通過しないよう修正
- data-nosnippet属性がwp_ksesフィルタリングで失われないよう、divタグに属性を追加

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [ ] readme.txt に変更内容は書いたか？
- [ ] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [ ] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [ ] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- 「ExUnit」→「広告アラート」→「カスタムアラートコンテント」に<iframe src="http://XXX.XX.XX.XXX:XXXX"></iframe>などのアラート機能に不要なHTMLタグが入った状態で保存した後、「カスタムアラートコンテント」から <iframe src="http://XXX.XX.XX.XX:XXXX"></iframe> が消えていることを確認しました。
- ソース上では<div class="veu_promotion-alert" data-nosnippet><div class="veu_promotion-alert__content--custom">&lt;iframe src=&quot;XXX.XX.XX.XXX:XXXX&quot;&gt;&lt;/iframe&gt;</div></div> のようになっていることを確認しました。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
