### PR TITLE
[ 仕様変更 ][ 投稿タイプマネージャー ] 作成した CPT で custom-fields を強制サポート化

### DIFF
--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -272,10 +272,29 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 
 			echo '<ul>';
 			foreach ( $post_type_items_array as $key => $label ) {
+				// custom-fields は ExUnit の各種設定（noindex / CSS / CTA 等）保存に必須のため強制有効化する.
+				// custom-fields is force-enabled because it is required to save ExUnit settings (noindex / CSS / CTA, etc.).
+				// See issue #1322.
+				if ( 'custom-fields' === $key ) {
+					echo '<li>';
+					echo '<span class="dashicons dashicons-yes" aria-hidden="true"></span> ';
+					echo esc_html( $label );
+					echo ' <small>(' . esc_html__( 'Always enabled', 'vk-all-in-one-expansion-unit' ) . ')</small>';
+					// 強制保存用の hidden を併置（保存処理側でも上書きしているが UI からも値が POST されるようにする）.
+					// Hidden input ensures the value is POSTed even though the save handler also enforces it.
+					echo '<input type="hidden" name="veu_post_type_items[custom-fields]" value="true">';
+					echo '</li>';
+					continue;
+				}
+
 				$checked = ( isset( $post_type_items_value[ $key ] ) && $post_type_items_value[ $key ] ) ? ' checked' : '';
 				echo '<li><label><input type="checkbox" id="veu_post_type_items[' . esc_attr( $key ) . ']" name="veu_post_type_items[' . esc_attr( $key ) . ']" value="true"' . esc_attr( $checked ) . '> ' . esc_html( $label ) . '</label></li>';
 			}
 			echo '</ul>';
+
+			// custom-fields 強制有効化に関する注記.
+			// Notice about forced custom-fields support.
+			echo '<p class="description">' . esc_html__( '"custom-fields" is always enabled to save ExUnit settings (noindex / CSS / CTA, etc.).', 'vk-all-in-one-expansion-unit' ) . '</p>';
 
 			echo '<hr>';
 
@@ -641,6 +660,11 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 				}
 			}
 
+			// custom-fields は ExUnit の各種設定（noindex / CSS / CTA 等）保存に必須のため強制注入する.
+			// Force-enable custom-fields support to ensure ExUnit settings (noindex / CSS / CTA, etc.) can be saved.
+			// See issue #1322.
+			$post_type_items['custom-fields'] = 'true';
+
 			$menu_posttion = isset( $_POST['veu_menu_position'] ) ? sanitize_text_field( wp_unslash( $_POST['veu_menu_position'] ) ) : '';
 			$menu_icon     = isset( $_POST['veu_menu_icon'] ) ? sanitize_text_field( wp_unslash( $_POST['veu_menu_icon'] ) ) : '';
 
@@ -831,8 +855,19 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 					if ( ! $post_type_items ) {
 						$post_type_items = array( 'title' );
 					}
+					// $supports を明示初期化（PHP 8 系の Warning 対策） / Initialize $supports explicitly to avoid PHP 8 warnings.
+					$supports = array();
 					foreach ( $post_type_items as $key => $value ) {
 						$supports[] = $key;
+					}
+
+					// 強制サポートする項目（issue #1322）。配列にしておくことで将来の追加要件にも対応しやすくする.
+					// Forced supports (issue #1322). Kept as an array for future extensibility.
+					$forced_supports = array( 'custom-fields' );
+					foreach ( $forced_supports as $forced ) {
+						if ( ! in_array( $forced, $supports, true ) ) {
+							$supports[] = $forced;
+						}
 					}
 
 					// カスタム投稿タイプのスラッグ.

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -684,12 +684,11 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 			$is_embeddable = isset( $_POST['veu_is_embeddable'] ) ? 'false' : 'true';
 
 			// 必須項目バリデーション.
