### PR TITLE
Fix: Sass deprecation warnings

### DIFF
--- a/assets/_scss/_child_page_list.scss
+++ b/assets/_scss/_child_page_list.scss
@@ -1,14 +1,14 @@
 .veu_childPage_list {
 	margin-top: 2.5em;
-	&:first-child{
-		margin-top:0;
-	}
 	display: flex;
 	align-items: stretch;
 	flex-wrap: wrap;
 	-webkit-flex-wrap: wrap; /* Safari */
 	justify-content: space-between;
 	-webkit-justify-content: space-between; /* Safari */
+	&:first-child{
+		margin-top:0;
+	}
 	.childPage_list_box {
 		margin-bottom: 1.5em;
 		width: 100%;

--- a/assets/_scss/_contact_section.scss
+++ b/assets/_scss/_contact_section.scss
@@ -69,10 +69,10 @@
 } // @media (min-width: 1200px){
    
 .widget_vkexunit_contact_section {
+    margin-bottom:var(--vk-margin-block-bottom);
     .veu_contentAddSection {
         margin:0;
     }
-    margin-bottom:var(--vk-margin-block-bottom);
 }
 
 // カスタマイザでウィジェット選択と問い合わせ情報のショートカットアイコンが重ならないように

--- a/assets/_scss/vkExUnit_style.scss
+++ b/assets/_scss/vkExUnit_style.scss
@@ -156,13 +156,13 @@
 	.followSet_body {
 		display: table-cell;
 		padding: 15px;
-		@media (min-width: 481px) {
-			padding: 40px;
-		}
 		text-align: center;
 		vertical-align: middle;
 		line-height: 1.4;
 		font-size: 20px;
+		@media (min-width: 481px) {
+			padding: 40px;
+		}
 	}
 
 	.followSet_title {
@@ -540,13 +540,13 @@ iframe.twitter-timeline {
 }
 .veu_3prArea_image {
 	margin-bottom: 0.8em;
+	border: 1px solid #e5e5e5;
 	.image_pc {
 		display: block;
 	}
 	.image_sp {
 		display: none;
 	}
-	border: 1px solid #e5e5e5;
 	img {
 		width: 100%;
 	}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
npm run buildしたらSCSSでいくつか非推奨警告（Deprecation Warning）が出たため。

## どういう変更をしたか？

Sassの最新仕様に対応するため、通常のCSSプロパティをネストの前に移動しました。
1人確認で大丈夫です。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？ →スキップ
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？ →スキップ

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？ →スキップ
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？ →スキップ
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？ →スキップ

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ →スキップ
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？ →スキップ

#### その他

- [ ] readme.txt に変更内容は書いたか？ →内部のためスキップ
- [ ] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [ ] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [ ] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. `master`で以下の機能を設定
   - ブロックの子ページリスト
   - ウィジェットの「お問い合わせ」
   - 3PRエリエの画像版
2. `fix/sass/deprecations`に移動し、npm run build した時にエラーが発生しないことを確認
3. 1の設定場所に移動し、CSSが正常に出力されていることを確認
   - ブロックの子ページリスト
   - ウィジェットの「お問い合わせ」
   - 3PRエリエの画像版

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

実装者と同じ確認を行ってください。

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
