### PR TITLE
[ 不具合修正 ][ カスタム投稿タイプ設定 ] 埋め込み設定のチェックボックスにチェックを入れても保存されないのを解消

### DIFF
--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -432,7 +432,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			}
 
 			// Save is_embeddable option
-			$is_embeddable = isset( $_POST['veu_is_embeddable'] ) ? 'true' : 'false';
+			$is_embeddable = isset( $_POST['veu_is_embeddable'] ) ? 'false' : 'true';
 			update_post_meta( $post_id, 'veu_is_embeddable', $is_embeddable );
 
 			// 保存しているカスタムフィールド.
@@ -558,7 +558,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 
 						// Add is_embeddable option
 						$is_embeddable         = get_post_meta( $post->ID, 'veu_is_embeddable', true );
-						$args['is_embeddable'] = ( 'false' === $is_embeddable ) ? false : true;
+						$args['is_embeddable'] = ( 'false' !== $is_embeddable );
 
 						// カスタム投稿タイプを発行.
 						register_post_type( $post_type_id, $args );

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -558,7 +558,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 
 						// Add is_embeddable option
 						$is_embeddable         = get_post_meta( $post->ID, 'veu_is_embeddable', true );
-						$args['is_embeddable'] = ( 'false' !== $is_embeddable );
+						$args['is_embeddable'] = ( 'false' === $is_embeddable );
 
 						// カスタム投稿タイプを発行.
 						register_post_type( $post_type_id, $args );

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -558,7 +558,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 
 						// Add is_embeddable option
 						$is_embeddable         = get_post_meta( $post->ID, 'veu_is_embeddable', true );
-						$args['is_embeddable'] = ( 'false' === $is_embeddable );
+						$args['is_embeddable'] = ( 'false' !== $is_embeddable );
 
 						// カスタム投稿タイプを発行.
 						register_post_type( $post_type_id, $args );

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Post Type Manager ] Fix is_embeddable checkbox not saving properly.
+
 = 9.107.0 =
 [ Add setting ][ Post Type Manager ] Add is_embeddable support for oEmbed control on WP6.8
 [ Specification Change ][ HTML Sitemap ] Add CSS to create a two-column layout.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

配信中の最新のカスタム投稿タイプ設定で埋め込み設定（任意）にチェックを入れても保存できませんでした。

## どういう変更をしたか？

チェックを付けて保存しても、保存後にチェックが外れてしまっていた原因は、
チェック時に `'true'` を保存していたため、内部的には `is_embeddable = true（埋め込みOK）` と解釈されてしまい、
チェックボックスが「外れて表示される」という逆転現象が起きていました。

本来このチェックボックスは「埋め込みを無効にしたいときにチェックを入れる」仕様なので、
チェックされていたら `'false'` を保存し、`('false' !== $is_embeddable)` によって
`is_embeddable = false` と解釈されるように修正しました。

以前のプルリクでは直していたのですが、途中バージョン変更をする際に古いデータで書き換えていたかもしれません。
すみません。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？ → スキップ
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？ → スキップ

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？ → スキップ
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？ → スキップ
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？ → スキップ

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ → スキップ
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？ → スキップ

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. カスタム投稿タイプ設定で「外部サイトからの埋め込み（oEmbed）を許可しない」がチェックでき、保存後もチェックのままになっていることを確認
2. カスタム投稿タイプ設定で「外部サイトからの埋め込み（oEmbed）を許可しない」がチェックを外し、保存後もチェックが外れていることを確認
3. 以下のサイトでチェックの有無によって埋め込めるか否かを確認
   ※ 以前以下のドメインのサイトを埋め込みで貼り付けたことのあるサイトではキャッシュで昔の情報が参照される恐れがあります。
   - 外部サイトからの埋め込み（oEmbed）を許可しないチェックをした投稿タイプ
   https://demo.dev3.biz/portfolio-basic/test/tesuto/
   - 外部サイトからの埋め込み（oEmbed）を許可しないにチェックをしていない投稿タイプ
    https://demo.dev3.biz/portfolio-basic/works/is_embeddable-true/
4. AIによるコードチェックで、チェックの有無によりis_embeddableが適切に切り替わることを確認

## 確認URL

https://demo.dev3.biz/portfolio-basic/works/is_embeddable-true/

## レビュワーの確認方法・確認する内容など

実装者の確認の1〜3と同じ確認を行ってください。

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
