### PR TITLE
[ 不具合修正 ] distパッケージにbuildディレクトリが含まれず、ブロックエディタのサイドバーパネルが表示されない不具合を修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -189,6 +189,7 @@ gulp.task('dist', function() {
 				'./assets/**',
 				'./admin/**',
 				'./languages/**',
+				'./build/**',
 				"!./compile.bat",
 				"!./config.rb",
 				"!./tests/**",

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ e.g.
 
 [ Spec Change ] Migrate post editor settings UI to block editor sidebar panels
 [ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process
+[ Bug Fix ] Fixed block editor sidebar panels not appearing on sites installed from the dist zip because the build/ directory was excluded from the dist package.
 [ Other ] Replace htmlspecialchars() with sanitize_text_field( wp_unslash() ) for $_POST input sanitization in save_post handlers.
 
 = 9.113.6 =


### PR DESCRIPTION
## 関連PR
- #1304 (投稿編集画面の設定UIをブロックエディタのサイドバーに移行)

## 変更の目的・理由

#1304 で追加された PluginSidebar（`build/editor-panel/index.js`）が **`npm run zip` で生成される配布zipに含まれない** 不具合がある。このため、ローカルでは動作するが zip を別サイトに持ち込むとサイドバーパネルが表示されない。

### 原因

`gulpfile.js` の `dist` タスクのコピー対象 glob は、PHP/CSS/画像/`inc/`/`assets/`/`admin/` などの限定リストで、`./build/**` や `./**/*.js` を含んでいなかった。

既存ブロック（CTA、sitemap-page、SNS 等）は `inc/xxx/package/block/build/` のように `inc/` 配下に出力されるため `./inc/**` でカバーされていたが、今回の PluginSidebar は `webpack.panel.js` がルート直下の `build/editor-panel/` に出力するため、このパターンから外れて漏れていた。

配布zipには `./**/*.php` glob で `build/editor-panel/index.asset.php` のみ入り、`index.js` / `index.js.map` が抜け落ちる状態だった。

## 実装内容

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他

### 技術的な詳細

| ファイル | 変更内容 |
|---|---|
| `gulpfile.js` | `dist` タスクのコピー対象 glob に `'./build/**'` を追加 |
| `readme.txt` | Changelog に不具合修正エントリ追記 |

## 確認手順

### 前提条件
- このブランチをチェックアウトして `npm install` 済み
- 別サイトに持ち込んで動作確認できる WordPress 環境があること

### 手順

#### Before（修正前の再現手順）

1. `master` ブランチで `npm run zip` を実行
2. 生成された `dist/vk-all-in-one-expansion-unit.zip` を別サイトにアップロード・有効化
3. 投稿編集画面を開く
   → ✗ ツールバーのプラグインアイコンから開くサイドバーパネルが表示されない

#### After（修正後）

1. このブランチで `npm run zip` を実行
2. 生成された `dist/vk-all-in-one-expansion-unit.zip` を別サイトにアップロード・有効化
3. 投稿編集画面を開く
   → ✓ ツールバーにプラグインアイコンが表示され、クリックするとサイドバーパネル「VK All in One Expansion Unit」が開く
   → ✓ 各セクション（Promotion / SNS / noindex / Head Title / アイキャッチ / CTA / カスタムCSS 等）が操作可能

### 配布zipの中身の確認（簡易検証）

```bash
npm run zip
unzip -l dist/vk-all-in-one-expansion-unit.zip | grep build/editor-panel/
```

→ ✓ 以下の3ファイルが含まれていること
- `build/editor-panel/index.asset.php`
- `build/editor-panel/index.js`
- `build/editor-panel/index.js.map`

### デグレ確認

1. `dist/vk-all-in-one-expansion-unit/` 配下のファイル構成を master のzipと比較
   → ✓ 従来含まれていたファイルが漏れていない（`./build/**` は追加のみで除外ルールに影響なし）

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] ローカルで `gulp dist` を実行し、`build/editor-panel/index.js` が `dist/vk-all-in-one-expansion-unit/build/editor-panel/` にコピーされることを確認
- [x] 修正前の状態（stash）でも同じテストを実施し、index.js が抜け落ちる挙動を再現確認

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ブロックエディタのサイドバーパネルがdist版で正常に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->