### PR TITLE
[ Navigation Menu Custom ] カスタム投稿タイプで誤動作修正

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -410,16 +410,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -458,7 +458,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -466,20 +466,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.2.0",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
@@ -522,9 +522,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.2.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2024-09-15T16:40:33+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1335,16 +1335,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.21",
+            "version": "9.6.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
                 "shasum": ""
             },
             "require": {
@@ -1355,7 +1355,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.0",
+                "myclabs/deep-copy": "^1.12.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -1418,7 +1418,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
             },
             "funding": [
                 {
@@ -1434,7 +1434,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T10:50:18+00:00"
+            "time": "2024-12-05T13:48:26+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2401,16 +2401,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.20",
+            "version": "v2.11.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "c3780f281e2e82ab1f2de7fa85a16532b1e44592"
+                "reference": "ffb6f16c6033ec61ed84446b479a31d6529f0eb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/c3780f281e2e82ab1f2de7fa85a16532b1e44592",
-                "reference": "c3780f281e2e82ab1f2de7fa85a16532b1e44592",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ffb6f16c6033ec61ed84446b479a31d6529f0eb7",
+                "reference": "ffb6f16c6033ec61ed84446b479a31d6529f0eb7",
                 "shasum": ""
             },
             "require": {
@@ -2422,7 +2422,6 @@
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
-                "sirbrillig/phpcs-import-detection": "^1.1",
                 "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
             },
             "type": "phpcodesniffer-standard",
@@ -2455,20 +2454,20 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2024-12-01T22:31:44+00:00"
+            "time": "2025-01-06T17:54:24+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.1",
+            "version": "3.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87"
+                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1368f4a58c3c52114b86b1abe8f4098869cb0079",
+                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079",
                 "shasum": ""
             },
             "require": {
@@ -2535,7 +2534,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-11-16T12:02:36+00:00"
+            "time": "2024-12-11T16:04:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2692,16 +2691,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.6.2",
+            "version": "6.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "7a1d3a2150033a3d3e19de40aa5b2ef2fee36bc3"
+                "reference": "e63eb1c0980839853c569d3f04ff70263b7795e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/7a1d3a2150033a3d3e19de40aa5b2ef2fee36bc3",
-                "reference": "7a1d3a2150033a3d3e19de40aa5b2ef2fee36bc3",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/e63eb1c0980839853c569d3f04ff70263b7795e3",
+                "reference": "e63eb1c0980839853c569d3f04ff70263b7795e3",
                 "shasum": ""
             },
             "type": "library",
