### PR TITLE
[ Bug Fix ] Fixed a PHP error that occurs when the activation settings have never been saved.

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -21,9 +21,15 @@ VkAdmin::admin_scripts( $admin_pages );
 
 function veu_common_options_init() {
 	register_setting(
-		'vkExUnit_common_options_fields',   //  Immediately following form tag of edit page.
+		'vkExUnit_common_options_fields',   // Immediately following form tag of edit page.
 		'vkExUnit_common_options',          // name attr
-		'veu_common_options_validate'
+		array(
+			'type'              => 'array',
+			'description'       => 'vkExUnit common options',
+			'sanitize_callback' => 'veu_common_options_validate',
+			'show_in_rest'      => false,
+			'default'           => veu_get_common_options_default(),
+		)
 	);
 }
 add_action( 'admin_init', 'veu_common_options_init' );

--- a/initialize.php
+++ b/initialize.php
@@ -39,17 +39,6 @@ function veu_load_packages(){
 	require_once VEU_DIRECTORY_PATH . '/inc/common-block.php';
 	require VEU_DIRECTORY_PATH . '/inc/footer-copyright-change.php';
 	veu_package_include(); // package_manager.php
-
-	// vkExUnit_common_options initialize
-	register_setting(
-		'options',
-		'vkExUnit_common_options',
-		array(
-			'type'              => 'array',
-			'sanitize_callback' => null,
-			'default'           => veu_get_common_options_default(),
-		)
-	);
 }
 add_action( 'after_setup_theme', 'veu_load_packages' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ] Fixed a PHP error that occurs when the activation settings have never been saved.
+
 = 9.100.3 =
 [ Bug Fix ][ CSS Customize ] Fixed an issue where CSS customizations were not applied on single page.
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

まっさらな WordPress で有効化すると

```
Warning: Undefined array key "default" in /var/www/html/wp-includes/option.php on line 3177
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/option.php:3177) in /var/www/html/wp-admin/customize.php on line 130
```

が発生する

## どういう変更をしたか？

* initialize.php に記載してあった option値 vkExUnit_common_options の register_setting() を削除
  そもそも vkExUnit_common_options は admin/admin.php で register_setting() してる

## 確認方法

* `delete_option( 'vkExUnit_common_options' );` などで vkExUnit_common_options を一旦削除
* master ブランチ で ExUnit > 有効化設定にアクセス -> Warning が発生
* このブランチに切り替える -> Warning が消える
