### PR TITLE
[ Bug fix ][ Categories/Custom taxonomies list widget ] Display order translation

### DIFF
--- a/inc/other-widget/widget-taxonomies.php
+++ b/inc/other-widget/widget-taxonomies.php
@@ -147,7 +147,7 @@ class WP_Widget_VK_taxonomy_list extends WP_Widget {
 
 		<!-- [ Form sort ] -->
 		<div>
-			<label for="<?php echo $this->get_field_id( 'form_sort' ); ?>">Display order:</label>
+			<label for="<?php echo $this->get_field_id( 'form_sort' ); ?>"><?php _e( 'Display order', 'vk-all-in-one-expansion-unit' ); ?>:</label>
 			<select name="<?php echo $this->get_field_name( 'form_sort' ); ?>" class="admin-custom-input">
 				<option value="asc" <?php selected( $instance['form_sort'], 'asc' ); ?>><?php _e('Ascending Order ( A → Z )','vk-all-in-one-expansion-unit');?></option>
 				<option value="desc" <?php selected( $instance['form_sort'], 'desc' ); ?>><?php _e('Descending Order ( Z → A )','vk-all-in-one-expansion-unit');?></option>

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Categories/Custom taxonomies list widget ] Display order translation
+
 = 9.100.6 =
 [ Bug Fix ][ Loop before widget area ] Fixed an issue where widgets placed in the "Loop Before Widget Area" were not displaying correctly.
 


### PR DESCRIPTION
翻訳関数があたってなくて翻訳できないので修正