### PR TITLE
[ 開発環境 ] CI/CDワークフローをフェーズ0 C-7 要件に対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,6 @@ jobs:
               with:
                   name: dist
                   path: dist/
-            - name: Create zip
-              run: cd dist && zip -r ${{ env.plugin_name }}.zip ${{ env.plugin_name }}/
             - name: Create Release
               # softprops/action-gh-release v2.6.1 / v2
               uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe


### PR DESCRIPTION
## 概要

vektor-inc/multi-repo-tasks#5 の対応。

フェーズ0 C-7 要件に未対応だったCI/CDワークフローを修正。

## 変更内容

- PHPUnit を dist に対してテストするよう修正（ソースコードではなく配布物でテスト）
- `php_unit` ジョブに dist へテスト依存ファイル（`vendor/`・`tests/`・phpunit設定）をコピーするステップを追加
- `upload-artifact` / `download-artifact` でジョブ間のアーティファクト共有を実現
- deploy/release ジョブで再ビルドせず smoke_test で作成した dist を使用
- wp-env のリトライループに `exit 1` を追加
- `release` ジョブの zip 再作成を廃止し、`npm run dist` が生成した zip を直接使用

## テスト

- [ ] ワークフローの YAML 構文が正しいか確認
- [ ] release ジョブで zip を再作成していないことを確認

関連: vektor-inc/multi-repo-tasks#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)