### PR TITLE
メイン設定画面の SNS の非表示設定を削除

### DIFF
--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -21,6 +21,26 @@ if ( veu_is_sns_btns_auto_insert() ) {
 }
 
 /**
+ * Fix share button hide option
+ */
+function veu_fix_sns_btns_hide() {
+	$options = veu_get_sns_options();
+	if ( ! empty( $options['snsBtn_ignorePosts'] ) ) {
+		$ignore_post_ids = explode( ',', $options['snsBtn_ignorePosts'] );
+		foreach ( $ignore_post_ids as $ignore_post_id ) {
+			$ignore_post_id = trim( $ignore_post_id );
+			if ( ! empty( get_post( $ignore_post_id ) ) ) {
+				update_post_meta( $ignore_post_id, 'sns_share_botton_hide', true );
+			}
+		}
+		unset( $options['snsBtn_ignorePosts'] );
+		update_option( 'vkExUnit_sns_options', $options );
+	}
+}
+add_action( 'admin_init', 'veu_fix_sns_btns_hide' );
+
+
+/**
  * Display share button on hook point
  *
  * @param object $query : main query.
@@ -71,7 +91,6 @@ function veu_is_sns_btns_auto_insert() {
  */
 function veu_is_sns_btns_display() {
 	$options               = veu_get_sns_options();
-	$ignore_posts          = explode( ',', $options['snsBtn_ignorePosts'] );
 	$post_type             = vk_get_post_type();
 	$post_type             = $post_type['slug'];
 	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
@@ -87,11 +106,6 @@ function veu_is_sns_btns_display() {
 
 	// シェアボタンを表示しない投稿タイプが配列で指定されている場合（チェックが入ってたら）.
 	if ( ! empty( $options['snsBtn_exclude_post_types'][ $post_type ] ) ) {
-		return false;
-	}
-
-	// 非表示対象の中にこの投稿IDが含まれる場合は表示しない.
-	if ( ! empty( $ignore_posts ) && is_array( $ignore_posts ) && in_array( (string) get_the_ID(), $ignore_posts, true ) ) {
 		return false;
 	}
 

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -37,7 +37,7 @@ function veu_fix_sns_btns_hide() {
 		update_option( 'vkExUnit_sns_options', $options );
 	}
 }
-add_action( 'plugin_loaded', 'veu_fix_sns_btns_hide' );
+add_action( 'admin_init', 'veu_fix_sns_btns_hide' );
 
 
 /**

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -37,7 +37,7 @@ function veu_fix_sns_btns_hide() {
 		update_option( 'vkExUnit_sns_options', $options );
 	}
 }
-add_action( 'admin_init', 'veu_fix_sns_btns_hide' );
+add_action( 'plugin_loaded', 'veu_fix_sns_btns_hide' );
 
 
 /**

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -97,27 +97,6 @@
 	</p>
 </dd>
 </dl>
-
-<dl>
-<dt><?php _e( 'Exclude Post ID', 'vk-all-in-one-expansion-unit' ); ?></dt>
-<dd>
-<input type="text" id="snsBtn_ignorePosts" name="vkExUnit_sns_options[snsBtn_ignorePosts]" value="
-<?php
-if ( isset( $options['snsBtn_ignorePosts'] ) ) {
-	echo esc_attr( $options['snsBtn_ignorePosts'] );}
-?>
-" />
-<br/>
-<?php
-_e( 'if you need filtering by post_ID, add the ignore post_ID separate by ",".', 'vk-all-in-one-expansion-unit' );
-echo '<br/>';
-_e( 'if empty this area, I will do not filtering.', 'vk-all-in-one-expansion-unit' );
-echo '<br/>';
-_e( 'example', 'vk-all-in-one-expansion-unit' );
-?>
-	(12,31,553)
-</dd>
-</dl>
 </td>
 </tr>
 

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -80,7 +80,18 @@
 <th><label for="enableSnsBtns"><?php _e( 'Social bookmark buttons', 'vk-all-in-one-expansion-unit' ); ?></label></th>
 <td><label><input type="checkbox" name="vkExUnit_sns_options[enableSnsBtns]" id="enableSnsBtns" value="true" <?php echo ( $options['enableSnsBtns'] ) ? 'checked' : ''; ?> /><?php _e( 'Automatic insertion', 'vk-all-in-one-expansion-unit' ); ?></label>
 <p><?php _e( 'Automatically insert social bookmarks (share buttons and tweet buttons) into the body content field or specified action hooks.', 'vk-all-in-one-expansion-unit' ); ?></p>
-
+<dl>
+<dt><?php _e( 'Exclude Post Types', 'vk-all-in-one-expansion-unit' ); ?></dt>
+<dd>
+<?php
+$args = array(
+	'name'    => 'vkExUnit_sns_options[snsBtn_exclude_post_types]',
+	'checked' => $options['snsBtn_exclude_post_types'],
+);
+vk_the_post_type_check_list( $args );
+?>
+</dd>
+</dl>
 <dl>
 <dt><?php _e( 'Social button style setting', 'vk-all-in-one-expansion-unit' ); ?></dt>
 <dd>

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification change ] Delete SNS button hidden setting from main setting.
+
 = 9.104.0 =
 [ Add function ][ SNS : Share button ] Added a main setting page for Share button style in ExUnit.
 [ Add function ][ No index ] Add a feature to display an alert on the dashboard if "Discourage search engines from indexing this site" is enabled in Settings > Reading.

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -154,7 +154,7 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					),
 				),
 				'target_url' => get_permalink( $data['post_id_02'] ),
-				'correct'    => false,
+				'correct'    => true,
 			),
 			array(
 				'options'    => array(
@@ -172,15 +172,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					),
 				),
 				'target_url' => get_permalink( $data['post_id_02'] ),
-				'correct'    => true,
-			),
-			array(
-				'options'    => array(
-					'snsBtn_exclude_post_types' => array(
-						'post' => true,
-					),
-				),
-				'target_url' => get_permalink( $data['post_id_03'] ),
 				'correct'    => false,
 			),
 			array(
@@ -199,15 +190,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					),
 				),
 				'target_url' => get_permalink( $data['page_id_02'] ),
-				'correct'    => false,
-			),
-			array(
-				'options'    => array(
-					'snsBtn_exclude_post_types' => array(
-						'page' => false,
-					),
-				),
-				'target_url' => get_permalink( $data['page_id_03'] ),
 				'correct'    => true,
 			),
 			array(
@@ -231,15 +213,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			array(
 				'options'    => array(
 					'snsBtn_exclude_post_types' => array(
-						'page' => true,
-					),
-				),
-				'target_url' => get_permalink( $data['page_id_03'] ),
-				'correct'    => false,
-			),
-			array(
-				'options'    => array(
-					'snsBtn_exclude_post_types' => array(
 						'event' => false,
 					),
 				),
@@ -253,15 +226,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					),
 				),
 				'target_url' => get_permalink( $data['event_id_02'] ),
-				'correct'    => false,
-			),
-			array(
-				'options'    => array(
-					'snsBtn_exclude_post_types' => array(
-						'event' => false,
-					),
-				),
-				'target_url' => get_permalink( $data['event_id_03'] ),
 				'correct'    => true,
 			),
 			array(
@@ -280,15 +244,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					),
 				),
 				'target_url' => get_permalink( $data['event_id_02'] ),
-				'correct'    => false,
-			),
-			array(
-				'options'    => array(
-					'snsBtn_exclude_post_types' => array(
-						'event' => true,
-					),
-				),
-				'target_url' => get_permalink( $data['event_id_03'] ),
 				'correct'    => false,
 			),
 			array(

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -93,20 +93,9 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			'post_category' => array( $data['category_id'] ),
 		);
 		$data['post_id_02'] = wp_insert_post( $post );
-		add_post_meta( $data['post_id_02'], 'sns_share_botton_hide', true );
+		add_post_meta( $data['post_id_02'], 'sns_share_botton_hide', false );
 
-		// 投稿「テスト03」を追加
-		$post               = array(
-			'post_title'    => 'Post Test 03',
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_content'  => 'Post Test 03',
-			'post_category' => array( $data['category_id'] ),
-		);
-		$data['post_id_03'] = wp_insert_post( $post );
-		add_post_meta( $data['post_id_03'], 'sns_share_botton_hide', false );
-
-		// 固定ページ「テスト0１」を追加
+		// 固定ページ「テスト01」を追加
 		$post               = array(
 			'post_title'   => 'Page Test 01',
 			'post_type'    => 'page',
@@ -124,17 +113,7 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			'post_content' => 'Page Test 02',
 		);
 		$data['page_id_02'] = wp_insert_post( $post );
-		add_post_meta( $data['page_id_02'], 'sns_share_botton_hide', true );
-
-		// 固定ページ「テスト03」を追加
-		$post               = array(
-			'post_title'   => 'Page Test 03',
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_content' => 'Page Test 03',
-		);
-		$data['page_id_03'] = wp_insert_post( $post );
-		add_post_meta( $data['page_id_03'], 'sns_share_botton_hide', false );
+		add_post_meta( $data['page_id_02'], 'sns_share_botton_hide', false );
 
 		// イベント「テスト01」を追加
 		$post                = array(
@@ -156,18 +135,7 @@ class SnsBtnsTest extends WP_UnitTestCase {
 		);
 		$data['event_id_02'] = wp_insert_post( $post );
 		wp_set_object_terms( $data['event_id_02'], 'event_category_name', 'event_cat' );
-		add_post_meta( $data['event_id_02'], 'sns_share_botton_hide', true );
-
-		// イベント「テスト03」を追加
-		$post                = array(
-			'post_title'   => 'Event Test 03',
-			'post_type'    => 'event',
-			'post_status'  => 'publish',
-			'post_content' => 'Event Test 03',
-		);
-		$data['event_id_03'] = wp_insert_post( $post );
-		wp_set_object_terms( $data['event_id_03'], 'event_category_name', 'event_cat' );
-		add_post_meta( $data['event_id_03'], 'sns_share_botton_hide', false );
+		add_post_meta( $data['event_id_02'], 'sns_share_botton_hide', false );
 
 		$test_array = array(
 			array(
@@ -187,15 +155,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 				),
 				'target_url' => get_permalink( $data['post_id_02'] ),
 				'correct'    => false,
-			),
-			array(
-				'options'    => array(
-					'snsBtn_exclude_post_types' => array(
-						'post' => false,
-					),
-				),
-				'target_url' => get_permalink( $data['post_id_03'] ),
-				'correct'    => true,
 			),
 			array(
 				'options'    => array(

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -169,19 +169,12 @@ class SnsBtnsTest extends WP_UnitTestCase {
 		wp_set_object_terms( $data['event_id_03'], 'event_category_name', 'event_cat' );
 		add_post_meta( $data['event_id_03'], 'sns_share_botton_hide', false );
 
-		$ignore_posts = array(
-			$data['post_id_02'],
-			$data['page_id_02'],
-			$data['event_id_02'],
-		);
-
 		$test_array = array(
 			array(
 				'options'    => array(
 					'snsBtn_exclude_post_types' => array(
 						'post' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['post_id_01'] ),
 				'correct'    => false,
@@ -191,7 +184,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'post' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['post_id_02'] ),
 				'correct'    => false,
@@ -201,7 +193,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'post' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['post_id_03'] ),
 				'correct'    => true,
@@ -211,7 +202,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'post' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['post_id_01'] ),
 				'correct'    => false,
@@ -221,17 +211,15 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'post' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['post_id_02'] ),
-				'correct'    => false,
+				'correct'    => true,
 			),
 			array(
 				'options'    => array(
 					'snsBtn_exclude_post_types' => array(
 						'post' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['post_id_03'] ),
 				'correct'    => false,
@@ -241,7 +229,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'page' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['page_id_01'] ),
 				'correct'    => false,
@@ -251,7 +238,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'page' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['page_id_02'] ),
 				'correct'    => false,
@@ -261,7 +247,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'page' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['page_id_03'] ),
 				'correct'    => true,
@@ -271,7 +256,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'page' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['page_id_01'] ),
 				'correct'    => false,
@@ -281,7 +265,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'page' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['page_id_02'] ),
 				'correct'    => false,
@@ -291,7 +274,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'page' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['page_id_03'] ),
 				'correct'    => false,
@@ -301,7 +283,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'event' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['event_id_01'] ),
 				'correct'    => false,
@@ -311,7 +292,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'event' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['event_id_02'] ),
 				'correct'    => false,
@@ -321,7 +301,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'event' => false,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['event_id_03'] ),
 				'correct'    => true,
@@ -331,7 +310,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'event' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['event_id_01'] ),
 				'correct'    => false,
@@ -341,7 +319,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'event' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['event_id_02'] ),
 				'correct'    => false,
@@ -351,7 +328,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'event' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => get_permalink( $data['event_id_03'] ),
 				'correct'    => false,
@@ -361,7 +337,6 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					'snsBtn_exclude_post_types' => array(
 						'event' => true,
 					),
-					'snsBtn_ignorePosts'        => json_encode( $ignore_posts ),
 				),
 				'target_url' => home_url( '/' ) . '?p=9999',
 				'correct'    => false,


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1177

## どういう変更をしたか？

- メイン設定画面で , 区切りで保存されている値（ vkExUnit_sns_options[snsBtn_ignorePosts] ）がある場合、カスタムフィールドでの保存値に変換
- メイン設定画面から入力UIの削除
- シェアボタン表示側で vkExUnit_sns_options[snsBtn_ignorePosts] に該当する場合は非表示にする処理があるが、不要になるため削除
- テストもそのあたり不要になるので削除

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [x] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [x] 情報意味を考慮した意味グルーピング・余白になっているか？
- [x] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [x] 書けそうなテストは書いたか？
- [x] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. master ブランチでExUnit の SNS Settings の シェアボタンを表示しない投稿のID に既存の投稿 ID をカンマ区切りで入力して保存
2. このブランチに切り替えてブラウザを再読み込み（一応）したあと設定した投稿 ID の記事をの編集画面に移動
3. 記事編集画面の ExUnit のシェアボタンの非表示設定のソーシャルボタンを表示しないにチェックが入っているのを確認
4. ExUnit の設定の SNS Settings の シェアボタンを表示しない投稿のID が存在しないことを確認
5. npm run phpunit

## 確認URL

開発環境

## レビュワーの確認方法・確認する内容など

1. master ブランチでExUnit の SNS Settings の シェアボタンを表示しない投稿のID に既存の投稿 ID をカンマ区切りで入力して保存
2. このブランチに切り替えてブラウザを再読み込み（一応）したあと設定した投稿 ID の記事をの編集画面に移動
3. 記事編集画面の ExUnit のシェアボタンの非表示設定のソーシャルボタンを表示しないにチェックが入っているのを確認
4. ExUnit の設定の SNS Settings の シェアボタンを表示しない投稿のID が存在しないことを確認
5. npm run phpunit

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
