### PR TITLE
従来のレイアウトの CTA のスタイルが編集画面に当たらないのを修正

### DIFF
--- a/inc/call-to-action/package/assets/_scss/style.scss
+++ b/inc/call-to-action/package/assets/_scss/style.scss
@@ -4,13 +4,19 @@
 
 $section_margin : 30px;
 
-.veu-cta-block + .veu_adminEdit {
-	position: absolute;
-	margin-top:-3em;
-	margin-left:1em;
-	z-index: 999;
-	& > .btn {
-		font-size:12px;
+.veu-cta-block {
+	& + .veu_adminEdit {
+		position: absolute;
+		margin-top:-3em;
+		margin-left:1em;
+		z-index: 999;
+		& > .btn {
+			font-size:12px;
+		}
+	}
+
+	.btn-block {
+		width: initial; // デフォルトテーマ用
 	}
 }
 
@@ -22,7 +28,7 @@ $section_margin : 30px;
 	.cta_title { @include veu_content_bottom_section_title; }
 	.cta_body { @include veu_content_bottom_section_body;line-height: 170%; }
 	.cta_body_image { margin-bottom:1.5em; }
-	.cta_body_image img { max-width: 250px; }
+	.cta_body_image img { max-width: 250px; height: 100%; }
 	.cta_body_image_center { display:block; overflow:hidden;text-align: center;
 		img { display:block; margin:0 auto 15px;max-width: 100%; }
 	}

--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -77,7 +77,7 @@ add_action( 'init', 'veu_register_cta_block', 15 );
 /**
  * Gutenberg ブロックにスタイルを適用
  */
-function vk_call_to_action_enqueue_assets() {
+function veu_cta_block_enqueue_styles() {
 	wp_enqueue_style(
 		'vk-call-to-action-style',
 		plugin_dir_url( __DIR__ ) . 'assets/css/style.css',
@@ -85,7 +85,7 @@ function vk_call_to_action_enqueue_assets() {
 		filemtime( plugin_dir_path( __DIR__ ) . 'assets/css/style.css' )
 	);
 }
-add_action( 'enqueue_block_assets', 'vk_call_to_action_enqueue_assets' );
+add_action( 'enqueue_block_editor_assets', 'veu_cta_block_enqueue_styles' );
 
 /**
  * 翻訳を設定

--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -80,12 +80,12 @@ add_action( 'init', 'veu_register_cta_block', 15 );
 function vk_call_to_action_enqueue_assets() {
 	wp_enqueue_style(
 		'vk-call-to-action-style',
-		plugins_url('../assets/css/style.css', __FILE__),
+		plugin_dir_url( __DIR__ ) . 'assets/css/style.css',
 		array(),
-		filemtime(plugin_dir_path(__FILE__) . '../assets/css/style.css')
+		filemtime( plugin_dir_path( __DIR__ ) . 'assets/css/style.css' )
 	);
 }
-add_action('enqueue_block_assets', 'vk_call_to_action_enqueue_assets');
+add_action( 'enqueue_block_assets', 'vk_call_to_action_enqueue_assets' );
 
 /**
  * 翻訳を設定

--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -75,6 +75,19 @@ function veu_register_cta_block() {
 add_action( 'init', 'veu_register_cta_block', 15 );
 
 /**
+ * Gutenberg ブロックにスタイルを適用
+ */
+function vk_call_to_action_enqueue_assets() {
+	wp_enqueue_style(
+		'vk-call-to-action-style',
+		plugins_url('../assets/css/style.css', __FILE__),
+		array(),
+		filemtime(plugin_dir_path(__FILE__) . '../assets/css/style.css')
+	);
+}
+add_action('enqueue_block_assets', 'vk_call_to_action_enqueue_assets');
+
+/**
  * 翻訳を設定
  */
 function veu_cta_block_translation() {

--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -78,14 +78,17 @@ add_action( 'init', 'veu_register_cta_block', 15 );
  * Gutenberg ブロックにスタイルを適用
  */
 function veu_cta_block_enqueue_styles() {
-	wp_enqueue_style(
-		'vk-call-to-action-style',
-		plugin_dir_url( __DIR__ ) . 'assets/css/style.css',
-		array(),
-		filemtime( plugin_dir_path( __DIR__ ) . 'assets/css/style.css' )
-	);
+	// 管理画面（エディタ）でのみ適用
+	if ( is_admin() ) {
+		wp_enqueue_style(
+			'vk-call-to-action-style-editor',
+			plugin_dir_url( __DIR__ ) . 'assets/css/style.css',
+			array(),
+			filemtime( plugin_dir_path( __DIR__ ) . 'assets/css/style.css' )
+		);
+	}
 }
-add_action( 'enqueue_block_editor_assets', 'veu_cta_block_enqueue_styles' );
+add_action( 'enqueue_block_assets', 'veu_cta_block_enqueue_styles' );
 
 /**
  * 翻訳を設定

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ e.g.
 == Changelog ==
 
 [ Specification change ] Delete SNS button hidden setting from main setting.
+[ Bug fix ][ CTA ] Fixed the missing style application in the editor when creating a CTA using the "Use traditional layout" option.
 
 = 9.104.1 =
 [ Bug fix ] Fixed editor style not loading in environments using basic authentication.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1183 

## どういう変更をしたか？

元々 enqueue_block_assets で style.css を読み込む処理が master には存在していなかったため、CTA ブロックを「従来のレイアウトを使用する」に設定した際に、編集画面でスタイルが適用されてませんでした。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？ →スキップ
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？ →スキップ
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？ →スキップ

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ →編集画面のCSS読み込み用の関数を追加しただけなのでスキップ
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？ →編集画面のCSS読み込み用の関数を追加しただけなのでスキップ

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

Lightining、X-T9、TT5で確認しました。

1. `master`でカスタム投稿のCTAで「従来のレイアウトを使用する」に設定したCTAを保存
2. 固定ページの編集画面でCTAブロックを置いた時にスタイルが適用されないことを確認
3. `fix/cta/editor/css`に切り替え`npm run build`
4. 固定ページの編集画面でCTAブロックを置いた時にスタイルが適用されることを確認
(Lightningの場合、CTAで使っているクラス名とテーマで使っているクラス名が被っている関係で、編集画面では表示が異なっている部分があります。テーマ側での対応をお願いいたします。)
5. フロントエンドでの表示に影響が出ていないことを確認(二重でCSSが読み込まれていないことも確認)
6. カスタム投稿のCTAでブロックエディタのCTAを作って保存し、固定ページの編集画面でそのCTAをCTAブロックに設定した時、スタイルの読み込みの影響で崩れたり表示がフロントエンドと同一であることを確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

実装者と同じ確認を行ってください。
他にも気になるところがあったら確認してください。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