+			// custom-fields は常に強制注入されるため、Supports の空チェックは不要（issue #1322）.
+			// custom-fields is always force-injected, so the Supports empty check is unnecessary (issue #1322).
 			$validation_errors = array();
 			if ( empty( $post_type_id ) ) {
 				$validation_errors[] = __( 'Post Type ID (Required): please enter a value.', 'vk-all-in-one-expansion-unit' );
-			}
-			if ( empty( $post_type_items ) ) {
-				$validation_errors[] = __( 'Supports (Required): please select at least one item.', 'vk-all-in-one-expansion-unit' );
 			}
 
 			// 復元用に入力値を一時保存（バリデーションエラー時にフォームへ反映）.

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -856,7 +856,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 					}
 					// $supports を明示初期化（PHP 8 系の Warning 対策） / Initialize $supports explicitly to avoid PHP 8 warnings.
 					$supports = array();
-					foreach ( $post_type_items as $key => $value ) {
+					foreach ( array_keys( $post_type_items ) as $key ) {
 						$supports[] = $key;
 					}
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Spec Change ][ Post Type Manager ] Custom post types created via the Post Type Manager now always support 'custom-fields'. The 'custom-fields' checkbox in the Supports list has been replaced with an "Always enabled" indicator and can no longer be unchecked, so ExUnit settings (noindex / CSS / CTA, etc.) are guaranteed to be saved.
+
 [ Bug Fix ] Fixed an issue where settings such as noindex were silently lost on save for custom post types that do not declare 'custom-fields' support, because the new block editor sidebar panel relies on REST API meta which is not exposed for those post types. The legacy metabox is now kept as a fallback on such post types.
 
 = 9.114.0 =

