### PR TITLE
[ 不具合修正 ] custom-fields 非対応の CPT で noindex 等の設定が保存時に外れる不具合を修正

### DIFF
--- a/admin/admin-post-metabox.php
+++ b/admin/admin-post-metabox.php
@@ -26,9 +26,27 @@ function veu_add_parent_metabox() {
 		);
 		$post_types = get_post_types( $args );
 
-		// Add parent meta box on exists post types
+		// Add parent meta box on exists post types.
+		// 投稿タイプごとに統合メタボックスを登録する。
 		foreach ( $post_types as $key => $post_type ) {
-			add_meta_box( 'veu_parent_post_metabox', $meta_box_name, 'veu_parent_metabox_body', $post_type, 'normal', 'high', array( '__back_compat_meta_box' => true ) );
+			// __back_compat_meta_box => true means "this metabox is replaced by a Block Editor
+			// equivalent, so hide it on Block Editor screens (still show on Classic Editor)".
+			// We only set this flag for post types that support 'custom-fields', because the
+			// new sidebar panel relies on REST API meta which WordPress only exposes when
+			// 'custom-fields' is supported. For post types without that support, the sidebar
+			// panel cannot save values, so we must NOT mark the legacy metabox as back-compat;
+			// it has to remain visible on the Block Editor screen as the working UI.
+			//
+			// __back_compat_meta_box => true は「ブロックエディタで代替されるので
+			// ブロックエディタ画面では非表示（クラシックエディタでは表示）」を意味する。
+			// サイドバーパネルは REST API メタに依存しており、これは 'custom-fields' を
+			// サポートする投稿タイプでのみ露出される。非対応の投稿タイプではサイドバー
+			// パネルから保存できないため、このフラグを付けてはならない（旧メタボックスを
+			// ブロックエディタ画面でも実働 UI として表示し続ける必要がある）。
+			$callback_args = post_type_supports( $post_type, 'custom-fields' )
+				? array( '__back_compat_meta_box' => true )
+				: null;
+			add_meta_box( 'veu_parent_post_metabox', $meta_box_name, 'veu_parent_metabox_body', $post_type, 'normal', 'high', $callback_args );
 		}
 	}
 	/*

--- a/inc/block-editor-panels/enqueue.php
+++ b/inc/block-editor-panels/enqueue.php
@@ -143,6 +143,16 @@ function veu_register_active_feature_meta() {
 		foreach ( $metas as $meta ) {
 			$target_post_types = isset( $meta['post_type'] ) ? array( $meta['post_type'] ) : $post_types;
 			foreach ( $target_post_types as $post_type ) {
+				// Skip post types that do not support 'custom-fields'.
+				// REST API does not expose meta on such post types, so register_post_meta would
+				// not be saved through the block editor sidebar panel. The legacy metabox is
+				// kept (via __back_compat_meta_box) and will be used as a fallback instead.
+				// 'custom-fields' をサポートしない投稿タイプはスキップする。
+				// REST API がメタを露出しないためサイドバーパネルから保存できないので、
+				// __back_compat_meta_box によって残された旧メタボックスにフォールバックさせる。
+				if ( ! post_type_supports( $post_type, 'custom-fields' ) ) {
+					continue;
+				}
 				$args = array(
 					'type'          => $meta['type'],
 					'single'        => true,
@@ -221,6 +231,25 @@ function veu_register_head_title_rest_field() {
 
 	$post_types = get_post_types( array( 'public' => true ) );
 
+	// Limit REST field registration to post types that support 'custom-fields'.
+	// Post types without this support do not expose meta via REST and cannot
+	// persist values from the sidebar panel; they fall back to the legacy metabox.
+	// 'custom-fields' をサポートする投稿タイプのみに REST フィールド登録を限定する。
+	// 非対応の投稿タイプは REST にメタを露出できずサイドバーから保存できないため、
+	// 旧メタボックスにフォールバックさせる。
+	$post_types = array_values(
+		array_filter(
+			$post_types,
+			function ( $post_type ) {
+				return post_type_supports( $post_type, 'custom-fields' );
+			}
+		)
+	);
+
+	if ( empty( $post_types ) ) {
+		return;
+	}
+
 	register_rest_field(
 		$post_types,
 		'veu_head_title_object',
@@ -275,6 +304,16 @@ function veu_enqueue_block_editor_panels() {
 	// 投稿エディタのみで読み込む（サイトエディタ・ウィジェットエディタでは不要）。
 	$screen = get_current_screen();
 	if ( ! $screen || ! $screen->is_block_editor || empty( $screen->post_type ) ) {
+		return;
+	}
+
+	// Bail out for post types without 'custom-fields' support.
+	// REST API hides meta on such post types, so the sidebar panel cannot
+	// persist values; the legacy metabox is shown instead as a fallback.
+	// 'custom-fields' をサポートしない投稿タイプでは早期リターンする。
+	// REST API がメタを隠すためサイドバーパネルから保存できず、
+	// 旧メタボックスへフォールバックさせる必要があるため。
+	if ( ! post_type_supports( $screen->post_type, 'custom-fields' ) ) {
 		return;
 	}
 
@@ -431,9 +470,20 @@ add_action( 'enqueue_block_editor_assets', 'veu_enqueue_block_editor_panels' );
  */
 function veu_remove_legacy_metabox_on_block_editor() {
 	$screen = get_current_screen();
-	if ( ! $screen || ! $screen->is_block_editor ) {
+	if ( ! $screen || ! $screen->is_block_editor || empty( $screen->post_type ) ) {
 		return;
 	}
+
+	// Keep the legacy metabox visible for post types without 'custom-fields' support.
+	// The sidebar panel cannot save values for these post types (REST API does not
+	// expose their meta), so the legacy metabox must remain as the working UI.
+	// 'custom-fields' をサポートしない投稿タイプでは旧メタボックスを残す。
+	// サイドバーパネルでは保存できない（REST API がメタを露出しない）ため、
+	// 旧メタボックスを実働 UI として残す必要がある。
+	if ( ! post_type_supports( $screen->post_type, 'custom-fields' ) ) {
+		return;
+	}
+
 	// Remove the unified legacy metabox used on post/page/custom post types.
 	// 投稿・固定ページ・カスタム投稿タイプで使われる統合版の旧メタボックスを削除。
 	remove_meta_box( 'veu_parent_post_metabox', $screen->post_type, 'normal' );

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ] Fixed an issue where settings such as noindex were silently lost on save for custom post types that do not declare 'custom-fields' support, because the new block editor sidebar panel relies on REST API meta which is not exposed for those post types. The legacy metabox is now kept as a fallback on such post types.
+
 = 9.114.0 =
 [ Spec Change ] Migrate post editor settings UI to block editor sidebar panels
 [ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process


### PR DESCRIPTION
## 関連 issue

- Fix #1319

## 概要

vk-all-in-one-expansion-unit 9.114.0 で、`supports` に `'custom-fields'` を含めない CPT の編集画面において、noindex / sitemap hide / SNS タイトル等の設定が保存時に外れる不具合を修正する。

## 原因

#1304 でブロックエディタの設定 UI を旧メタボックスから PluginSidebar (`register_post_meta` + REST API 経由) に移行した。しかし WordPress は `post_type_supports( $post_type, 'custom-fields' )` が false の投稿タイプでは REST API レスポンスに meta を含めないため、サイドバーパネルから値を保存できず、結果として値が永続化されない（保存しても元に戻る）状態になっていた。

旧メタボックス本体は #1304 で `__back_compat_meta_box => true` 付きで残されているが、ブロックエディタ画面では `veu_remove_legacy_metabox_on_block_editor()` によって一律に `remove_meta_box` されていたため、非対応 CPT ではフォールバック先がなくユーザーが値を保存する手段が失われていた。

## 修正方針

`inc/block-editor-panels/enqueue.php` の 4 関数に `post_type_supports( $post_type, 'custom-fields' )` ガードを追加し、custom-fields 非対応 CPT ではサイドバーパネルを使わず、`__back_compat_meta_box` で残されている旧メタボックスをそのまま実働 UI として使うフォールバック構成にする。

- 対応 CPT（`'custom-fields'` を supports に含む）: 新サイドバーパネル（変化なし）
- 非対応 CPT: 旧メタボックスを残してそこから保存できるようにする

## 変更点

`inc/block-editor-panels/enqueue.php` の 4 関数：

1. **`veu_register_active_feature_meta()`** — `register_post_meta` のループ内側で `post_type_supports` が false なら `continue` し、非対応 CPT に対する meta 登録をスキップ。
2. **`veu_register_head_title_rest_field()`** — `$post_types` を `array_filter` で対応 CPT のみに絞り、空なら早期 return。`veu_head_title_object` REST フィールドを非対応 CPT に登録しない。
3. **`veu_enqueue_block_editor_panels()`** — `$screen->post_type` が非対応なら早期 return。サイドバーパネルのスクリプトを enqueue しない。
4. **`veu_remove_legacy_metabox_on_block_editor()`** — `$screen->post_type` が非対応なら早期 return（**鍵となる箇所**）。これでブロックエディタ画面でも旧メタボックスが残り、保存可能な UI として機能する。

## レビュー状況

- セキュリティレビュー（安藤）: PASS 済み（`auth_callback` は `current_user_can('edit_post', \$object_id)` で正しく実装済みのため変更不要）
- UX レビュー: PHP ロジックのみのため省略

## 確認手順

### 前提条件

- VK All in One Expansion Unit を有効化
- `theme/functions.php` 等に以下のような custom-fields 非対応 CPT を register しておく：

\`\`\`php
add_action( 'init', function () {
    register_post_type( 'vkx_no_cf', array(
        'label'        => 'NoCF Test',
        'public'       => true,
        'show_in_rest' => true,
        // 'custom-fields' を含めない
        'supports'     => array( 'title', 'editor' ),
    ) );
} );
\`\`\`

- 比較用に custom-fields を含む CPT も register しておく（または `post` / `page` を使用）：

\`\`\`php
register_post_type( 'vkx_with_cf', array(
    'label'        => 'WithCF Test',
    'public'       => true,
    'show_in_rest' => true,
    'supports'     => array( 'title', 'editor', 'custom-fields' ),
) );
\`\`\`

### 手順

#### Before（修正前の再現手順）

1. 9.114.0 を有効化した状態で `vkx_no_cf`（custom-fields 非対応 CPT）の新規投稿を開く（管理画面 > NoCF Test > 新規追加）
2. ブロックエディタ右サイドバーの「VK ExUnit」パネルを開く
3. 「Noindex setting」のチェックを ON にする
4. 公開（または下書き保存）する
5. 一旦投稿一覧に戻り、再度同じ投稿を開く
   → ✗ Noindex のチェックが外れている（保存されていない）

#### After（修正後の確認手順）

1. 本ブランチを有効化し、`vkx_no_cf`（custom-fields 非対応 CPT）の新規投稿を開く
   → ✓ 右サイドバーの「VK ExUnit」パネルは表示されない
   → ✓ 投稿本文の下に旧メタボックス「VK ExUnit Setting」が表示される
2. 旧メタボックス内の Noindex / Sitemap hide / SNS タイトル等のチェックや値を変更して保存する
3. 投稿一覧に戻り、再度同じ投稿を開く
   → ✓ 各設定値が保存され、再表示時にも維持されている
4. `vkx_with_cf`（custom-fields 対応 CPT）の新規投稿を開く
   → ✓ 右サイドバーに「VK ExUnit」パネルが表示される
   → ✓ サイドバーから Noindex 等にチェックを入れて保存し、再表示しても値が維持される
5. 標準 `post`（投稿）の編集画面を開く
   → ✓ サイドバーパネルから Noindex / Head Title 等を設定して保存し、再表示しても値が維持される（デグレなし）
6. 標準 `page`（固定ページ）の編集画面を開く
   → ✓ サイドバーパネルから Page List 除外 / Child Page Index / Sitemap insert / Contact section 等の固定ページ専用項目が表示・保存できる（デグレなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カスタムフィールドに非対応の投稿タイプで、noindexなどの設定が保存時に失われていた問題を修正しました。これらの投稿タイプでは従来のメタボックスがフォールバックとして機能し、設定が確実に保持されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->