### PR TITLE
[ 不具合修正 ][ タイトルタグ ] description が未登録の場合はセパレーターを表示しないように変更

### DIFF
--- a/inc/wp-title/package/wp-title.php
+++ b/inc/wp-title/package/wp-title.php
@@ -43,7 +43,11 @@ function vkExUnit_get_wp_head_title() {
 		if ( is_front_page() ) {
 			$options = vkExUnit_get_wp_title_options();
 			if ( empty( $options['extend_frontTitle'] ) ) {
-				$title = get_bloginfo( 'name' ) . $sep . get_bloginfo( 'description' );
+				$description = get_bloginfo( 'description' );
+				$title       = get_bloginfo( 'name' );
+				if ( ! empty( $description ) ) {
+					$title .= $sep . $description;
+				}
 			} else {
 				$title = $options['extend_frontTitle'];
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Title Tag ] Prevent the separator from appearing on the front page when the site description is empty.
+
 = 9.112.1 =
 [ Bug Fix ][ Default Thumbnail ] Fix issue where default thumbnail appears in media library list view.
 

--- a/tests/test-wp-title.php
+++ b/tests/test-wp-title.php
@@ -216,6 +216,20 @@ class WpTitleTest extends WP_UnitTestCase {
 				),
 				'expected'      => 'ExUnit Front Page Title',
 			),
+			// トップページ / サイトの説明が空
+			// Return : サイト名のみ（セパレータなし）
+			array(
+				'target_url'    => home_url( '/' ),
+				'target_id'     => $test_posts['front_page_id'],
+				'options'       => array(
+					'blogname'          => 'Site name',
+					'blogdescription'   => '',
+					'show_on_front'     => 'posts',
+					'vkExUnit_wp_title' => array(),
+				),
+				'custom_fields' => array(),
+				'expected'      => 'Site name',
+			),
 			/***********************************************************
 			 * トップページ仕様変更
 			 *


### PR DESCRIPTION
## 変更の目的・理由

最近のWordPressはデフォルトでサイトのキャッチコピーが空なので、トップページのタイトルタグが、
「サイト名 | 」のようにセパレーターで終わった状態になる。

## 実装内容

サイトキャッチコピーがない場合はセパレーターを出力しないように変更

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み
- [x] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順
<!-- レビュワーがテストする際の手順を記載してください -->

1. サイトの説明を未記入にしてトップページのタイトルタグを確認

### 動作確認時の注意事項
<!-- レビュー時に変更が反映されない場合の確認項目 -->

- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

### 追加の確認事項
<!-- 必要に応じて追加の確認項目を記載 -->