### PR TITLE
[シェアボタン] ソーシャルボタンのスタイル設定（色や背景なし）をExUnitのメイン設定からでも変更できるようにしました

### DIFF
--- a/inc/sns/block/src/edit.js
+++ b/inc/sns/block/src/edit.js
@@ -1,5 +1,7 @@
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
+import { PanelBody, BaseControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 export default function ShareButtonEdit( props ) {
 	const { attributes } = props;
@@ -11,6 +13,22 @@ export default function ShareButtonEdit( props ) {
 
 	return (
 		<>
+			<InspectorControls>
+				<PanelBody
+					title={ __(
+						'Style Setting',
+						'vk-all-in-one-expansion-unit'
+					) }
+					initialOpen={ true }
+				>
+					<BaseControl>
+						<p>{__(
+							'You can configure the icon style from the admin panel under ExUnit > Main Settings > SNS Setting.',
+							'vk-all-in-one-expansion-unit'
+						) }</p>
+					</BaseControl>
+				</PanelBody>
+			</InspectorControls>
 			<div { ...blockProps }>
 				<ServerSideRender
 					block="vk-blocks/share-button"

--- a/inc/sns/block/src/edit.js
+++ b/inc/sns/block/src/edit.js
@@ -22,10 +22,12 @@ export default function ShareButtonEdit( props ) {
 					initialOpen={ true }
 				>
 					<BaseControl>
-						<p>{__(
-							'You can configure the icon style from the admin panel under ExUnit > Main Settings > SNS Setting.',
-							'vk-all-in-one-expansion-unit'
-						) }</p>
+						<p>
+							{ __(
+								'You can configure the icon style from the admin panel under ExUnit > Main Settings > SNS Setting.',
+								'vk-all-in-one-expansion-unit'
+							) }
+						</p>
 					</BaseControl>
 				</PanelBody>
 			</InspectorControls>

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -256,8 +256,16 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output['hook_point'] = str_replace( array( ' ', '　', "\t", "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
 	$output['hook_point'] = str_replace( "\n\n", "\n", $output['hook_point'] );
 
+	$options_old = get_option( 'vkExUnit_sns_options' );
+
 	$output['snsBtn_bg_fill_not'] = ( isset( $input['snsBtn_bg_fill_not'] ) && $input['snsBtn_bg_fill_not'] ) ? true : false;
 	$output['snsBtn_color']       = sanitize_hex_color( $input['snsBtn_color'] );
+	if ( empty( $input['snsBtn_bg_fill_not'] ) ) {
+		$output['snsBtn_bg_fill_not'] = ! empty( $options_old['snsBtn_bg_fill_not'] ) ? $options_old['snsBtn_bg_fill_not'] : false;
+	}
+	if ( empty( $input['snsBtn_color'] ) ) {
+		$output['snsBtn_color'] = ! empty( $options_old['snsBtn_color'] ) ? $options_old['snsBtn_color'] : '';
+	}
 
 	return apply_filters( 'vkExUnit_sns_options_validate', $output, $input, $defaults );
 }

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -256,13 +256,8 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output['hook_point'] = str_replace( array( ' ', '　', "\t", "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
 	$output['hook_point'] = str_replace( "\n\n", "\n", $output['hook_point'] );
 
-	/*
-	SNSボタンの塗りつぶし関連は管理画面に値がないので、カスタマイザーで保存された値を入れる必要がある
-	既に保存されている値をアップデート用にそのまま返すだけなのでサニタイズしていない
-	 */
-	$options_old                  = get_option( 'vkExUnit_sns_options' );
-	$output['snsBtn_bg_fill_not'] = ( ! empty( $options_old['snsBtn_bg_fill_not'] ) ) ? $options_old['snsBtn_bg_fill_not'] : '';
-	$output['snsBtn_color']       = ( ! empty( $options_old['snsBtn_color'] ) ) ? $options_old['snsBtn_color'] : '';
+	$output['snsBtn_bg_fill_not'] = ( isset( $input['snsBtn_bg_fill_not'] ) && $input['snsBtn_bg_fill_not'] ) ? true : false;
+	$output['snsBtn_color']       = sanitize_hex_color( $input['snsBtn_color'] );
 
 	return apply_filters( 'vkExUnit_sns_options_validate', $output, $input, $defaults );
 }

--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -256,15 +256,10 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output['hook_point'] = str_replace( array( ' ', '　', "\t", "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
 	$output['hook_point'] = str_replace( "\n\n", "\n", $output['hook_point'] );
 
-	$options_old = get_option( 'vkExUnit_sns_options' );
-
-	$output['snsBtn_bg_fill_not'] = ( isset( $input['snsBtn_bg_fill_not'] ) && $input['snsBtn_bg_fill_not'] ) ? true : false;
-	$output['snsBtn_color']       = sanitize_hex_color( $input['snsBtn_color'] );
-	if ( empty( $input['snsBtn_bg_fill_not'] ) ) {
-		$output['snsBtn_bg_fill_not'] = ! empty( $options_old['snsBtn_bg_fill_not'] ) ? $options_old['snsBtn_bg_fill_not'] : false;
-	}
-	if ( empty( $input['snsBtn_color'] ) ) {
-		$output['snsBtn_color'] = ! empty( $options_old['snsBtn_color'] ) ? $options_old['snsBtn_color'] : '';
+	$output['snsBtn_bg_fill_not'] = isset( $input['snsBtn_bg_fill_not'] ) ? true : false;
+	$output['snsBtn_color']       = isset( $input['snsBtn_color'] ) ? sanitize_hex_color( $input['snsBtn_color'] ) : '';
+	if ( ! isset( $input['snsBtn_color'] ) || trim( $input['snsBtn_color'] ) === '' ) {
+		$output['snsBtn_color'] = '';
 	}
 
 	return apply_filters( 'vkExUnit_sns_options_validate', $output, $input, $defaults );

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -256,7 +256,7 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 		document.getElementById('snsBtn_color_picker').click();
 	});
 	document.getElementById('clear_color_btn').addEventListener('click', function() {
-		document.getElementById('snsBtn_color_picker').value = '#f6f7f7'; // カラーピッカーはデフォルト色を表示
-		document.getElementById('snsBtn_color').value = ''; // テキストボックスの値は空（保存時に '' になる）
+		document.getElementById('snsBtn_color_picker').value = '#f6f7f7';
+		document.getElementById('snsBtn_color').value = '';
 	});
 </script>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -2,6 +2,12 @@
 <?php
 	$options = veu_get_sns_options();
 
+if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
+	$options['snsBtn_bg_fill_not'] = isset( $_POST['vkExUnit_sns_options']['snsBtn_bg_fill_not'] ) ? true : false;
+	$options['snsBtn_color']       = sanitize_hex_color( $_POST['vkExUnit_sns_options']['snsBtn_color'] );
+	update_option( 'vkExUnit_sns_options', $options );
+}
+
 /*
 	SNS
 /*-------------------------------------------*/
@@ -9,6 +15,7 @@
 <div id="snsSetting" class="sectionBox">
 
 <!-- OGP hidden -->
+<form method="post" action="">
 <table class="form-table">
 <tr>
 <th><?php _e( 'Post title custom for SNS', 'vk-all-in-one-expansion-unit' ); ?></th>
@@ -80,6 +87,15 @@
 <th><label for="enableSnsBtns"><?php _e( 'Social bookmark buttons', 'vk-all-in-one-expansion-unit' ); ?></label></th>
 <td><label><input type="checkbox" name="vkExUnit_sns_options[enableSnsBtns]" id="enableSnsBtns" value="true" <?php echo ( $options['enableSnsBtns'] ) ? 'checked' : ''; ?> /><?php _e( 'Automatic insertion', 'vk-all-in-one-expansion-unit' ); ?></label>
 <p><?php _e( 'Automatically insert social bookmarks (share buttons and tweet buttons) into the body content field or specified action hooks.', 'vk-all-in-one-expansion-unit' ); ?></p>
+<dl>
+<dt><?php _e( 'Social button style setting', 'vk-all-in-one-expansion-unit' ); ?></dt>
+<dd>
+	<label><input type="checkbox" name="vkExUnit_sns_options[snsBtn_bg_fill_not]" value="true" <?php echo ( $options['snsBtn_bg_fill_not'] ) ? 'checked' : ''; ?> /><?php _e( 'No background', 'vk-all-in-one-expansion-unit' ); ?></label><br>
+	<label><?php _e( 'Btn color', 'vk-all-in-one-expansion-unit' ); ?></label><br>
+	<input type="color" id="snsBtn_color_picker" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
+	<input type="text" name="vkExUnit_sns_options[snsBtn_color]" id="snsBtn_color" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
+</dd>
+</dl>
 <dl>
 <dt><?php _e( 'Exclude Post Types', 'vk-all-in-one-expansion-unit' ); ?></dt>
 <dd>
@@ -236,4 +252,14 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 </table>
 
 <?php submit_button(); ?>
+</form>
 </div>
+
+<script>
+document.getElementById('snsBtn_color_picker').addEventListener('input', function() {
+	document.getElementById('snsBtn_color').value = this.value;
+});
+document.getElementById('snsBtn_color').addEventListener('input', function() {
+	document.getElementById('snsBtn_color_picker').value = this.value;
+});
+</script>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -80,25 +80,21 @@
 <th><label for="enableSnsBtns"><?php _e( 'Social bookmark buttons', 'vk-all-in-one-expansion-unit' ); ?></label></th>
 <td><label><input type="checkbox" name="vkExUnit_sns_options[enableSnsBtns]" id="enableSnsBtns" value="true" <?php echo ( $options['enableSnsBtns'] ) ? 'checked' : ''; ?> /><?php _e( 'Automatic insertion', 'vk-all-in-one-expansion-unit' ); ?></label>
 <p><?php _e( 'Automatically insert social bookmarks (share buttons and tweet buttons) into the body content field or specified action hooks.', 'vk-all-in-one-expansion-unit' ); ?></p>
+
 <dl>
 <dt><?php _e( 'Social button style setting', 'vk-all-in-one-expansion-unit' ); ?></dt>
 <dd>
-	<label><input type="checkbox" name="vkExUnit_sns_options[snsBtn_bg_fill_not]" value="true" <?php echo ( $options['snsBtn_bg_fill_not'] ) ? 'checked' : ''; ?> /><?php _e( 'No background', 'vk-all-in-one-expansion-unit' ); ?></label><br>
-	<label><?php _e( 'Btn color', 'vk-all-in-one-expansion-unit' ); ?></label><br>
-	<input type="color" id="snsBtn_color_picker" value="<?php echo esc_attr( $options['snsBtn_color'] ? $options['snsBtn_color'] : '#f6f7f7' ); ?>" />	<input type="text" name="vkExUnit_sns_options[snsBtn_color]" id="snsBtn_color" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
-	<button type="button" id="select_color_btn"><?php _e( 'Select Color', 'vk-all-in-one-expansion-unit' ); ?></button>
-</dd>
-</dl>
-<dl>
-<dt><?php _e( 'Exclude Post Types', 'vk-all-in-one-expansion-unit' ); ?></dt>
-<dd>
-<?php
-$args = array(
-	'name'    => 'vkExUnit_sns_options[snsBtn_exclude_post_types]',
-	'checked' => $options['snsBtn_exclude_post_types'],
-);
-vk_the_post_type_check_list( $args );
-?>
+	<label style="margin-bottom: .375rem">
+		<input type="checkbox" name="vkExUnit_sns_options[snsBtn_bg_fill_not]" value="true" <?php echo ( $options['snsBtn_bg_fill_not'] ) ? 'checked' : ''; ?> />
+		<?php _e( 'No background', 'vk-all-in-one-expansion-unit' ); ?>
+	</label>
+	<p>
+		<label><?php _e( 'Btn color', 'vk-all-in-one-expansion-unit' ); ?></label><br>
+		<input type="color" id="snsBtn_color_picker" value="<?php echo esc_attr( $options['snsBtn_color'] ? $options['snsBtn_color'] : '#f6f7f7' ); ?>" />
+		<input type="text" name="vkExUnit_sns_options[snsBtn_color]" id="snsBtn_color" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
+		<button type="button" id="select_color_btn"><?php _e( 'Select', 'vk-all-in-one-expansion-unit' ); ?></button>
+		<button type="button" id="clear_color_btn"><?php _e( 'Clear', 'vk-all-in-one-expansion-unit' ); ?></button>
+	</p>
 </dd>
 </dl>
 
@@ -249,13 +245,19 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 </div>
 
 <script>
-document.getElementById('snsBtn_color_picker').addEventListener('input', function() {
-	document.getElementById('snsBtn_color').value = this.value;
-});
-document.getElementById('snsBtn_color').addEventListener('input', function() {
-	document.getElementById('snsBtn_color_picker').value = this.value;
-});
-document.getElementById('select_color_btn').addEventListener('click', function() {
-	document.getElementById('snsBtn_color_picker').click();
-});
+	// カラーピッカー設定
+	document.getElementById('snsBtn_color_picker').addEventListener('input', function() {
+		document.getElementById('snsBtn_color').value = this.value;
+	});
+	document.getElementById('snsBtn_color').addEventListener('input', function() {
+		document.getElementById('snsBtn_color_picker').value = this.value;
+	});
+	document.getElementById('select_color_btn').addEventListener('click', function() {
+		document.getElementById('snsBtn_color_picker').click();
+	});
+
+	document.getElementById('clear_color_btn').addEventListener('click', function() {
+		document.getElementById('snsBtn_color_picker').value = '#f6f7f7';
+		document.getElementById('snsBtn_color').value = '';
+	});
 </script>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -2,12 +2,6 @@
 <?php
 	$options = veu_get_sns_options();
 
-if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
-	$options['snsBtn_bg_fill_not'] = isset( $_POST['vkExUnit_sns_options']['snsBtn_bg_fill_not'] ) ? true : false;
-	$options['snsBtn_color']       = sanitize_hex_color( $_POST['vkExUnit_sns_options']['snsBtn_color'] );
-	update_option( 'vkExUnit_sns_options', $options );
-}
-
 /*
 	SNS
 /*-------------------------------------------*/
@@ -15,7 +9,7 @@ if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
 <div id="snsSetting" class="sectionBox">
 
 <!-- OGP hidden -->
-<form method="post" action="">
+
 <table class="form-table">
 <tr>
 <th><?php _e( 'Post title custom for SNS', 'vk-all-in-one-expansion-unit' ); ?></th>
@@ -252,7 +246,7 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 </table>
 
 <?php submit_button(); ?>
-</form>
+
 </div>
 
 <script>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -9,7 +9,6 @@
 <div id="snsSetting" class="sectionBox">
 
 <!-- OGP hidden -->
-
 <table class="form-table">
 <tr>
 <th><?php _e( 'Post title custom for SNS', 'vk-all-in-one-expansion-unit' ); ?></th>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -94,6 +94,7 @@ if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
 	<label><?php _e( 'Btn color', 'vk-all-in-one-expansion-unit' ); ?></label><br>
 	<input type="color" id="snsBtn_color_picker" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
 	<input type="text" name="vkExUnit_sns_options[snsBtn_color]" id="snsBtn_color" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
+	<button type="button" id="select_color_btn"><?php _e( 'Select Color', 'vk-all-in-one-expansion-unit' ); ?></button>
 </dd>
 </dl>
 <dl>
@@ -261,5 +262,8 @@ document.getElementById('snsBtn_color_picker').addEventListener('input', functio
 });
 document.getElementById('snsBtn_color').addEventListener('input', function() {
 	document.getElementById('snsBtn_color_picker').value = this.value;
+});
+document.getElementById('select_color_btn').addEventListener('click', function() {
+	document.getElementById('snsBtn_color_picker').click();
 });
 </script>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -92,8 +92,7 @@ if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
 <dd>
 	<label><input type="checkbox" name="vkExUnit_sns_options[snsBtn_bg_fill_not]" value="true" <?php echo ( $options['snsBtn_bg_fill_not'] ) ? 'checked' : ''; ?> /><?php _e( 'No background', 'vk-all-in-one-expansion-unit' ); ?></label><br>
 	<label><?php _e( 'Btn color', 'vk-all-in-one-expansion-unit' ); ?></label><br>
-	<input type="color" id="snsBtn_color_picker" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
-	<input type="text" name="vkExUnit_sns_options[snsBtn_color]" id="snsBtn_color" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
+	<input type="color" id="snsBtn_color_picker" value="<?php echo esc_attr( $options['snsBtn_color'] ? $options['snsBtn_color'] : '#f6f7f7' ); ?>" />	<input type="text" name="vkExUnit_sns_options[snsBtn_color]" id="snsBtn_color" value="<?php echo esc_attr( $options['snsBtn_color'] ); ?>" />
 	<button type="button" id="select_color_btn"><?php _e( 'Select Color', 'vk-all-in-one-expansion-unit' ); ?></button>
 </dd>
 </dl>

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -255,9 +255,8 @@ if ( ! empty( $options['snsBtn_position']['after'] ) ) {
 	document.getElementById('select_color_btn').addEventListener('click', function() {
 		document.getElementById('snsBtn_color_picker').click();
 	});
-
 	document.getElementById('clear_color_btn').addEventListener('click', function() {
-		document.getElementById('snsBtn_color_picker').value = '#f6f7f7';
-		document.getElementById('snsBtn_color').value = '';
+		document.getElementById('snsBtn_color_picker').value = '#f6f7f7'; // カラーピッカーはデフォルト色を表示
+		document.getElementById('snsBtn_color').value = ''; // テキストボックスの値は空（保存時に '' になる）
 	});
 </script>

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ e.g.
 
 == Changelog ==
 
+[ Add function ][ SNS : Share button ] Added a main setting page for Share button style in ExUnit.
 = 9.103.0 =
 [ Specification change ] Fixed the zoom-out toggle not always displaying in the editor toolbar (updated blocks.json API version from 2 to 3).
 [ Design Bug Fix ][ Share button ]Resolved an issue where `gap` in the `.veu_socialSet` component was not applying proper spacing between elements.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1162 

## どういう変更をしたか？

ソーシャルボタンのスタイル設定（ボタンの色や背景なしのオプション）を ExUnit のメイン設定画面（ExUnit > メイン設定 > SNS Setting）からも変更できるようにしました。

### 変更前 Before
ExUnit > メイン設定 > SNS Setting 
![スクリーンショット 2025-02-10 16 56 17](https://github.com/user-attachments/assets/588113e4-ebdd-45e1-979c-66104a81bde2)

シェアボタンブロック
![スクリーンショット 2025-02-10 16 51 20](https://github.com/user-attachments/assets/4cb7e3f7-7385-4bf6-8137-4c4e2c829220)

### 変更後 After
ExUnit > メイン設定 > SNS Setting
![スクリーンショット 2025-02-10 16 52 42](https://github.com/user-attachments/assets/dd34e143-b654-42ef-aed1-274873157675)

シェアボタンブロック
![スクリーンショット 2025-02-10 16 50 53](https://github.com/user-attachments/assets/3361cb8b-1270-467e-8aec-957e031d87b3)

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [x] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [x] 情報意味を考慮した意味グルーピング・余白になっているか？
- [x] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ →値を追加したわけではないのでスキップしましたが、必要であれば書きます。
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. 管理画面の ExUnit > メイン設定 > SNS Settingから 背景なし のチェックとボタンの色のカラーピッカーが出ていることを確認しました。
2. 1の設定をしたら、シェアボタンの色や背景の有無が変わることを確認しました。
3. 外観 > カスタマイズ > ExUnit 設定 > SNS 設定 にある 背景なし のチェックとボタンの色のカラーピッカーの設定が1の保存値と同じことを確認しました。
4. カスタマイザーから、背景なし のチェックとボタンの色のカラーピッカーの設定を保存したとき、 ExUnit > メイン設定 > SNS Settingにも反映されていることを確認しました。
5. 4の設定に基づいてシェアボタンの色や背景の有無が変わることを確認しました。
6. ExUnit > メイン設定 > SNS Settingから カラーピッカーのテキスト入力欄で16進法以外のテキストを入力すると空になるようにしました。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

実装者と同じ確認を行ってください。
気になるところがあれば他にもご確認ください。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
