### PR TITLE
[ 不具合修正 ][ シェアボタン ] Snow Monky Forms で Form タグの中に表示されてしまうシェアボタンを削除するようにしました

### DIFF
--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -224,7 +224,9 @@ function veu_get_sns_btns( $attr = array() ) {
 			$classes .= ' ' . $attr['className'];
 		}
 
-		$social_btns = '<div class="veu_socialSet' . esc_attr( $classes ) . ' veu_contentAddSection"><script>window.twttr=(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return t;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));</script><ul>';
+		$auto_class = ( isset( $attr['auto'] ) && $attr['auto'] ) ? ' veu_socialSet-auto' : '';
+	
+		$social_btns = '<div class="veu_socialSet' . $auto_class . esc_attr( $classes ) . ' veu_contentAddSection"><script>window.twttr=(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return t;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));</script><ul>';
 		// facebook.
 		if ( ! empty( $options['useFacebook'] ) ) {
 			$social_btns .= '<li class="sb_facebook sb_icon">';
@@ -333,36 +335,36 @@ function veu_add_sns_btns( $content ) {
 		return $content;
 	}
 
-	// フォーム内のSNSボタンを削除
+	// フォーム内の自動挿入SNSボタンを表示しない.
 	if ( strpos( $content, '<form' ) !== false ) {
-		// フォームの開始位置と終了位置を特定
 		$form_start = strpos( $content, '<form' );
 		if ( preg_match( '/<\/form>/', $content, $matches, PREG_OFFSET_CAPTURE, $form_start ) ) {
 			$form_end = $matches[0][1] + strlen( $matches[0][0] );
 		} else {
-			return $content; // </form>が見つからない場合
+			return $content; // </form> が見つからない場合はそのまま返す
 		}
 
-		// フォーム内のコンテンツを取得し、SNSボタンを削除
-		$form_content = preg_replace( '/<div class="veu_socialSet.*?<\/div>/s', '', substr( $content, $form_start, $form_end - $form_start ) );
+		$form_inner = substr( $content, $form_start, $form_end - $form_start );
 
-		// フォームの外のコンテンツを取得
-		$before_form = substr( $content, 0, $form_start );
-		$after_form  = substr( $content, $form_end );
+		// veu_socialSet-auto クラスを含む要素だけ削除（ブロックは残す）
+		$form_inner_cleaned = preg_replace(
+			'/<div[^>]+class="[^"]*veu_socialSet-auto[^"]*"[^>]*>.*?<\/div>/s',
+			'',
+			$form_inner
+		);
 
-		// フォームの外にSNSボタンを追加
-		$content = $before_form . $form_content . $after_form;
+		$content = substr( $content, 0, $form_start ) . $form_inner_cleaned . substr( $content, $form_end );
 	}
 
 	if ( veu_is_sns_btns_display() ) {
 		$options = veu_get_sns_options();
 
 		if ( ! empty( $options['snsBtn_position']['before'] ) ) {
-			$content = veu_get_sns_btns( array( 'position' => 'before' ) ) . $content;
+			$content = veu_get_sns_btns( array( 'position' => 'before', 'auto' => true ) ) . $content;
 		}
 
 		if ( ! empty( $options['snsBtn_position']['after'] ) ) {
-			$content .= veu_get_sns_btns( array( 'position' => 'after' ) );
+			$content .= veu_get_sns_btns( array( 'position' => 'after', 'auto' => true ) );
 		}
 	}
 

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -90,10 +90,10 @@ function veu_is_sns_btns_auto_insert() {
  * @return bool
  */
 function veu_is_sns_btns_display() {
-	$options = veu_get_sns_options();
-	$post_type = vk_get_post_type();
-	$post_type = $post_type['slug'];
-
+	$options               = veu_get_sns_options();
+	$post_type             = vk_get_post_type();
+	$post_type             = $post_type['slug'];
+	// カスタムフィールドで非表示の場合は表示しない
 	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
 	if ( ! empty( $sns_share_button_hide ) ) {
 		return false;
@@ -308,6 +308,7 @@ function veu_get_sns_btns( $attr = array() ) {
  * @return string $content add sns btns
  */
 function veu_add_sns_btns( $content ) {
+
 	// ウィジェットなら表示しない.
 	global $is_pagewidget;
 	if ( $is_pagewidget ) {
@@ -326,26 +327,7 @@ function veu_add_sns_btns( $content ) {
 		return $content;
 	}
 
-	// フォーム内のSNSボタンを削除
-	if ( strpos( $content, '<form' ) !== false ) {
-		// フォームの開始位置と終了位置を特定
-		$form_start = strpos( $content, '<form' );
-		if ( preg_match('/<\/form>/', $content, $matches, PREG_OFFSET_CAPTURE, $form_start) ) {
-			$form_end = $matches[0][1] + strlen($matches[0][0]);
-		} else {
-			return $content; // </form>が見つからない場合
-		}
 
-		// フォーム内のコンテンツを取得し、SNSボタンを削除
-		$form_content = preg_replace('/<div class="veu_socialSet.*?<\/div>/s', '', substr( $content, $form_start, $form_end - $form_start ));
-
-		// フォームの外のコンテンツを取得
-		$before_form = substr( $content, 0, $form_start );
-		$after_form = substr( $content, $form_end );
-
-		// フォームの外にSNSボタンを追加
-		$content = $before_form . $form_content . $after_form;
-	}
 
 	if ( veu_is_sns_btns_display() ) {
 		$options = veu_get_sns_options();

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -90,10 +90,10 @@ function veu_is_sns_btns_auto_insert() {
  * @return bool
  */
 function veu_is_sns_btns_display() {
-	$options               = veu_get_sns_options();		$options   = veu_get_sns_options();
-	$post_type             = vk_get_post_type();		$post_type = vk_get_post_type();
-	$post_type             = $post_type['slug'];		$post_type = $post_type['slug'];
-	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );	
+	$options               = veu_get_sns_options();
+	$post_type             = vk_get_post_type();
+	$post_type             = $post_type['slug'];
+	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
 	// カスタムフィールドで非表示の場合は表示しない
 	if ( ! empty( $sns_share_button_hide ) ) {
 		return false;

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -90,11 +90,11 @@ function veu_is_sns_btns_auto_insert() {
  * @return bool
  */
 function veu_is_sns_btns_display() {
-	$options   = veu_get_sns_options();
-	$post_type = vk_get_post_type();
-	$post_type = $post_type['slug'];
+	$options               = veu_get_sns_options();		$options   = veu_get_sns_options();
+	$post_type             = vk_get_post_type();		$post_type = vk_get_post_type();
+	$post_type             = $post_type['slug'];		$post_type = $post_type['slug'];
+	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );	
 	// カスタムフィールドで非表示の場合は表示しない
-	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
 	if ( ! empty( $sns_share_button_hide ) ) {
 		return false;
 	}

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -94,6 +94,12 @@ function veu_is_sns_btns_display() {
 	$post_type             = vk_get_post_type();
 	$post_type             = $post_type['slug'];
 	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
+
+	// メインループ外なら除外
+	if ( ! apply_filters( 'veu_sns_btns_check_mainloop', in_the_loop() && is_main_query() ) ) {
+		return false;
+	}
+	
 	// カスタムフィールドで非表示の場合は表示しない
 	if ( ! empty( $sns_share_button_hide ) ) {
 		return false;

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -90,11 +90,11 @@ function veu_is_sns_btns_auto_insert() {
  * @return bool
  */
 function veu_is_sns_btns_display() {
-	$options               = veu_get_sns_options();
-	$post_type             = vk_get_post_type();
-	$post_type             = $post_type['slug'];
+	$options = veu_get_sns_options();
+	$post_type = vk_get_post_type();
+	$post_type = $post_type['slug'];
+
 	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
-	// カスタムフィールドで非表示の場合は表示しない
 	if ( ! empty( $sns_share_button_hide ) ) {
 		return false;
 	}
@@ -209,6 +209,7 @@ function veu_get_sns_btns( $attr = array() ) {
 
 	$classes     = '';
 	$social_btns = '';
+
 	// 個別の記事で ボタンを表示する指定にしてある場合 or サイトエディターの場合.
 	if ( veu_is_sns_btns_display() || false !== strpos( $current_url, 'context=edit' ) ) {
 		if ( function_exists( 'veu_add_common_attributes_class' ) ) {
@@ -307,7 +308,6 @@ function veu_get_sns_btns( $attr = array() ) {
  * @return string $content add sns btns
  */
 function veu_add_sns_btns( $content ) {
-
 	// ウィジェットなら表示しない.
 	global $is_pagewidget;
 	if ( $is_pagewidget ) {
@@ -324,6 +324,27 @@ function veu_add_sns_btns( $content ) {
 	// アーカイブページでも表示しない.
 	if ( is_archive() ) {
 		return $content;
+	}
+
+	// フォーム内のSNSボタンを削除
+	if ( strpos( $content, '<form' ) !== false ) {
+		// フォームの開始位置と終了位置を特定
+		$form_start = strpos( $content, '<form' );
+		if ( preg_match('/<\/form>/', $content, $matches, PREG_OFFSET_CAPTURE, $form_start) ) {
+			$form_end = $matches[0][1] + strlen($matches[0][0]);
+		} else {
+			return $content; // </form>が見つからない場合
+		}
+
+		// フォーム内のコンテンツを取得し、SNSボタンを削除
+		$form_content = preg_replace('/<div class="veu_socialSet.*?<\/div>/s', '', substr( $content, $form_start, $form_end - $form_start ));
+
+		// フォームの外のコンテンツを取得
+		$before_form = substr( $content, 0, $form_start );
+		$after_form = substr( $content, $form_end );
+
+		// フォームの外にSNSボタンを追加
+		$content = $before_form . $form_content . $after_form;
 	}
 
 	if ( veu_is_sns_btns_display() ) {

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -94,11 +94,6 @@ function veu_is_sns_btns_display() {
 	$post_type             = vk_get_post_type();
 	$post_type             = $post_type['slug'];
 	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
-
-	// メインループ外なら除外
-	if ( ! apply_filters( 'veu_sns_btns_check_mainloop', in_the_loop() && is_main_query() ) ) {
-		return false;
-	}
 	
 	// カスタムフィールドで非表示の場合は表示しない
 	if ( ! empty( $sns_share_button_hide ) ) {
@@ -330,6 +325,11 @@ function veu_add_sns_btns( $content ) {
 
 	// アーカイブページでも表示しない.
 	if ( is_archive() ) {
+		return $content;
+	}
+
+	// フォーム内など不適切なループ外で混入するのを防ぐ
+	if ( ! apply_filters( 'veu_sns_btns_check_mainloop', in_the_loop() && is_main_query() ) ) {
 		return $content;
 	}
 

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -90,9 +90,9 @@ function veu_is_sns_btns_auto_insert() {
  * @return bool
  */
 function veu_is_sns_btns_display() {
-	$options               = veu_get_sns_options();
-	$post_type             = vk_get_post_type();
-	$post_type             = $post_type['slug'];
+	$options   = veu_get_sns_options();
+	$post_type = vk_get_post_type();
+	$post_type = $post_type['slug'];
 	// カスタムフィールドで非表示の場合は表示しない
 	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
 	if ( ! empty( $sns_share_button_hide ) ) {
@@ -327,7 +327,26 @@ function veu_add_sns_btns( $content ) {
 		return $content;
 	}
 
+	// フォーム内のSNSボタンを削除
+	if ( strpos( $content, '<form' ) !== false ) {
+		// フォームの開始位置と終了位置を特定
+		$form_start = strpos( $content, '<form' );
+		if ( preg_match( '/<\/form>/', $content, $matches, PREG_OFFSET_CAPTURE, $form_start ) ) {
+			$form_end = $matches[0][1] + strlen( $matches[0][0] );
+		} else {
+			return $content; // </form>が見つからない場合
+		}
 
+		// フォーム内のコンテンツを取得し、SNSボタンを削除
+		$form_content = preg_replace( '/<div class="veu_socialSet.*?<\/div>/s', '', substr( $content, $form_start, $form_end - $form_start ) );
+
+		// フォームの外のコンテンツを取得
+		$before_form = substr( $content, 0, $form_start );
+		$after_form  = substr( $content, $form_end );
+
+		// フォームの外にSNSボタンを追加
+		$content = $before_form . $form_content . $after_form;
+	}
 
 	if ( veu_is_sns_btns_display() ) {
 		$options = veu_get_sns_options();

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -94,7 +94,7 @@ function veu_is_sns_btns_display() {
 	$post_type             = vk_get_post_type();
 	$post_type             = $post_type['slug'];
 	$sns_share_button_hide = get_post_meta( get_the_ID(), 'sns_share_botton_hide', true );
-	
+
 	// カスタムフィールドで非表示の場合は表示しない
 	if ( ! empty( $sns_share_button_hide ) ) {
 		return false;
@@ -225,7 +225,7 @@ function veu_get_sns_btns( $attr = array() ) {
 		}
 
 		$auto_class = ( isset( $attr['auto'] ) && $attr['auto'] ) ? ' veu_socialSet-auto' : '';
-	
+
 		$social_btns = '<div class="veu_socialSet' . $auto_class . esc_attr( $classes ) . ' veu_contentAddSection"><script>window.twttr=(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return t;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));</script><ul>';
 		// facebook.
 		if ( ! empty( $options['useFacebook'] ) ) {
@@ -360,11 +360,21 @@ function veu_add_sns_btns( $content ) {
 		$options = veu_get_sns_options();
 
 		if ( ! empty( $options['snsBtn_position']['before'] ) ) {
-			$content = veu_get_sns_btns( array( 'position' => 'before', 'auto' => true ) ) . $content;
+			$content = veu_get_sns_btns(
+				array(
+					'position' => 'before',
+					'auto'     => true,
+				)
+			) . $content;
 		}
 
 		if ( ! empty( $options['snsBtn_position']['after'] ) ) {
-			$content .= veu_get_sns_btns( array( 'position' => 'after', 'auto' => true ) );
+			$content .= veu_get_sns_btns(
+				array(
+					'position' => 'after',
+					'auto'     => true,
+				)
+			);
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ SNS Buttons ] Fixed SNS buttons from being displayed inside forms.
+
 = 9.108.1 =
 [ Bug Fix ][ Meta Description ] Refactor meta-description.php to improve excerpt support and sanitize function
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ e.g.
 
 == Changelog ==
 
-[ Bug Fix ][ SNS Buttons ] Fixed SNS buttons from being displayed inside forms.
+[ Bug Fix ][ Share button ] Fixed share buttons from being displayed inside forms.
 
 = 9.108.1 =
 [ Bug Fix ][ Meta Description ] Refactor meta-description.php to improve excerpt support and sanitize function


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1211 

## どういう変更をしたか？

Snow Monkey Forms の <form> 要素内部に veu_socialSet クラスのシェアボタンが混入してしまう不具合を修正しました。
Snow Monkey Forms 以外でも、Formタグに入ってしまうことがあるかもしれないため、以下2点の対策を `veu_add_sns_btns() `に追加しました。

1. フォーム内混入の削除処理
`the_content` に挿入された シェアボタンが `<form>`タグ内に入り込むことを避けるため、`</form>` タグの位置を特定し、その範囲内から `veu_socialSet` を含む`<div> `を削除する処理を追加。
これまでは条件分岐のみで`the_content`に入るか否かを決めていたが、Formでは対応が難しかったため、自動挿入の時には `veu_socialSet-auto` というクラスを追加して、そのクラスが入ったシェアボタンを削除するように動作。

2. メインループ・メインクエリでない場合の挿入防止
シェアボタンが本文の前か後に入るのが前提のため、意図せずthe_contentが呼び出されている場合は挿入を防止するようにしました。
- in_the_loop() && is_main_query() を通過しない場合は、シェアボタンを追加しないように制御。
- フィルターフック veu_sns_btns_check_mainloop によって開発者が任意に条件を緩和できるように設計。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

### スクリーンショットまたは動画
#### 変更前 Before
![スクリーンショット 2025-05-21 10 37 09](https://github.com/user-attachments/assets/b020271d-650e-42c3-8297-1163147f3d9d)
![スクリーンショット 2025-05-21 10 37 30](https://github.com/user-attachments/assets/68e34d9a-a846-464e-85ee-f4e625154222)
![スクリーンショット 2025-05-21 10 37 36](https://github.com/user-attachments/assets/b660d2d2-6c61-48f9-87bb-d17ebd5beaa2)

#### 変更後 Before
![スクリーンショット 2025-05-21 10 38 41](https://github.com/user-attachments/assets/a04c6327-eaa5-4048-aceb-f7b12687293d)
![スクリーンショット 2025-05-21 10 38 49](https://github.com/user-attachments/assets/433bc089-369b-4bf3-b679-1f188b217337)
![スクリーンショット 2025-05-21 10 39 00](https://github.com/user-attachments/assets/4f629f0d-4044-4795-b61d-97a92cbb0fb8)

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？ → スキップ
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？ → スキップ
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？ → スキップ

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ → 現状で通るかを`npm run phpunit`で確認済みのためスキップ
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？ → 現状で通るかを`npm run phpunit`で確認済みのためスキップ

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

### 前提
ExUnit > メイン設定 > SNS > ソーシャルボタン で以下の状態に設定
- 自動挿入にチェック
- シェアボタンを表示しない投稿タイプのチェックは全てしない

### 確認項目
- Snow Monkey Forms を固定ページに設置し、入力画面、送信画面、確認画面、送信エラー画面のFormタグの中に、シェアボタンが混入しないことを確認
(「シェアボタンを表示しない投稿タイプのチェックは全てしない」ためthe_contentの下に一つ表示される)
- 投稿や通常の固定ページでは自動挿入された シェアボタンが正常に表示されることも確認
- Snow Monkey Formsを貼り付けた固定ページの編集画面のメタボックスで「ソーシャルボタンを表示しない」にチェックした場合は、すべてのシェアボタンが表示されなくなることを確認
- シェアボタンブロックを用いてSnow Monkey Forms内に挿入した場合は、上記の影響を受けないことを確認

## 確認URL

https://demo.dev3.biz/bodysalon/%e3%83%86%e3%82%b9%e3%83%88snow-monkey-forms/
いつものでログインしてご確認ください。フォームを送信後、管理者宛のメールはvkサポートに送られます。

## レビュワーの確認方法・確認する内容など

変更コードや方針等も含め、確認項目をご確認いただけたらと思います。
確認URLでご確認いただくのが早いかと思います。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
