### PR TITLE
[ 広告アラート ][ リファクタリング ] 	get_alert_content() は中身だけ返すようにして表示・非表示は外で使うように移動

### DIFF
--- a/inc/promotion-alert/package/class-veu-promotion-alert.php
+++ b/inc/promotion-alert/package/class-veu-promotion-alert.php
@@ -423,12 +423,6 @@ class VEU_Promotion_Alert {
 		$alert         = '';
 		$alert_content = '';
 
-		// 表示条件を判定
-		$display = self::is_display( get_the_ID() );
-
-		// 表示条件が true の場合はアラートを表示
-		if ( ! empty( $display ) ) {
-
 			// オプションを取得
 			$options = self::get_options();
 
@@ -452,7 +446,6 @@ class VEU_Promotion_Alert {
 				$alert = wp_kses( '<div class="veu_promotion-alert">' . $alert_content . '</div>', $allowed_html );
 				$alert = str_replace( '<div class="veu_promotion-alert">', '<div class="veu_promotion-alert" data-nosnippet>', $alert );
 			}
-		}
 
 		// 許可されたHTMLタグで再度サニタイズ
 		return apply_filters( 'veu_promotion_alert_content', $alert );
@@ -465,11 +458,12 @@ class VEU_Promotion_Alert {
 	 */
 	public static function display_alert_filter( $content ) {
 
-		// アラートを取得
-		$alert = self::get_alert_content();
-
-		// 文頭にアラートを追加
-		$content = $alert . $content;
+		if ( self::is_display( get_the_ID() ) ){
+			// アラートを取得
+			$alert = self::get_alert_content();
+			// 文頭にアラートを追加
+			$content = $alert . $content;
+		}
 
 		return $content;
 	}
@@ -479,12 +473,15 @@ class VEU_Promotion_Alert {
 	 */
 	public static function display_alert_action() {
 
-		// アラートを取得
-		$alert = self::get_alert_content();
-		// 許可されたHTMLタグ
-		$allowed_html = self::kses_allowed();
-
-		echo wp_kses( $alert, $allowed_html );
+		if ( self::is_display( get_the_ID() ) ){
+			// アラートを取得
+			$alert = self::get_alert_content();
+			// 許可されたHTMLタグ
+			$allowed_html = self::kses_allowed();
+			echo wp_kses( $alert, $allowed_html );
+		} else {
+			return;
+		}
 	}
 
 	/**

--- a/tests/test-promotion-alert.php
+++ b/tests/test-promotion-alert.php
@@ -422,50 +422,6 @@ class PromotionAlertTest extends WP_UnitTestCase {
 				),
 				'correct' => '<div class="veu_promotion-alert" data-nosnippet><div class="veu_promotion-alert__content--custom">bbbb</div></div>',
 			),
-			array(
-				'name'   => 'No text and content / display:hide',
-				'options' => array(
-					'alert-text'    => '',
-					'alert-content' => '',
-					'alert-display' => array(
-						'post' => 'hide',
-					),
-				),
-				'correct' => '',
-			),
-			array(
-				'name'   => 'No content / display:hide',
-				'options' => array(
-					'alert-text'    => 'aaaa',
-					'alert-content' => '',
-					'alert-display' => array(
-						'post' => 'hide',
-					),
-				),
-				'correct' => '',
-			),
-			array(
-				'name'   => 'No text / display:hide',
-				'options' => array(
-					'alert-text'    => '',
-					'alert-content' => 'bbbb',
-					'alert-display' => array(
-						'post' => 'hide',
-					),
-				),
-				'correct' => '',
-			),
-			array(
-				'name'   => 'Normal text and content / display:hide',
-				'options' => array(
-					'alert-text'    => 'aaaa',
-					'alert-content' => 'bbbb',
-					'alert-display' => array(
-						'post' => 'hide',
-					),
-				),
-				'correct' => '',
-			),
 			// XSS属性の削除をテスト
 			array(
 				'name'   => 'XSS content',


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

get_alert_content() で純粋に中身だけ取得してテストしたかったが、中に is_display() が入っていてそこで非表示にされてしまって都合が悪かった

## どういう変更をしたか？

 is_display()  の処理を get_alert_content()  の外に移動