--- a/tests/test-post-type-manager.php
+++ b/tests/test-post-type-manager.php
@@ -175,12 +175,15 @@ class PostTypeManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Required: Supports missing should not save meta, but should store draft transient.
+	 * Supports が POST に含まれない場合でも、custom-fields が強制補完されるため
+	 * バリデーションエラーは発生せず、メタが保存される事を確認する。
+	 * Issue #1322 の仕様に伴う既存テストの更新。
+	 *
+	 * Even when Supports is missing from POST, custom-fields is force-injected,
+	 * so validation does not fail and meta is saved (issue #1322).
 	 */
-	public function test_save_cf_value_missing_supports_sets_transients_and_does_not_update_meta() {
+	public function test_save_cf_value_missing_supports_still_saves_with_forced_custom_fields() {
 		$post_id = $this->create_post_type_manage_post();
-
-		update_post_meta( $post_id, 'veu_menu_position', '1' );
 
 		$_POST = array(
 			'noncename__post_type_manager' => $this->create_post_type_manager_nonce(),
@@ -191,16 +194,20 @@ class PostTypeManagerTest extends WP_UnitTestCase {
 
 		VK_Post_Type_Manager::save_cf_value( $post_id );
 
-		$this->assertSame( '1', get_post_meta( $post_id, 'veu_menu_position', true ) );
-		$this->assertSame( '', get_post_meta( $post_id, 'veu_post_type_id', true ) );
+		// バリデーションエラーが発生しないため Post Type ID も保存される.
+		// Post Type ID is saved because validation does not fail.
+		$this->assertSame( 'event', get_post_meta( $post_id, 'veu_post_type_id', true ) );
 
+		// custom-fields は強制補完されている / custom-fields is force-injected.
+		$saved_items = get_post_meta( $post_id, 'veu_post_type_items', true );
+		$this->assertIsArray( $saved_items );
+		$this->assertArrayHasKey( 'custom-fields', $saved_items );
+		$this->assertSame( 'true', $saved_items['custom-fields'] );
+
+		// バリデーションエラーの transient はセットされない.
+		// Validation error transient should not be set.
 		$errors = get_transient( $this->get_validation_error_key( $post_id ) );
-		$this->assertIsArray( $errors );
-		$this->assertNotEmpty( $errors );
-
-		$draft = get_transient( $this->get_validation_draft_key( $post_id ) );
-		$this->assertIsArray( $draft );
-		$this->assertSame( 'event', $draft['veu_post_type_id'] );
+		$this->assertFalse( $errors );
 	}
 
 	/**

--- a/tests/test-post-type-manager.php
+++ b/tests/test-post-type-manager.php
@@ -221,10 +221,106 @@ class PostTypeManagerTest extends WP_UnitTestCase {
 		VK_Post_Type_Manager::save_cf_value( $post_id );
 
 		$this->assertSame( 'event', get_post_meta( $post_id, 'veu_post_type_id', true ) );
-		$this->assertIsArray( get_post_meta( $post_id, 'veu_post_type_items', true ) );
+		$saved_items = get_post_meta( $post_id, 'veu_post_type_items', true );
+		$this->assertIsArray( $saved_items );
+		// custom-fields は強制有効化されるため必ず含まれる（issue #1322）.
+		// custom-fields must always be included (issue #1322).
+		$this->assertArrayHasKey( 'custom-fields', $saved_items );
+		$this->assertSame( 'true', $saved_items['custom-fields'] );
 		$this->assertSame( '10', get_post_meta( $post_id, 'veu_menu_position', true ) );
 		$this->assertSame( 'dashicons-admin-post', get_post_meta( $post_id, 'veu_menu_icon', true ) );
 		$this->assertSame( 'true', get_post_meta( $post_id, 'veu_post_type_export_to_api', true ) );
+	}
+
+	/**
+	 * custom-fields should always be present in saved meta even when not posted.
+	 * issue #1322
+	 */
+	public function test_save_cf_value_always_includes_custom_fields_meta() {
+		// テスト条件と期待値の配列。custom-fields の有無に関わらず必ずメタに含まれる事を確認する.
+		// Each case verifies that 'custom-fields' is always present in saved meta.
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'POST に custom-fields が含まれない場合でも、保存後メタに custom-fields => true が含まれる',
+				'post_items'          => array( 'title' => 'true' ),
+			),
+			array(
+				'test_condition_name' => 'POST に複数項目（title, editor）が含まれていても、custom-fields も自動付与される',
+				'post_items'          => array(
+					'title'  => 'true',
+					'editor' => 'true',
+				),
+			),
+			array(
+				'test_condition_name' => 'POST に custom-fields が明示指定されている場合も、メタに custom-fields => true が保持される',
+				'post_items'          => array(
+					'title'         => 'true',
+					'custom-fields' => 'true',
+				),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$post_id = $this->create_post_type_manage_post();
+
+			$_POST = array(
+				'noncename__post_type_manager' => $this->create_post_type_manager_nonce(),
+				'veu_post_type_id'             => 'event',
+				'veu_post_type_items'          => $case['post_items'],
+			);
+
+			VK_Post_Type_Manager::save_cf_value( $post_id );
+
+			$saved_items = get_post_meta( $post_id, 'veu_post_type_items', true );
+			$this->assertIsArray( $saved_items, $case['test_condition_name'] );
+			$this->assertArrayHasKey( 'custom-fields', $saved_items, $case['test_condition_name'] );
+			$this->assertSame( 'true', $saved_items['custom-fields'], $case['test_condition_name'] );
+
+			// 後片付け / Cleanup.
+			wp_delete_post( $post_id, true );
+			$_POST = array();
+		}
+	}
+
+	/**
+	 * Registered CPT should always declare 'custom-fields' support, even when meta does not include it.
+	 * issue #1322
+	 */
+	public function test_add_post_type_registers_with_custom_fields_support() {
+		$post_id = $this->create_post_type_manage_post(
+			array(
+				'post_title' => 'Force CF CPT',
+			)
+		);
+
+		// あえて custom-fields をメタに入れずに CPT を登録する（旧データ想定）.
+		// Intentionally save meta without custom-fields to simulate legacy data.
+		update_post_meta( $post_id, 'veu_post_type_id', 'force_cf_cpt' );
+		update_post_meta(
+			$post_id,
+			'veu_post_type_items',
+			array(
+				'title'  => 'true',
+				'editor' => 'true',
+			)
+		);
+
+		// 念のため、既に登録されていれば一度解除する / Unregister if already registered.
+		if ( post_type_exists( 'force_cf_cpt' ) ) {
+			unregister_post_type( 'force_cf_cpt' );
+		}
+
+		VK_Post_Type_Manager::add_post_type();
+
+		// add_post_type 後は custom-fields がサポートされている事.
+		// After add_post_type(), custom-fields support must be declared.
+		$this->assertTrue(
+			post_type_supports( 'force_cf_cpt', 'custom-fields' ),
+			'CPT must support custom-fields even if meta did not include it (issue #1322).'
+		);
+
+		// 後片付け / Cleanup.
+		unregister_post_type( 'force_cf_cpt' );
 	}
 
 	/**

--- a/tests/test-post-type-manager.php
+++ b/tests/test-post-type-manager.php
@@ -175,39 +175,100 @@ class PostTypeManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Supports が POST に含まれない場合でも、custom-fields が強制補完されるため
-	 * バリデーションエラーは発生せず、メタが保存される事を確認する。
-	 * Issue #1322 の仕様に伴う既存テストの更新。
+	 * Supports が POST に含まれない・空配列でも custom-fields が強制補完されるため
+	 * バリデーションエラーは発生せずメタが保存される事を、複数条件でまとめて検証する。
+	 * Issue #1322 の仕様に伴うテーブル駆動テスト。
 	 *
-	 * Even when Supports is missing from POST, custom-fields is force-injected,
-	 * so validation does not fail and meta is saved (issue #1322).
+	 * Table-driven test verifying that custom-fields is force-injected even when
+	 * Supports is missing or empty in POST, and that Post Type ID validation
+	 * still gates meta updates as a boundary case (issue #1322).
 	 */
 	public function test_save_cf_value_missing_supports_still_saves_with_forced_custom_fields() {
-		$post_id = $this->create_post_type_manage_post();
-
-		$_POST = array(
-			'noncename__post_type_manager' => $this->create_post_type_manager_nonce(),
-			'veu_post_type_id'             => 'event',
-			// 'veu_post_type_items' is intentionally missing.
-			'veu_menu_position'            => '10',
+		// テスト条件と期待値の配列 / Test conditions and expected results.
+		$test_cases = array(
+			array(
+				'test_condition_name'          => 'Supports が POST に含まれない場合 => custom-fields が補完されメタが保存される',
+				'post_type_id'                 => 'event',
+				'include_post_type_items_post' => false,
+				'post_type_items_post'         => null,
+				'expected_meta_saved'          => true,
+				'expected_post_type_id_meta'   => 'event',
+				'expected_validation_error'    => false,
+			),
+			array(
+				'test_condition_name'          => 'Supports が空配列の場合 => custom-fields のみ補完されメタが保存される',
+				'post_type_id'                 => 'event',
+				'include_post_type_items_post' => true,
+				'post_type_items_post'         => array(),
+				'expected_meta_saved'          => true,
+				'expected_post_type_id_meta'   => 'event',
+				'expected_validation_error'    => false,
+			),
+			array(
+				'test_condition_name'          => 'Post Type ID 空 + Supports 未指定 => バリデーションエラーでメタは更新されない（境界値）',
+				'post_type_id'                 => '',
+				'include_post_type_items_post' => false,
+				'post_type_items_post'         => null,
+				'expected_meta_saved'          => false,
+				'expected_post_type_id_meta'   => '',
+				'expected_validation_error'    => true,
+			),
 		);
 
-		VK_Post_Type_Manager::save_cf_value( $post_id );
+		foreach ( $test_cases as $case ) {
+			// ケース毎にクリーンな投稿を作成 / Create a fresh post per case.
+			$post_id = $this->create_post_type_manage_post();
 
-		// バリデーションエラーが発生しないため Post Type ID も保存される.
-		// Post Type ID is saved because validation does not fail.
-		$this->assertSame( 'event', get_post_meta( $post_id, 'veu_post_type_id', true ) );
+			$_POST = array(
+				'noncename__post_type_manager' => $this->create_post_type_manager_nonce(),
+				'veu_post_type_id'             => $case['post_type_id'],
+				'veu_menu_position'            => '10',
+			);
+			// Supports（veu_post_type_items）を POST に含めるかどうかをケースで切替.
+			// Decide whether to include veu_post_type_items in POST per case.
+			if ( $case['include_post_type_items_post'] ) {
+				$_POST['veu_post_type_items'] = $case['post_type_items_post'];
+			}
 
-		// custom-fields は強制補完されている / custom-fields is force-injected.
-		$saved_items = get_post_meta( $post_id, 'veu_post_type_items', true );
-		$this->assertIsArray( $saved_items );
-		$this->assertArrayHasKey( 'custom-fields', $saved_items );
-		$this->assertSame( 'true', $saved_items['custom-fields'] );
+			VK_Post_Type_Manager::save_cf_value( $post_id );
 
-		// バリデーションエラーの transient はセットされない.
-		// Validation error transient should not be set.
-		$errors = get_transient( $this->get_validation_error_key( $post_id ) );
-		$this->assertFalse( $errors );
+			// Post Type ID メタの期待値を検証 / Verify Post Type ID meta.
+			$this->assertSame(
+				$case['expected_post_type_id_meta'],
+				get_post_meta( $post_id, 'veu_post_type_id', true ),
+				$case['test_condition_name']
+			);
+
+			$saved_items = get_post_meta( $post_id, 'veu_post_type_items', true );
+
+			if ( $case['expected_meta_saved'] ) {
+				// custom-fields が強制補完されメタが保存されている事を検証.
+				// Verify that custom-fields is force-injected and meta is persisted.
+				$this->assertIsArray( $saved_items, $case['test_condition_name'] );
+				$this->assertArrayHasKey( 'custom-fields', $saved_items, $case['test_condition_name'] );
+				$this->assertSame( 'true', $saved_items['custom-fields'], $case['test_condition_name'] );
+			} else {
+				// バリデーション失敗時はメタが更新されていない事を検証.
+				// On validation failure, meta should not be updated.
+				$this->assertSame( '', $saved_items, $case['test_condition_name'] );
+			}
+
+			// バリデーションエラー transient の状態を検証.
+			// Verify validation error transient state.
+			$errors = get_transient( $this->get_validation_error_key( $post_id ) );
+			if ( $case['expected_validation_error'] ) {
+				$this->assertIsArray( $errors, $case['test_condition_name'] );
+				$this->assertNotEmpty( $errors, $case['test_condition_name'] );
+			} else {
+				$this->assertFalse( $errors, $case['test_condition_name'] );
+			}
+
+			// 後片付け / Cleanup.
+			delete_transient( $this->get_validation_error_key( $post_id ) );
+			delete_transient( $this->get_validation_draft_key( $post_id ) );
+			wp_delete_post( $post_id, true );
+			$_POST = array();
+		}
 	}
 
 	/**
@@ -291,43 +352,75 @@ class PostTypeManagerTest extends WP_UnitTestCase {
 
 	/**
 	 * Registered CPT should always declare 'custom-fields' support, even when meta does not include it.
-	 * issue #1322
+	 * Issue #1322 の仕様に伴うテーブル駆動テスト。
+	 *
+	 * Table-driven test verifying that VK_Post_Type_Manager::add_post_type() always
+	 * registers the CPT with custom-fields support, regardless of stored meta state
+	 * (legacy data without custom-fields, partial meta, or already-explicit meta).
 	 */
 	public function test_add_post_type_registers_with_custom_fields_support() {
-		$post_id = $this->create_post_type_manage_post(
+		// テスト条件と期待値の配列 / Test conditions and expected results.
+		$test_cases = array(
 			array(
-				'post_title' => 'Force CF CPT',
-			)
+				'test_condition_name' => 'メタに veu_post_type_items が未保存（旧データ）でも、登録時に custom-fields がサポートされる',
+				'post_type_id'        => 'force_cf_cpt_legacy',
+				'set_post_type_items' => false,
+				'post_type_items'     => null,
+				'expected_supports'   => array( 'title', 'custom-fields' ),
+			),
+			array(
+				'test_condition_name' => 'メタに title のみ含まれる場合でも、登録時に custom-fields が補完される',
+				'post_type_id'        => 'force_cf_cpt_partial',
+				'set_post_type_items' => true,
+				'post_type_items'     => array( 'title' => 'true' ),
+				'expected_supports'   => array( 'title', 'custom-fields' ),
+			),
+			array(
+				'test_condition_name' => 'メタに既に custom-fields が含まれる場合は重複追加されない（境界値）',
+				'post_type_id'        => 'force_cf_cpt_explicit',
+				'set_post_type_items' => true,
+				'post_type_items'     => array(
+					'title'         => 'true',
+					'custom-fields' => 'true',
+				),
+				'expected_supports'   => array( 'title', 'custom-fields' ),
+			),
 		);
 
-		// あえて custom-fields をメタに入れずに CPT を登録する（旧データ想定）.
-		// Intentionally save meta without custom-fields to simulate legacy data.
-		update_post_meta( $post_id, 'veu_post_type_id', 'force_cf_cpt' );
-		update_post_meta(
-			$post_id,
-			'veu_post_type_items',
-			array(
-				'title'  => 'true',
-				'editor' => 'true',
-			)
-		);
+		foreach ( $test_cases as $case ) {
+			// ケース毎にクリーンな post_type_manage 投稿を作成.
+			// Create a fresh post_type_manage post per case.
+			$post_id = $this->create_post_type_manage_post(
+				array(
+					'post_title' => 'Force CF CPT (' . $case['post_type_id'] . ')',
+				)
+			);
 
-		// 念のため、既に登録されていれば一度解除する / Unregister if already registered.
-		if ( post_type_exists( 'force_cf_cpt' ) ) {
-			unregister_post_type( 'force_cf_cpt' );
+			update_post_meta( $post_id, 'veu_post_type_id', $case['post_type_id'] );
+			if ( $case['set_post_type_items'] ) {
+				update_post_meta( $post_id, 'veu_post_type_items', $case['post_type_items'] );
+			}
+
+			// 念のため既に登録されていれば一度解除する / Unregister if already registered.
+			if ( post_type_exists( $case['post_type_id'] ) ) {
+				unregister_post_type( $case['post_type_id'] );
+			}
+
+			VK_Post_Type_Manager::add_post_type();
+
+			// 期待される全 supports が宣言されている事を検証.
+			// Verify that all expected supports are declared.
+			foreach ( $case['expected_supports'] as $support ) {
+				$this->assertTrue(
+					post_type_supports( $case['post_type_id'], $support ),
+					$case['test_condition_name'] . ' / supports: ' . $support
+				);
+			}
+
+			// 後片付け / Cleanup.
+			unregister_post_type( $case['post_type_id'] );
+			wp_delete_post( $post_id, true );
 		}
-
-		VK_Post_Type_Manager::add_post_type();
-
-		// add_post_type 後は custom-fields がサポートされている事.
-		// After add_post_type(), custom-fields support must be declared.
-		$this->assertTrue(
-			post_type_supports( 'force_cf_cpt', 'custom-fields' ),
-			'CPT must support custom-fields even if meta did not include it (issue #1322).'
-		);
-
-		// 後片付け / Cleanup.
-		unregister_post_type( 'force_cf_cpt' );
 	}
 
 	/**


### PR DESCRIPTION
Closes #1322

## 概要

投稿タイプマネージャーで作成したカスタム投稿タイプ（CPT）が、設定画面の `Supports` チェックボックス操作に関わらず、常に `custom-fields` をサポートするように変更します。

ExUnit のサイドバー設定（noindex / CSS / CTA など）はカスタムフィールドとして保存されるため、`custom-fields` サポートが無い CPT では設定値が REST API 経由で保存できず、実質的に機能しないケースがありました（#1319 と同根の問題）。本 PR は投稿タイプマネージャー側の恒久対応です。

## 関連 issue

- Closes #1322
- Refs #1319（同じ根本原因の不具合修正。本 PR で投稿タイプマネージャー側を恒久対応）

## 変更内容

### 1. UI 変更（Supports セクション）

`inc/post-type-manager/package/class.post-type-manager.php`

- `Supports(Required)` の `custom-fields` 行を、チェックボックスから「`dashicons-yes` アイコン + `custom-fields` (自動的に有効 / Always enabled)」の静的表示に変更
- 同じ `<li>` 内に `<input type="hidden" name=\"veu_post_type_items[custom-fields]\" value=\"true\">` を併置し、保存時に値が POST されるようにする
- リスト末尾に注記を追加: `\"custom-fields\" is always enabled to save ExUnit settings (noindex / CSS / CTA, etc.).`

### 2. 保存処理の強制注入

`save_cf_value()` 内、`$post_type_items` 組み立て直後に強制注入。

```php
// custom-fields は ExUnit の各種設定（noindex / CSS / CTA 等）保存に必須のため強制注入する.
$post_type_items['custom-fields'] = 'true';
```

UI を改ざんされたり、UI を経由しない経路で保存された場合でもメタデータが必ず正しい状態で保存されるよう、保存処理側でも強制します。

### 3. 登録ロジックの強制サポート

`add_post_type()` 内、`$supports` 配列を組み立てた後に強制サポートをマージ。

```php
$forced_supports = array( 'custom-fields' );
foreach ( $forced_supports as $forced ) {
    if ( ! in_array( $forced, $supports, true ) ) {
        $supports[] = $forced;
    }
}
```

将来、強制サポート対象が増える可能性に備えて配列で持たせています。**既存メタへのマイグレーションは行わず、登録時の補完で動作担保**することで、ユーザーが既存 CPT を再保存することなく正しい挙動になります。

### 4. 副次効果（潜在バグの解消）

`add_post_type()` の `$supports` 変数は元コードでは明示初期化されておらず、複数 CPT を登録するループ内で **前ループの supports が次の CPT に累積する潜在バグ** がありました。本 PR で `$supports = array();` を明示的に追加したことで、PHP 8 系の Warning 対策と合わせてこの不整合も解消しています。

### 5. デッドコード削除

`save_cf_value()` の以下バリデーションを削除しました。

```php
// 削除
if ( empty( $post_type_items ) ) {
    $validation_errors[] = __( 'Supports (Required): please select at least one item.', 'vk-all-in-one-expansion-unit' );
}
```

custom-fields の強制注入により `$post_type_items` は必ず非空になるため、このチェックは永遠に発火しないデッドコードです。連動して i18n 文字列 `Supports (Required): please select at least one item.` も削除しています（コードベース内に他参照がないことを grep で確認済み）。

## テスト

`tests/test-post-type-manager.php`

- 既存テストを仕様に合わせて書き換え:
  - `test_save_cf_value_missing_supports_sets_transients_and_does_not_update_meta` → `test_save_cf_value_missing_supports_still_saves_with_forced_custom_fields`
  - 「Supports 未指定でもバリデーションは通り、custom-fields が強制補完されてメタが保存される」事を assert
- 既存テスト `test_save_cf_value_with_required_fields_saves_meta` に `custom-fields => 'true'` の assertion を追加
- 新規追加:
  - `test_save_cf_value_always_includes_custom_fields_meta`: POST に custom-fields が無くても／複数項目／明示指定の3条件で必ずメタに `custom-fields => 'true'` が含まれる事を確認
  - `test_add_post_type_registers_with_custom_fields_support`: メタに custom-fields が無い CPT を作成 → `add_post_type()` 後に `post_type_supports( $slug, 'custom-fields' )` が true を返す事を確認

> **PHPUnit 実行**: worktree 起動時の wp-env コンテナがプラグイン用に存在しないため、ローカルからは未実行です。CI / メンテナ環境での実行をお願いします。`php -l` での syntax チェック、`composer format`（phpcbf）、`npm run lint:block` は通過しています。

## changelog

`readme.txt` の `== Changelog ==` 直下に英語で追記済みです（既存 changelog が全て英語のため、change-types.md ルールに従い英語）。

```
[ Spec Change ][ Post Type Manager ] Custom post types created via the Post Type Manager now always support 'custom-fields'. The 'custom-fields' checkbox in the Supports list has been replaced with an \"Always enabled\" indicator and can no longer be unchecked, so ExUnit settings (noindex / CSS / CTA, etc.) are guaranteed to be saved.
```

## 確認手順

### 前提条件

- ExUnit を有効化
- 投稿タイプマネージャー機能が有効（管理画面に「投稿タイプ設定」メニューが表示されている事）
- 管理者権限のユーザーでログイン

### 手順

#### After（修正後 / 確認手順）

1. 管理画面 > 投稿タイプ設定 > 新規追加 を開く
2. 「Post Type ID(Required)」に任意の英数 ID（例: `event_test`）を入力
3. 「Supports(Required)」セクションを確認する
   → ✓ `custom-fields` の行がチェックボックスではなく `dashicons-yes` アイコン + `custom-fields (Always enabled)` の静的表示になっている
   → ✓ 同行のソース上に `<input type=\"hidden\" name=\"veu_post_type_items[custom-fields]\" value=\"true\">` が出力されている
   → ✓ Supports リストの末尾に `\"custom-fields\" is always enabled to save ExUnit settings (noindex / CSS / CTA, etc.).` という注記（`<p class=\"description\">`）が表示されている
4. `title` のみチェックを入れた状態でタイトルを入力して公開する
   → ✓ 「Supports (Required): please select at least one item.」のエラーが出ずに保存できる
5. 管理画面のメニューに新規 CPT が登場することを確認し、新規投稿画面を開く
6. ExUnit のサイドバーパネルから noindex / CSS / CTA 等の設定を入力して保存
   → ✓ 設定値が保存・再表示される（投稿に紐づくメタとして反映される）
7. PHP コンソールまたは `wp shell` で `post_type_supports( 'event_test', 'custom-fields' )` を確認
   → ✓ `true` を返す

#### デグレ確認 / 既存データの互換性

1. **既存 CPT の互換性**: 過去に作成された CPT（`veu_post_type_items` メタに `custom-fields` を含まないもの）を持つ環境で、何も再保存せずに init 後の `post_type_supports( $slug, 'custom-fields' )` が `true` を返す事を確認
   → ✓ `add_post_type()` 内の `$forced_supports` マージにより、既存 CPT もユーザー操作なしで `custom-fields` サポートが付く
2. **複数 CPT 登録時の supports 累積バグ**: CPT を 2 つ以上作成し、それぞれに異なる Supports（例: A は title のみ、B は title + thumbnail）を設定して保存
   → ✓ A の supports に thumbnail が紛れ込まない（`$supports = array();` 明示初期化により累積バグは発生しない）
3. **必須バリデーション**: 「Post Type ID(Required)」を空のまま保存
   → ✓ 「Post Type ID (Required): please enter a value.」のエラーで保存がブロックされる（Post Type ID 側のバリデーションは従来通り機能する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カスタム投稿タイプマネージャーでカスタムフィールドサポートが常に有効になりました。UI上では「常に有効」として表示され、設定を保存する際に自動的にカスタムフィールドが含まれるようになります。

* **テスト**
  * カスタムフィールド機能の常時有効化に対応したテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->