### PR TITLE
[ 不具合修正 ] メタボックス保存処理の入力サニタイズを適切な関数に修正

### DIFF
--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -136,7 +136,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 		public static function save_custom_field( $post_id ) {
 			if ( ! isset( $_POST['_vkExUnit_cta_switch'] ) ) {
 				return $post_id; }
-			$noonce = isset( $_POST['_nonce_vkExUnit_custom_cta'] ) ? htmlspecialchars( $_POST['_nonce_vkExUnit_custom_cta'] ) : null;
+			$noonce = isset( $_POST['_nonce_vkExUnit_custom_cta'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce_vkExUnit_custom_cta'] ) ) : null;
 
 			// if autosave is to deny.
 			if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {

--- a/inc/child-page-index/child-page-index.php
+++ b/inc/child-page-index/child-page-index.php
@@ -156,7 +156,7 @@ save_custom_field
 /*-------------------------------------------*/
 add_action( 'save_post', 'veu_child_page_index_save_custom_field' );
 function veu_child_page_index_save_custom_field( $post_id ) {
-	$childPageIndex = isset( $_POST['_nonce_vkExUnit__custom_field_childPageIndex'] ) ? htmlspecialchars( $_POST['_nonce_vkExUnit__custom_field_childPageIndex'] ) : null;
+	$childPageIndex = isset( $_POST['_nonce_vkExUnit__custom_field_childPageIndex'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce_vkExUnit__custom_field_childPageIndex'] ) ) : null;
 
 	if ( ! wp_verify_nonce( $childPageIndex, plugin_basename( __FILE__ ) ) ) {
 		return $post_id;
@@ -165,7 +165,7 @@ function veu_child_page_index_save_custom_field( $post_id ) {
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 		return $post_id; }
 
-	$data = isset( $_POST['vkExUnit_childPageIndex'] ) ? htmlspecialchars( $_POST['vkExUnit_childPageIndex'] ) : null;
+	$data = isset( $_POST['vkExUnit_childPageIndex'] ) ? sanitize_text_field( wp_unslash( $_POST['vkExUnit_childPageIndex'] ) ) : null;
 
 	if ( 'page' == $data ) {
 		if ( ! current_user_can( 'edit_page', $post_id ) ) {

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -274,9 +274,9 @@ class VkExUnit_Contact {
 
 
 	public function save_custom_field_postdata( $post_id ) {
-		$childPageIndex = isset( $_POST['_nonce_vkExUnit_contact'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce_vkExUnit_contact'] ) ) : null;
+		$contact_nonce = isset( $_POST['_nonce_vkExUnit_contact'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce_vkExUnit_contact'] ) ) : null;
 
-		if ( ! wp_verify_nonce( $childPageIndex, plugin_basename( __FILE__ ) ) ) {
+		if ( ! wp_verify_nonce( $contact_nonce, plugin_basename( __FILE__ ) ) ) {
 			return $post_id;
 		}
 

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -274,7 +274,7 @@ class VkExUnit_Contact {
 
 
 	public function save_custom_field_postdata( $post_id ) {
-		$childPageIndex = isset( $_POST['_nonce_vkExUnit_contact'] ) ? htmlspecialchars( $_POST['_nonce_vkExUnit_contact'] ) : null;
+		$childPageIndex = isset( $_POST['_nonce_vkExUnit_contact'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce_vkExUnit_contact'] ) ) : null;
 
 		if ( ! wp_verify_nonce( $childPageIndex, plugin_basename( __FILE__ ) ) ) {
 			return $post_id;
@@ -284,7 +284,7 @@ class VkExUnit_Contact {
 			return $post_id;
 		}
 
-		$data = isset( $_POST['vkExUnit_contact_enable'] ) ? htmlspecialchars( $_POST['vkExUnit_contact_enable'] ) : null;
+		$data = isset( $_POST['vkExUnit_contact_enable'] ) ? sanitize_text_field( wp_unslash( $_POST['vkExUnit_contact_enable'] ) ) : null;
 
 		if ( 'page' == $data ) {
 			if ( ! current_user_can( 'edit_page', $post_id ) ) {

--- a/inc/page-list-ancestor/page-list-ancestor.php
+++ b/inc/page-list-ancestor/page-list-ancestor.php
@@ -124,7 +124,7 @@ save_custom_field
 add_action( 'save_post', 'veu_page_list_ancestor_save_custom_field' );
 function veu_page_list_ancestor_save_custom_field( $post_id ) {
 
-	$pageList_ancestor = isset( $_POST['_nonce_vkExUnit__custom_field_pageList_ancestor'] ) ? htmlspecialchars( $_POST['_nonce_vkExUnit__custom_field_pageList_ancestor'] ) : null;
+	$pageList_ancestor = isset( $_POST['_nonce_vkExUnit__custom_field_pageList_ancestor'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce_vkExUnit__custom_field_pageList_ancestor'] ) ) : null;
 
 	if ( ! wp_verify_nonce( $pageList_ancestor, plugin_basename( __FILE__ ) ) ) {
 		return $post_id;
@@ -133,7 +133,7 @@ function veu_page_list_ancestor_save_custom_field( $post_id ) {
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 		return $post_id; }
 
-	$mydata = isset( $_POST['vkExUnit_pageList_ancestor'] ) ? htmlspecialchars( $_POST['vkExUnit_pageList_ancestor'] ) : null;
+	$mydata = isset( $_POST['vkExUnit_pageList_ancestor'] ) ? sanitize_text_field( wp_unslash( $_POST['vkExUnit_pageList_ancestor'] ) ) : null;
 
 	if ( 'page' == $mydata ) {
 		if ( ! current_user_can( 'edit_page', $post_id ) ) {

--- a/inc/sitemap-page/sitemap-page.php
+++ b/inc/sitemap-page/sitemap-page.php
@@ -278,7 +278,7 @@ function vkExUnit_sitemap_meta_box() {
 // save custom field sitemap
 add_action( 'save_post', 'vkExUnit_save_custom_field_sitemapData' );
 function vkExUnit_save_custom_field_sitemapData( $post_id ) {
-	$sitemap = isset( $_POST['_nonce_vkExUnit__custom_field_sitemap'] ) ? htmlspecialchars( $_POST['_nonce_vkExUnit__custom_field_sitemap'] ) : null;
+	$sitemap = isset( $_POST['_nonce_vkExUnit__custom_field_sitemap'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce_vkExUnit__custom_field_sitemap'] ) ) : null;
 
 	if ( ! wp_verify_nonce( $sitemap, plugin_basename( __FILE__ ) ) ) {
 			return $post_id;
@@ -287,7 +287,7 @@ function vkExUnit_save_custom_field_sitemapData( $post_id ) {
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 		return $post_id; }
 
-	$data = isset( $_POST['vkExUnit_sitemap'] ) ? htmlspecialchars( $_POST['vkExUnit_sitemap'] ) : null;
+	$data = isset( $_POST['vkExUnit_sitemap'] ) ? sanitize_text_field( wp_unslash( $_POST['vkExUnit_sitemap'] ) ) : null;
 
 	if ( 'page' == $data ) {
 		if ( ! current_user_can( 'edit_page', $post_id ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,8 @@ e.g.
 
 == Changelog ==
 
+[ Security Fix ] Replace htmlspecialchars() with sanitize_text_field( wp_unslash() ) for $_POST input sanitization in save_post handlers.
+
 = 9.113.6 =
 [ Specification Change ] Update vektor-inc/font-awesome-versions from 0.7.0 to 0.7.2
 [ Specification Change ] Update vektor-inc/vk-admin from 0.4.1 to 0.5.0


### PR DESCRIPTION
## 関連Issue
- 関連Issue: #1300

## 変更の目的・理由

メタボックスの `save_post` ハンドラで `$_POST` の値を `htmlspecialchars()` でサニタイズしていました。`htmlspecialchars()` は出力エスケープ用の関数であり、入力サニタイズには不適切です。WordPress 推奨の `sanitize_text_field( wp_unslash() )` に修正します。

## 実装内容

### 主な変更点
- [x] バグ修正

### 技術的な詳細

**原因:** 2020年の初期実装時から `htmlspecialchars( $_POST[...] )` パターンが使用されていた。その後の XSS 修正（出力エスケープ側）では修正されたが、入力サニタイズ側は見落とされていた。

**対策:** 全5ファイル9箇所の `htmlspecialchars()` を `sanitize_text_field( wp_unslash() )` に置き換え。

| ファイル | 修正箇所 |
|---|---|
| `inc/page-list-ancestor/page-list-ancestor.php` | nonce + データ（2箇所） |
| `inc/child-page-index/child-page-index.php` | nonce + データ（2箇所） |
| `inc/contact-section/contact-section.php` | nonce + データ（2箇所） |
| `inc/sitemap-page/sitemap-page.php` | nonce + データ（2箇所） |
| `inc/call-to-action/package/class-vk-call-to-action.php` | nonce（1箇所） |

## スクリーンショット

コードのみの変更のためスクリーンショットなし。

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [ ] 書けるテストは実装済み
- [x] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

### 最終確認
- [ ] このテンプレートの全項目を確認済み
- [ ] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順

#### 前提条件
- 固定ページが2件以上あること（親子関係のあるページが望ましい）
- VK ExUnit の以下の機能が有効であること: 子ページリスト、サイトマップページ、お問い合わせセクション、CTA

#### Before（修正前の問題）
`htmlspecialchars()` は入力サニタイズとして不適切。WPCS で指摘される。

#### After（修正後の確認手順）
1. 管理画面 > 固定ページ > 任意のページを編集画面で開く
2. 「先祖階層ページリスト」メタボックスのチェックを ON にする
3. 「更新」を押す
   → ✓ 設定が正しく保存される（再読み込み後もチェックが ON のまま）
4. 「子ページリスト」メタボックスのチェックを ON にする
5. 「更新」を押す
   → ✓ 設定が正しく保存される
6. 「お問い合わせセクション」メタボックスの「このページのお問い合わせ情報を非表示にする」を ON にする
7. 「更新」を押す
   → ✓ 設定が正しく保存される
8. 「サイトマップ」メタボックスのチェックを変更して保存する
   → ✓ 設定が正しく保存される
9. CTA の設定画面で CTA の切り替え設定を変更して保存する
   → ✓ 設定が正しく保存される
10. 公開側でページを確認する
   → ✓ 各機能の表示が設定通りに反映されている

### レビューポイント（任意）

- `htmlspecialchars()` → `sanitize_text_field( wp_unslash() )` の置換が正しいこと
- 既存の `post-type-manager` の実装（L618）と同じパターンであること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ修正**
  * フォーム入力のサニタイズ処理を改善しました。複数の箇所での入力値処理がより安全で堅牢になり、全体的なセキュリティが向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->