### PR TITLE
[ CTA ] 一部のcssがエスケープされる現象を修正しました

### DIFF
--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -165,48 +165,39 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						'escape_type' => '',
 					),
 					'vkExUnit_cta_img'                => array(
-						'escape_type' => 'esc_url',
+						'escape_type' => '',
 					),
 					'vkExUnit_cta_img_position'       => array(
 						'escape_type' => '',
 					),
 					'vkExUnit_cta_button_text'        => array(
-						'escape_type' => array( 'stripslashes', 'wp_kses_post' ),
+						'escape_type' => 'stripslashes',
 					),
 					'vkExUnit_cta_button_icon'        => array(
-						'escape_type' => 'wp_kses_post',
+						'escape_type' => 'stripslashes',
 					),
 					'vkExUnit_cta_button_icon_before' => array(
-						'escape_type' => 'wp_kses_post',
+						'escape_type' => 'stripslashes',
 					),
 					'vkExUnit_cta_button_icon_after'  => array(
-						'escape_type' => 'wp_kses_post',
+						'escape_type' => 'stripslashes',
 					),
 					'vkExUnit_cta_url'                => array(
-						'escape_type' => 'esc_url',
+						'escape_type' => '',
 					),
 					'vkExUnit_cta_url_blank'          => array(
 						'escape_type' => '',
 					),
 					'vkExUnit_cta_text'               => array(
-						'escape_type' => array( 'stripslashes', 'wp_kses_post' ),
+						'escape_type' => 'stripslashes',
 					),
 				);
 
 				// カスタムフィールドの保存.
 				foreach ( $custom_fields as $custom_field_name => $custom_field_options ) {
 					if ( isset( $_POST[ $custom_field_name ] ) ) {
-						if ( ! empty( $custom_field_name['escape_type'] ) ) {
-							if ( is_array( $custom_field_name['escape_type'] ) ) {
-								// エスケープ処理が複数ある場合
-								$data = $_POST[ $custom_field_name ];
-								foreach ( $custom_field_name['escape_type'] as $escape ) {
-									$data = call_user_func( $escape, $data );
-								}
-							} else {
-								// エスケープ処理が一つの場合
-								$data = call_user_func( $custom_field_name['escape_type'], $_POST[ $custom_field_name ] );
-							}
+						if ( isset( $custom_field_name['escape_type'] ) && $custom_field_name['escape_type'] == 'stripslashes' ) {
+							$data = stripslashes( $_POST[ $custom_field_name ] );
 						} else {
 							$data = $_POST[ $custom_field_name ];
 						}
@@ -404,12 +395,84 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 <tr><th><label for="vkExUnit_cta_text"><?php _e( 'Text message', 'vk-all-in-one-expansion-unit' ); ?>
 </th>
 <td>
-<textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses_post( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ) ); ?></textarea>
+			<?php
+			$allowed_html = array(
+				'div'  => array(
+					'id'        => array(),
+					'class'     => array(),
+					'itemprop'  => array(),
+					'itemscope' => array(),
+					'itemtype'  => array(),
+				),
+				'h3'   => array(
+					'id'    => array(),
+					'class' => array(),
+				),
+				'h4'   => array(
+					'id'    => array(),
+					'class' => array(),
+				),
+				'h5'   => array(
+					'id'    => array(),
+					'class' => array(),
+				),
+				'h6'   => array(
+					'id'    => array(),
+					'class' => array(),
+				),
+				'p'    => array(
+					'id'    => array(),
+					'class' => array(),
+				),
+				'ul'   => array(
+					'id'        => array(),
+					'class'     => array(),
+					'itemprop'  => array(),
+					'itemscope' => array(),
+					'itemtype'  => array(),
+				),
+				'ol'   => array(
+					'id'        => array(),
+					'class'     => array(),
+					'itemprop'  => array(),
+					'itemscope' => array(),
+					'itemtype'  => array(),
+				),
+				'li'   => array(
+					'id'        => array(),
+					'class'     => array(),
+					'itemprop'  => array(),
+					'itemscope' => array(),
+					'itemtype'  => array(),
+				),
+				'a'    => array(
+					'id'       => array(),
+					'class'    => array(),
+					'href'     => array(),
+					'target'   => array(),
+					'itemprop' => array(),
+				),
+				'span' => array(
+					'id'        => array(),
+					'class'     => array(),
+					'itemprop'  => array(),
+					'itemscope' => array(),
+					'itemtype'  => array(),
+				),
+				'i'    => array(
+					'id'    => array(),
+					'class' => array(),
+				),
+			);
+			?>
+<textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ), $allowed_html ); ?></textarea>
 </td></tr>
 </table>
 <a href="<?php echo admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ); ?>" class="button button-default" target="_blank"><?php _e( 'CTA setting', 'vk-all-in-one-expansion-unit' ); ?></a>
 			<?php
 		}
