### PR TITLE
[ Bug fix ][ SNS ] ExUnit Main Setting の Warning に対処

### DIFF
--- a/inc/sns/sns.php
+++ b/inc/sns/sns.php
@@ -229,12 +229,12 @@ function veu_get_the_sns_title( $post_id = '' ) {
 function vkExUnit_sns_options_validate( $input ) {
 	$output = $defaults = veu_get_sns_options_default();
 
-	$output['fbAppId']                     = stripslashes( esc_attr( $input['fbAppId'] ) );
-	$output['fbPageUrl']                   = esc_url( $input['fbPageUrl'] );
-	$output['fbAccessToken']               = stripslashes( esc_attr( $input['fbAccessToken'] ) );
-	$output['ogImage']                     = esc_url( $input['ogImage'] );
-	$output['twitterId']                   = stripslashes( esc_attr( $input['twitterId'] ) );
-	$output['snsBtn_ignorePosts']          = preg_replace( '/[^0-9,]/', '', esc_attr( $input['snsBtn_ignorePosts'] ) );
+	$output['fbAppId']                     = ! empty( $input['fbAppId'] ) ? stripslashes( esc_attr( $input['fbAppId'] ) ) : '';
+	$output['fbPageUrl']                   = ! empty( $input['fbPageUrl'] ) ? esc_url( $input['fbPageUrl'] ) : '';
+	$output['fbAccessToken']               = ! empty( $input['fbAccessToken'] ) ? stripslashes( esc_attr( $input['fbAccessToken'] ) ) : '';
+	$output['ogImage']                     = ! empty( $input['ogImage'] ) ? esc_url( $input['ogImage'] ) : '';
+	$output['twitterId']                   = ! empty( $input['twitterId'] ) ? stripslashes( esc_attr( $input['twitterId'] ) ) : '';
+	$output['snsBtn_ignorePosts']          = ! empty( $input['snsBtn_ignorePosts'] ) ? preg_replace( '/[^0-9,]/', '', esc_attr( $input['snsBtn_ignorePosts'] ) ) : '';
 	$output['snsTitle_use_only_postTitle'] = ( isset( $input['snsTitle_use_only_postTitle'] ) && $input['snsTitle_use_only_postTitle'] ) ? true : false;
 	$output['enableOGTags']                = ( isset( $input['enableOGTags'] ) && $input['enableOGTags'] ) ? true : false;
 	$output['enableTwitterCardTags']       = ( isset( $input['enableTwitterCardTags'] ) && $input['enableTwitterCardTags'] ) ? true : false;
@@ -242,7 +242,7 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output['snsBtn_exclude_post_types']   = ( isset( $input['snsBtn_exclude_post_types'] ) ) ? $input['snsBtn_exclude_post_types'] : '';
 	$output['snsBtn_position']             = ( isset( $input['snsBtn_position'] ) ) ? $input['snsBtn_position'] : '';
 	$output['enableFollowMe']              = ( isset( $input['enableFollowMe'] ) && $input['enableFollowMe'] ) ? true : false;
-	$output['followMe_title']              = stripslashes( $input['followMe_title'] );
+	$output['followMe_title']              = ! empty( $input['followMe_title'] ) ? stripslashes( $input['followMe_title'] ) : '';
 	$output['useFacebook']                 = ( isset( $input['useFacebook'] ) && $input['useFacebook'] == 'true' );
 	$output['useTwitter']                  = ( isset( $input['useTwitter'] ) && $input['useTwitter'] == 'true' );
 	$output['useBluesky']                  = ( isset( $input['useBluesky'] ) && $input['useBluesky'] == 'true' );
@@ -250,9 +250,9 @@ function vkExUnit_sns_options_validate( $input ) {
 	$output['usePocket']                   = ( isset( $input['usePocket'] ) && $input['usePocket'] == 'true' );
 	$output['useCopy']                     = ( isset( $input['useCopy'] ) && $input['useCopy'] == 'true' );
 	$output['useLine']                     = ( isset( $input['useLine'] ) && $input['useLine'] == 'true' );
-	$output['entry_count']                 = esc_attr( $input['entry_count'] );
+	$output['entry_count']                 = ! empty( $input['entry_count'] ) ? esc_attr( $input['entry_count'] ) : '';
 
-	$output['hook_point'] = esc_html( $input['hook_point'] );
+	$output['hook_point'] = ! empty( $input['hook_point'] ) ? esc_html( $input['hook_point'] ) : '';
 	$output['hook_point'] = str_replace( array( ' ', '　', "\t", "\r\n", "\r", "\n", ',' ), "\n", $output['hook_point'] );
 	$output['hook_point'] = str_replace( "\n\n", "\n", $output['hook_point'] );
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ e.g.
 
 == Changelog ==
 
-[ Bug Fix ][ SNS ] Fix Worning on ExUnit Main Setting screen.
+[ Bug Fix ][ SNS ] Fix Warning on ExUnit Main Setting screen.
 
 = 9.106.0 =
 [ Specification change ][ Follow Me Box ] Change default text and design tuning

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ SNS ] Fix Worning on ExUnit Main Setting screen.
+
 = 9.106.0 =
 [ Specification change ][ Follow Me Box ] Change default text and design tuning
 [ Specification change ][ Blocks ] Disable all links except for edit links.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1190

## どういう変更をしたか？

- SNS が原因で ExUnit Main Setting で Warning が出ないようにしました。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [x] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [x] 情報意味を考慮した意味グルーピング・余白になっているか？
- [x] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ ⇒ Warning の対処のみなので省略
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- ExUnit Main Setting の SNS の欄で Warning が出ないこと
- ExUnit Main Setting の SNS の欄で全て空欄にして保存しても Warning が出ないこと
- ExUnit Main Setting の SNS の欄を適当に埋めて値が保存されていること

上記を確認しました。

## 確認URL

ローカル環境

## レビュワーの確認方法・確認する内容など

- ExUnit Main Setting の SNS の欄で Warning が出ないこと
- ExUnit Main Setting の SNS の欄で全て空欄にして保存しても Warning が出ないこと
- ExUnit Main Setting の SNS の欄を適当に埋めて値が保存されていること

上記を確認お願いします。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
