### PR TITLE
[ 広告アラート ] get_display_condition() ->  is_display() に変更

### DIFF
--- a/inc/promotion-alert/package/class-veu-promotion-alert.php
+++ b/inc/promotion-alert/package/class-veu-promotion-alert.php
@@ -385,7 +385,7 @@ class VEU_Promotion_Alert {
 	 * @param int $post_id : 投稿id
 	 * @return bool
 	 */
-	public static function get_display_condition( $post_id ) {
+	public static function is_display( $post_id ) {
 
 		// 通常は false
 		$return = false;
@@ -424,7 +424,7 @@ class VEU_Promotion_Alert {
 		$alert_content = '';
 
 		// 表示条件を判定
-		$display = self::get_display_condition( get_the_ID() );
+		$display = self::is_display( get_the_ID() );
 
 		// 表示条件が true の場合はアラートを表示
 		if ( ! empty( $display ) ) {

--- a/tests/test-promotion-alert.php
+++ b/tests/test-promotion-alert.php
@@ -157,7 +157,7 @@ class PromotionAlertTest extends WP_UnitTestCase {
 		return $data;
 	}
 
-	public function test_get_display_condition() {
+	public function test_is_display() {
 
 		$data = self::setup_data();
 
@@ -361,7 +361,7 @@ class PromotionAlertTest extends WP_UnitTestCase {
 			// Set site name
 			update_option( 'vkExUnit_PA', $test_value['options'] );
 
-			$return  = VEU_Promotion_Alert::get_display_condition( $test_value['post_id'] );
+			$return  = VEU_Promotion_Alert::is_display( $test_value['post_id'] );
 			$correct = $test_value['correct'];
 
 			$this->assertEquals( $correct, $return );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

広告アラートを表示するかどうかのメソッド名が get_display_condition になっているが、
返り値が bool なので is_display の方が WordPress の作法的にわかりやすい気がする