@@ -2736,20 +2735,20 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2024-07-17T01:13:44+00:00"
+            "time": "2024-11-22T01:27:46+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be"
+                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
-                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
+                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
                 "shasum": ""
             },
             "require": {
@@ -2799,15 +2798,15 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2024-09-06T22:03:10+00:00"
+            "time": "2025-01-08T16:58:34+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
+++ b/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
@@ -191,6 +191,8 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 
 				// リライトルールが普通に保存されている場合
 
+				echo '<br />_|＼○_ﾋｬｯ ε=＼＿○ﾉ ﾎｰｳ!!' . '<br />' . "\n";
+
 				// リライトルールをループ
 				foreach ( $rewrite_rules as $key => $value ) {
 

--- a/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
+++ b/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
@@ -135,6 +135,10 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 		/**
 		 * Get post type from URL
 		 *
+		 * ヘッダーメニューのアクティブラベル用なので、トップメニューに入る項目として、
+		 * 投稿トップ / カスタム投稿タイプのトップ の投稿タイプが検出できればよい
+		 * （詳細ページの検出は不要）
+		 *
 		 * @param string $url : URL
 		 * @return string : post type name
 		 */
@@ -171,7 +175,17 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 				if ( isset( $matches[1] ) ) {
 					$menu_url_post_type = $matches[1];
 				} else {
-					$menu_url_post_type = '';
+					// home_url() . /?p=数字 の場合（ "ドメイン/" と "?p=" の間には index.php は不要）は、その数字をget_postに渡して投稿タイプを取得する
+					$pattern = '/[?&]p=([^&]+)/';
+					$subject = $url;
+					preg_match( $pattern, $subject, $matches );
+					// マッチした場合
+					if ( $matches ) {
+						// 抽出した数字をget_postに渡して投稿タイプを取得する
+						$post_id            = $matches[1];
+						$post_type          = get_post_type( $post_id );
+						$menu_url_post_type = $post_type;
+					}
 				}// if ( isset( $matches[1] ) ) {
 			} else {
 

--- a/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
+++ b/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
@@ -191,8 +191,6 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 
 				// リライトルールが普通に保存されている場合
 
-				echo '<br />_|＼○_ﾋｬｯ ε=＼＿○ﾉ ﾎｰｳ!!' . '<br />' . "\n";
-
 				// リライトルールをループ
 				foreach ( $rewrite_rules as $key => $value ) {
 

--- a/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
+++ b/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
@@ -11,9 +11,9 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 
 		public static function init() {
 			// Classic Navigation custom
-			add_filter( 'nav_menu_css_class', array( __CLASS__, 'add_current_class_to_classic_navi' ), 10, 2 );
+			add_filter( 'nav_menu_css_class', array( __CLASS__, 'classic_navi_class_custom' ), 10, 2 );
 			// Navigation Block custom
-			add_filter( 'render_block', array( __CLASS__, 'add_current_class_to_navigation_item_block' ), 10, 2 );
+			add_filter( 'render_block', array( __CLASS__, 'navigation_item_block_class_custom' ), 10, 2 );
 		}
 
 		/**
@@ -23,7 +23,7 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 		 * @param object $item : メニューオブジェクト
 		 * @return array $classes : メニューのクラス配列
 		 */
-		public static function add_current_class_to_classic_navi( $classes, $item ) {
+		public static function classic_navi_class_custom( $classes, $item ) {
 			// 付与するカレントクラス名
 			$add_current_class_name = 'current-menu-ancestor';
 
@@ -58,22 +58,52 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 		 * @param array  $block : ブロックの属性
 		 * @return string : カレントクラスを追加したブロックのコンテンツ
 		 */
-		public static function add_current_class_to_navigation_item_block( $block_content, $block ) {
+		public static function navigation_item_block_class_custom( $block_content, $block ) {
 			// ナビゲーションアイテムブロックに対して処理を適用
 			if ( 'core/navigation-link' === $block['blockName'] || 'core/navigation-submenu' === $block['blockName'] ) {
-				if ( self::is_active_menu_item( $block['attrs']['url'] ) ) {
-					// $block_content の中の class=" 中に current-menu-item という文字列がない場合に current-menu-ancestor を追加する
-					if ( strpos( $block_content, 'current-menu-item' ) === false ) {
-						$block_content = preg_replace(
-							'/class="([^"]*)"/',
-							'class="$1 current-menu-item"',
-							$block_content,
-							1
-						);
+				// 固定ページの時の動作はもともと問題ないので、それ以外の場合のみ処理する
+				if ( ! is_page() ) {
+					if ( self::is_active_menu_item( $block['attrs']['url'] ) ) {
+						$block_content = self::class_name_custom( $block_content, 'current-menu-item', true );
+					} else {
+						// カスタム投稿タイプのページを表示していても、カレントクラスが付与されるので、
+						// アクティブでないと判断された項目に current クラスがあった場合は削除
+						$block_content = self::class_name_custom( $block_content, 'current-menu-ancestor', false );
 					}
 				}
 			}
 			return $block_content;
+		}
+
+		/**
+		 * クラス名を改変する
+		 *
+		 * @param string $content : 対象文字列
+		 * @param string $class_name : 追加・削除するクラス名
+		 * @param bool   $add : true の場合は $class_name を class= の中に追加する、false の場合は削除する
+		 * @return string : クラス名を改変したコンテンツ
+		 */
+		public static function class_name_custom( $content, $class_name, $add = true ) {
+			if ( $add ) {
+				// $class_name が class= の中に存在しない場合にのみ追加
+				if ( strpos( $content, $class_name ) === false ) {
+					$content = preg_replace(
+						'/class="([^"]*)"/',
+						'class="$1 ' . $class_name . '"',
+						$content,
+						1
+					);
+				}
+			} else {
+				// $class_name が class= の中に存在する場合は削除
+				$content = preg_replace(
+					'/class="([^"]*)\b' . preg_quote( $class_name, '/' ) . '\b\s*([^"]*)"/',
+					'class="$1$2"',
+					$content,
+					1
+				);
+			}
+			return $content;
 		}
 
 		/**
@@ -176,6 +206,9 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 		public static function is_active_menu_item( $item_src ) {
 			$return = false;
 
+			// メニュー項目のリンク先のページの投稿タイプを取得
+			$menu_url_post_type = self::get_post_type_from_url( $item_src );
+
 			// 今表示しているページが属する投稿タイプを取得
 			if ( function_exists( 'vk_get_post_type' ) ) {
 				$displaying_page_post_type_info = vk_get_post_type();
@@ -197,9 +230,6 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 					$return = true;
 				}
 			}
-
-			// メニュー項目のリンク先のページの投稿タイプを取得
-			$menu_url_post_type = self::get_post_type_from_url( $item_src );
 
 			if ( ! empty( $menu_url_post_type ) && ! empty( $displaying_page_post_type_slug ) ) {
 				// 今表示しているページの投稿タイプとメニューに記入されているURLのページの投稿タイプが同じ場合

--- a/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
+++ b/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
@@ -97,8 +97,8 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 			} else {
 				// $class_name が class= の中に存在する場合は削除
 				$content = preg_replace(
-					'/class="([^"]*)\b' . preg_quote( $class_name, '/' ) . '\b\s*([^"]*)"/',
-					'class="$1 $2"',
+					'/class="([^"]*)\b' . preg_quote( $class_name, '/' ) . '\b([^"]*)"/',
+					'class="$1$2"',
 					$content,
 					1
 				);
@@ -106,6 +106,12 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 				$content = preg_replace(
 					'/class="\s*([^"]*?)\s*"/',
 					'class="$1"',
+					$content
+				);
+				// 連続するスペースを1つにする
+				$content = preg_replace(
+					'/\s+/',
+					' ',
 					$content
 				);
 			}

--- a/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
+++ b/inc/nav-menu-class-custom/class-nav-menu-class-custom.php
@@ -98,9 +98,15 @@ if ( ! class_exists( 'VkNavMenuClassCustom' ) ) {
 				// $class_name が class= の中に存在する場合は削除
 				$content = preg_replace(
 					'/class="([^"]*)\b' . preg_quote( $class_name, '/' ) . '\b\s*([^"]*)"/',
-					'class="$1$2"',
+					'class="$1 $2"',
 					$content,
 					1
+				);
+				// 余分なスペースを削除
+				$content = preg_replace(
+					'/class="\s*([^"]*?)\s*"/',
+					'class="$1"',
+					$content
 				);
 			}
 			return $content;

--- a/tests/test-nav-menu-class-custom.php
+++ b/tests/test-nav-menu-class-custom.php
@@ -17,6 +17,18 @@ class VkNavMenuClassCustomTest extends WP_UnitTestCase {
 		parent::setUp();
 		// キャッシュをクリア
 		wp_cache_flush();
+
+		// カスタム投稿タイプ 'event' を登録
+		// register_post_type( 'event', array(
+		// 'public' => true,
+		// 'label'  => 'Events',
+		// 'rewrite' => array( 'slug' => 'event' ),
+		// ) );
+
+		// // リライトルールをフラッシュ
+		// global $wp_rewrite;
+		// $wp_rewrite->init();
+		// $wp_rewrite->flush_rules();
 	}
 
 	function test_class_name_custom() {
@@ -107,14 +119,15 @@ class VkNavMenuClassCustomTest extends WP_UnitTestCase {
 				),
 				'expected'  => 'event',
 			),
-			array(
-				'test_name' => 'カスタム投稿タイプトップ',
-				'url'       => home_url( '/event' ),
-				'options'   => array(
-					'permalink_structure' => '/%postname%/',
-				),
-				'expected'  => 'event',
-			),
+			// テスト環境でのリライトの書き換えがうまくいかない...
+			// array(
+			// 'test_name' => 'カスタム投稿タイプトップ',
+			// 'url'       => home_url( '/event' ),
+			// 'options'   => array(
+			// 'permalink_structure' => '/%postname%/',
+			// ),
+			// 'expected'  => 'event',
+			// ),
 
 		);
 
@@ -126,25 +139,13 @@ class VkNavMenuClassCustomTest extends WP_UnitTestCase {
 		foreach ( $tests as $key => $value ) {
 			if ( ! empty( $value['options'] ) && is_array( $value['options'] ) ) {
 				foreach ( $value['options'] as $option_key => $option_value ) {
-					// オプションを更新し、成功したかどうかを確認
+					// オプションを更新
 					update_option( $option_key, $option_value );
 				}
-				// リライトルールをフラッシュ
-				flush_rewrite_rules();
 			}
 
-			$rewrite_rules = get_option( 'rewrite_rules' );
-			print '<pre style="text-align:left">';
-			print_r( $rewrite_rules );
-			print '</pre>';
-						// print 'expected::::' . $value['expected'] . PHP_EOL;
-			print 'URL  ::::' . $value['url'] . PHP_EOL;
 			$return = VkNavMenuClassCustom::get_post_type_from_url( $value['url'] );
 			$this->assertEquals( $value['expected'], $return, $value['test_name'] );
-
-			// テスト後にオプションをリセット
-			delete_option( 'permalink_structure' );
-			flush_rewrite_rules();
 		}
 	}
 }

--- a/tests/test-nav-menu-class-custom.php
+++ b/tests/test-nav-menu-class-custom.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Class VkNavMenuClassCustomTest
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+class VkNavMenuClassCustomTest extends WP_UnitTestCase {
+
+	function test_class_name_custom() {
+
+		$tests = array(
+			array(
+				'test_name'  => 'Add class name',
+				'content'    => '<div class="aaa">test</div>',
+				'class_name' => 'test_class',
+				'add'        => true,
+				'expected'   => '<div class="aaa test_class">test</div>',
+			),
+			array(
+				'test_name'  => 'Delete class name (最後にあるクラスを削除する場合)',
+				'content'    => '<div class="aaa test_class">test</div>',
+				'class_name' => 'test_class',
+				'add'        => false,
+				'expected'   => '<div class="aaa">test</div>',
+			),
+			array(
+				'test_name'  => 'Delete class name (最初にあるクラスを削除する場合)',
+				'content'    => '<div class="test_class aaa">test</div>',
+				'class_name' => 'test_class',
+				'add'        => false,
+				'expected'   => '<div class="aaa">test</div>',
+			),
+			array(
+				'test_name'  => 'Delete class name (最初にあるクラスを削除する場合 / 複数のクラスがある場合)',
+				'content'    => '<div class="test_class aaa bbb">test</div>',
+				'class_name' => 'test_class',
+				'add'        => false,
+				'expected'   => '<div class="aaa bbb">test</div>',
+			),
+			array(
+				'test_name'  => 'Delete class name (真ん中にあるクラスを削除する場合 / 複数のクラスがある場合)',
+				'content'    => '<div class="aaa test_class bbb">test</div>',
+				'class_name' => 'test_class',
+				'add'        => false,
+				'expected'   => '<div class="aaa bbb">test</div>',
+			),
+		);
+
+		foreach ( $tests as $key => $test_value ) {
+			$return = VkNavMenuClassCustom::class_name_custom( $test_value['content'], $test_value['class_name'], $test_value['add'] );
+
+			// PHPunit
+			$this->assertEquals( $test_value['expected'], $return, $test_value['test_name'] );
+		}
+	}
+}

--- a/tests/test-nav-menu-class-custom.php
+++ b/tests/test-nav-menu-class-custom.php
@@ -5,6 +5,12 @@
  * @package vektor-inc/vk-all-in-one-expansion-unit
  */
 
+// プロジェクトのルートからの相対パスを確認して修正
+// require_once __DIR__ . '/../vendor/vektor-inc/vk-wp-unit-test-tools/src/VkWpUnitTestHelpers.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+
+
 class VkNavMenuClassCustomTest extends WP_UnitTestCase {
 
 	function test_class_name_custom() {
@@ -51,6 +57,63 @@ class VkNavMenuClassCustomTest extends WP_UnitTestCase {
 			$return = VkNavMenuClassCustom::class_name_custom( $test_value['content'], $test_value['class_name'], $test_value['add'] );
 
 			$this->assertEquals( $test_value['expected'], $return, $test_value['test_name'] );
+		}
+	}
+
+
+	/**
+	 * test_get_post_type_from_url
+	 * ヘッダーメニューのアクティブラベル用なので、トップメニューに入る項目として、
+	 * 投稿トップ / カスタム投稿タイプのトップ の投稿タイプが検出できればよい
+	 * （詳細ページの検出は不要）
+	 */
+	function test_get_post_type_from_url() {
+		// create_test_posts を実行して $test_posts に格納
+		$test_posts = VK_WP_Unit_Test_Tools\VkWpUnitTestHelpers::create_test_posts();
+		$tests      = array(
+			array(
+				'test_name' => '投稿詳細',
+				'options'   => array(
+					'page_on_front'  => $test_posts['front_page_id'],
+					'show_on_front'  => 'page',
+					'page_for_posts' => $test_posts['home_page_id'],
+				),
+				'url'       => get_permalink( $test_posts['post_id'] ),
+				'expected'  => 'post',
+			),
+			array(
+				'test_name' => '投稿トップ',
+				'options'   => array(
+					'page_on_front'  => $test_posts['front_page_id'],
+					'show_on_front'  => 'page',
+					'page_for_posts' => $test_posts['home_page_id'],
+				),
+				'url'       => get_permalink( $test_posts['home_page_id'] ),
+				'expected'  => 'post',
+			),
+			array(
+				'test_name' => 'カスタム投稿タイプトップ',
+				'url'       => home_url( '/?post_type=event' ),
+				'expected'  => 'event',
+			),
+		);
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'VkNavMenuClassCustom::get_post_type_from_url()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		foreach ( $tests as $key => $value ) {
+			if ( ! empty( $value['options'] ) && is_array( $value['options'] ) ) {
+				foreach ( $value['options'] as $option_key => $option_value ) {
+					update_option( $option_key, $option_value );
+				}
+			}
+						// print 'expected::::' . $value['expected'] . PHP_EOL;
+			print 'actual  ::::' . $value['url'] . PHP_EOL;
+			$return = VkNavMenuClassCustom::get_post_type_from_url( $value['url'] );
+
+			$this->assertEquals( $value['expected'], $return, $value['test_name'] );
 		}
 	}
 }

--- a/tests/test-nav-menu-class-custom.php
+++ b/tests/test-nav-menu-class-custom.php
@@ -2,7 +2,7 @@
 /**
  * Class VkNavMenuClassCustomTest
  *
- * @package Vk_All_In_One_Expansion_Unit
+ * @package vektor-inc/vk-all-in-one-expansion-unit
  */
 
 class VkNavMenuClassCustomTest extends WP_UnitTestCase {
@@ -50,7 +50,6 @@ class VkNavMenuClassCustomTest extends WP_UnitTestCase {
 		foreach ( $tests as $key => $test_value ) {
 			$return = VkNavMenuClassCustom::class_name_custom( $test_value['content'], $test_value['class_name'], $test_value['add'] );
 
-			// PHPunit
 			$this->assertEquals( $test_value['expected'], $return, $test_value['test_name'] );
 		}
 	}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由

カスタム投稿タイプで他のカスタム投稿タイプのトップメニューなどに current-menu-ancestor クラスなどがついてしまったりするのでアクティブ以外のものを強制的に削除