+
+
 
 		/**
 		 * Get CTA Post
@@ -433,10 +496,11 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			return $target;
 		}
 
+
 		/**
 		 * CTAとして返す内容の処理
 		 *
-		 * @param  [type] $id CTA Post ID
+		 * @param  [type] $id [description]
 		 * @return [type]     [description]
 		 */
 		public static function render_cta_content( $id ) {
@@ -478,7 +542,8 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// リセットしないと$postが改変されたままでコメント欄が表示されなくなるなどの弊害が発生する.
 			wp_reset_postdata();
 
-			return self::safe_kses_post( do_blocks( do_shortcode( $content ) ) );
+			// wp_kses_post でエスケープすると outerブロックが出力するstyle属性を無効化される.
+			return do_blocks( do_shortcode( $content ) );
 		}
 
 		/**
@@ -648,8 +713,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// ↓ これであかんの？
 			// $output_option = wp_parse_args( $option, $default );
 			if ( ! $option || ! is_array( $option ) ) {
-				return $default;
-			}
+				return $default; }
 
 			$posttypes = array_merge(
 				array(
@@ -757,7 +821,6 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_custom_iframes' ), 10, 2 );
 			$content = wp_kses_post( $content );
 			remove_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_custom_iframes' ), 10, 2 );
-
 			return $content;
 		}
 
@@ -772,7 +835,8 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 					'loading'         => true,
 					'sandbox'         => true,
 				);
-				$tags['style']  = array(
+
+				$tags['style'] = array(
 					'type' => true,
 				);
 			}

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -758,10 +758,6 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 				}
 			}
 
-			// HTMLのフィルタリングを適用（`iframe` に関係なく実行）
-			add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_custom_iframes' ), 10, 2 );
-			remove_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_custom_iframes' ), 10, 2 );
-
 			return $content;
 		}
 

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -758,6 +758,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 				}
 			}
 
+			// 文字のハイライトによる mark タグへの style 属性やグループブロックの背景画像指定の style 属性が削除されるため wp_kses は通していない
 			return $content;
 		}
 

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -165,39 +165,48 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						'escape_type' => '',
 					),
 					'vkExUnit_cta_img'                => array(
-						'escape_type' => '',
+						'escape_type' => 'esc_url',
 					),
 					'vkExUnit_cta_img_position'       => array(
 						'escape_type' => '',
 					),
 					'vkExUnit_cta_button_text'        => array(
-						'escape_type' => 'stripslashes',
+						'escape_type' => array( 'stripslashes', 'wp_kses_post' ),
 					),
 					'vkExUnit_cta_button_icon'        => array(
-						'escape_type' => 'stripslashes',
+						'escape_type' => 'wp_kses_post',
 					),
 					'vkExUnit_cta_button_icon_before' => array(
-						'escape_type' => 'stripslashes',
+						'escape_type' => 'wp_kses_post',
 					),
 					'vkExUnit_cta_button_icon_after'  => array(
-						'escape_type' => 'stripslashes',
+						'escape_type' => 'wp_kses_post',
 					),
 					'vkExUnit_cta_url'                => array(
-						'escape_type' => '',
+						'escape_type' => 'esc_url',
 					),
 					'vkExUnit_cta_url_blank'          => array(
 						'escape_type' => '',
 					),
 					'vkExUnit_cta_text'               => array(
-						'escape_type' => 'stripslashes',
+						'escape_type' => array( 'stripslashes', 'wp_kses_post' ),
 					),
 				);
 
 				// カスタムフィールドの保存.
 				foreach ( $custom_fields as $custom_field_name => $custom_field_options ) {
 					if ( isset( $_POST[ $custom_field_name ] ) ) {
-						if ( isset( $custom_field_name['escape_type'] ) && $custom_field_name['escape_type'] == 'stripslashes' ) {
-							$data = stripslashes( $_POST[ $custom_field_name ] );
+						if ( ! empty( $custom_field_name['escape_type'] ) ) {
+							if ( is_array( $custom_field_name['escape_type'] ) ) {
+								// エスケープ処理が複数ある場合
+								$data = $_POST[ $custom_field_name ];
+								foreach ( $custom_field_name['escape_type'] as $escape ) {
+									$data = call_user_func( $escape, $data );
+								}
+							} else {
+								// エスケープ処理が一つの場合
+								$data = call_user_func( $custom_field_name['escape_type'], $_POST[ $custom_field_name ] );
+							}
 						} else {
 							$data = $_POST[ $custom_field_name ];
 						}
@@ -395,84 +404,12 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 <tr><th><label for="vkExUnit_cta_text"><?php _e( 'Text message', 'vk-all-in-one-expansion-unit' ); ?>
 </th>
 <td>
-			<?php
-			$allowed_html = array(
-				'div'  => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-				),
-				'h3'   => array(
-					'id'    => array(),
-					'class' => array(),
-				),
-				'h4'   => array(
-					'id'    => array(),
-					'class' => array(),
-				),
-				'h5'   => array(
-					'id'    => array(),
-					'class' => array(),
-				),
-				'h6'   => array(
-					'id'    => array(),
-					'class' => array(),
-				),
-				'p'    => array(
-					'id'    => array(),
-					'class' => array(),
-				),
-				'ul'   => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-				),
-				'ol'   => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-				),
-				'li'   => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-				),
-				'a'    => array(
-					'id'       => array(),
-					'class'    => array(),
-					'href'     => array(),
-					'target'   => array(),
-					'itemprop' => array(),
-				),
-				'span' => array(
-					'id'        => array(),
-					'class'     => array(),
-					'itemprop'  => array(),
-					'itemscope' => array(),
-					'itemtype'  => array(),
-				),
-				'i'    => array(
-					'id'    => array(),
-					'class' => array(),
-				),
-			);
-			?>
-<textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ), $allowed_html ); ?></textarea>
+<textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses_post( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ) ); ?></textarea>
 </td></tr>
 </table>
 <a href="<?php echo admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ); ?>" class="button button-default" target="_blank"><?php _e( 'CTA setting', 'vk-all-in-one-expansion-unit' ); ?></a>
 			<?php
 		}
-
-
 
 		/**
 		 * Get CTA Post
@@ -496,11 +433,10 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			return $target;
 		}
 
-
 		/**
 		 * CTAとして返す内容の処理
 		 *
-		 * @param  [type] $id [description]
+		 * @param  [type] $id CTA Post ID
 		 * @return [type]     [description]
 		 */
 		public static function render_cta_content( $id ) {
@@ -542,8 +478,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// リセットしないと$postが改変されたままでコメント欄が表示されなくなるなどの弊害が発生する.
 			wp_reset_postdata();
 
-			// wp_kses_post でエスケープすると outerブロックが出力するstyle属性を無効化される.
-			return do_blocks( do_shortcode( $content ) );
+			return self::safe_kses_post( do_blocks( do_shortcode( $content ) ) );
 		}
 
 		/**
@@ -713,7 +648,8 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// ↓ これであかんの？
 			// $output_option = wp_parse_args( $option, $default );
 			if ( ! $option || ! is_array( $option ) ) {
-				return $default; }
+				return $default;
+			}
 
 			$posttypes = array_merge(
 				array(
@@ -797,30 +733,35 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// すべての iframe タグを検索
 			preg_match_all( '/<iframe.*?src=["\'](.*?)["\'].*?>.*?<\/iframe>/i', $content, $matches );
 
-			$allowed_iframes    = array();
-			$disallowed_iframes = array();
+			// iframe が含まれている場合のみ処理する
+			if ( ! empty( $matches[1] ) ) {
+				$allowed_iframes    = array();
+				$disallowed_iframes = array();
 
-			foreach ( $matches[1] as $index => $iframe_src ) {
-				$allowed = false;
-				foreach ( $allowed_iframe_patterns as $pattern ) {
-					if ( preg_match( $pattern, $iframe_src ) ) {
-						$allowed_iframes[ $matches[0][ $index ] ] = $matches[0][ $index ]; // 許可リストに追加
-						$allowed                                  = true;
-						break;
+				foreach ( $matches[1] as $index => $iframe_src ) {
+					$allowed = false;
+					foreach ( $allowed_iframe_patterns as $pattern ) {
+						if ( preg_match( $pattern, $iframe_src ) ) {
+							$allowed_iframes[ $matches[0][ $index ] ] = $matches[0][ $index ]; // 許可リストに追加
+							$allowed                                  = true;
+							break;
+						}
+					}
+					if ( ! $allowed ) {
+						$disallowed_iframes[] = $matches[0][ $index ]; // 非許可リストに追加
 					}
 				}
-				if ( ! $allowed ) {
-					$disallowed_iframes[] = $matches[0][ $index ]; // 非許可リストに追加
+
+				// 許可されていない iframe を削除
+				if ( ! empty( $disallowed_iframes ) ) {
+					$content = str_replace( $disallowed_iframes, '', $content );
 				}
 			}
 
-			// すべての iframe を一旦削除
-			$content = str_replace( $disallowed_iframes, '', $content );
-
-			// HTMLのフィルタリング
+			// HTMLのフィルタリングを適用（`iframe` に関係なく実行）
 			add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_custom_iframes' ), 10, 2 );
-			$content = wp_kses_post( $content );
 			remove_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_custom_iframes' ), 10, 2 );
+
 			return $content;
 		}
 
@@ -835,8 +776,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 					'loading'         => true,
 					'sandbox'         => true,
 				);
-
-				$tags['style'] = array(
+				$tags['style']  = array(
 					'type' => true,
 				);
 			}

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -759,6 +759,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			}
 
 			// 文字のハイライトによる mark タグへの style 属性やグループブロックの背景画像指定の style 属性が削除されるため wp_kses は通していない
+			// https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1172
 			return $content;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ CTA ] Fixed some CSS being escaped.
+
 = 9.103.0 =
 [ Specification change ] Fixed the zoom-out toggle not always displaying in the editor toolbar (updated blocks.json API version from 2 to 3).
 [ Design Bug Fix ][ Share button ]Resolved an issue where `gap` in the `.veu_socialSet` component was not applying proper spacing between elements.

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -300,8 +300,8 @@ class CTATest extends WP_UnitTestCase {
 			),
 			array(
 				'name'     => 'class and style',
-				'input'    => '<div class="class-name" style="margin-bottom:3rem">CTA</div>',
-				'expected' => '<div class="class-name" style="margin-bottom:3rem">CTA</div>',
+				'input'    => '<div class="class-name" style="margin-bottom:3rem; background-image: url(http://localhost:8888/image.jpg);">CTA</div>',
+				'expected' => '<div class="class-name" style="margin-bottom:3rem; background-image: url(http://localhost:8888/image.jpg);">CTA</div>',
 			),
 			array(
 				'name'     => 'allow style tag',
@@ -316,6 +316,11 @@ class CTATest extends WP_UnitTestCase {
 				'expected' => '<div>CTA</div><style>@media screen and (max-width: 575.98px) {.target-class {
 			background-image: url(http://localhost:8888/image.jpg);
 			background-position: 50% 50%!important;}}</style>',
+			),
+			array(
+				'name'     => 'allow mark tag with class and style',
+				'input'    => '<mark class="has-inline-color" style="background-color: yellow;">Highlight</mark>',
+				'expected' => '<mark class="has-inline-color" style="background-color: yellow;">Highlight</mark>',
 			),
 		);
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1170 

## どういう変更をしたか？

- 不必要なwp_kses_post() を削除し、不要なエスケープ処理を排除。
- safe_kses_post() の iframe 処理を最適化し、iframe がない場合の不要な処理を削減。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [x] 書けそうなテストは書いたか？
- [x] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [ ] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [ ] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [ ] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. master ブランチでCTAで新規ページを追加し、以下のブロックを設定。
- グループブロックで背景画像を設定。
- 段落ブロックで一部のテキストを選択し、ハイライトで文字色だけを変更。
- Google Map をiframeタグで埋め込み。
- https://www.vektor-inc.co.jp/ をiframeタグで埋め込み。
2. ExUnit > メイン設定 > Call To Action で1で作成したページを設定
3. フロントエンドで以下になってしまっていることを確認。
- グループブロックで背景画像が消えてしまっている。
- ハイライト設定した背景色が黄色くなってしまっている。
- (Google Map はiframeタグで表示される。)
- (https://www.vektor-inc.co.jp/ は表示されない。)
4. fix/cta/mark に切り替え、1の編集画面と同じ表示になっていることを確認。
- グループブロックで背景画像が表示されている。
- ハイライト設定した背景色が黄色くならない。
- (Google Map はiframeタグで表示される。)
- (https://www.vektor-inc.co.jp/ は表示されない。)

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

実装者と同じ確認を行ってください。
また、コードの確認もお願いいたします。

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
