### PR TITLE
[ セキュリティ修正 ][ SNSシェアボタン ] シェア数取得 REST API の URL 検証をホスト名厳密一致に変更

### DIFF
--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -460,10 +460,20 @@ function vew_sns_hatena_restapi_callback( $data ) {
 	// Avoiding Apache config "AllowEncodedSlashes" option issue
 	$link_url = str_replace( '-#-', '/', urldecode( $data['linkurl'] ) );
 
-	// strpos() returns false when the needle is not found, and false < 0 evaluates to false in PHP,
-	// which previously caused the URL validation to be skipped entirely. Use === false to correctly
-	// reject URLs that do not belong to this site.
-	if ( false === strpos( preg_replace( '/^https?:\/\//', '', $link_url ), preg_replace( '/^https?:\/\//', '', $siteurl ) ) ) {
+	// ホスト名のみを抽出して厳密に比較する。
+	// 部分文字列一致 (strpos) では example.com.attacker.com のような
+	// 攻撃者制御下のドメインで自サイトのホスト名を含めることでバリデーションを
+	// 迂回されうるため、wp_parse_url() でホスト名のみを取り出し、
+	// 大文字小文字を無視して完全一致 (strcasecmp) で判定する。サブドメインは許可しない。
+	// Extract only the host name and compare strictly. Substring matching with
+	// strpos can be bypassed by attacker-controlled domains such as
+	// example.com.attacker.com that contain the site's host name, so we extract
+	// the host with wp_parse_url() and compare for an exact, case-insensitive
+	// match. Subdomains are not allowed.
+	$link_host = wp_parse_url( $link_url, PHP_URL_HOST );
+	$site_host = wp_parse_url( $siteurl, PHP_URL_HOST );
+
+	if ( empty( $link_host ) || empty( $site_host ) || 0 !== strcasecmp( $link_host, $site_host ) ) {
 		$response = new WP_REST_Response( array() );
 		$response->set_status( 403 );
 		return $response;
@@ -507,10 +517,20 @@ function vew_sns_facebook_restapi_callback( $data ) {
 	// Avoiding Apache config "AllowEncodedSlashes" option issue
 	$link_url = str_replace( '-#-', '/', urldecode( $data['linkurl'] ) );
 
-	// strpos() returns false when the needle is not found, and false < 0 evaluates to false in PHP,
-	// which previously caused the URL validation to be skipped entirely. Use === false to correctly
-	// reject URLs that do not belong to this site.
-	if ( false === strpos( preg_replace( '/^https?:\/\//', '', $link_url ), preg_replace( '/^https?:\/\//', '', $siteurl ) ) ) {
+	// ホスト名のみを抽出して厳密に比較する。
+	// 部分文字列一致 (strpos) では example.com.attacker.com のような
+	// 攻撃者制御下のドメインで自サイトのホスト名を含めることでバリデーションを
+	// 迂回されうるため、wp_parse_url() でホスト名のみを取り出し、
+	// 大文字小文字を無視して完全一致 (strcasecmp) で判定する。サブドメインは許可しない。
+	// Extract only the host name and compare strictly. Substring matching with
+	// strpos can be bypassed by attacker-controlled domains such as
+	// example.com.attacker.com that contain the site's host name, so we extract
+	// the host with wp_parse_url() and compare for an exact, case-insensitive
+	// match. Subdomains are not allowed.
+	$link_host = wp_parse_url( $link_url, PHP_URL_HOST );
+	$site_host = wp_parse_url( $siteurl, PHP_URL_HOST );
+
+	if ( empty( $link_host ) || empty( $site_host ) || 0 !== strcasecmp( $link_host, $site_host ) ) {
 		$response = new WP_REST_Response( array() );
 		$response->set_status( 403 );
 		return $response;

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Security Fix ][ SNS Share Button ] Strengthened URL validation in the Hatena Bookmark and Facebook share count REST API callbacks. The previous substring-based check could be bypassed by attacker-controlled hosts that embed the site's host name (e.g. example.com.attacker.com), allowing share counts to be fetched for external URLs. The host name is now extracted with wp_parse_url() and compared with the site's host name using a case-insensitive exact match. Subdomains are not allowed.
+
 = 9.115.0 =
 [ Spec Change ][ Post Type Manager ] Custom post types created via the Post Type Manager now always support 'custom-fields'. The 'custom-fields' checkbox in the Supports list has been replaced with an "Always enabled" indicator and can no longer be unchecked, so ExUnit settings (noindex / CSS / CTA, etc.) are guaranteed to be saved.
 


### PR DESCRIPTION
## 概要

SNSシェア数取得 REST API（はてなブックマーク / Facebook）のコールバック関数で行っていた URL バリデーションを、部分文字列一致から `wp_parse_url()` を使ったホスト名の厳密一致に変更します。

Closes #1327

## 背景

`inc/sns/function-sns-btns.php` の `vew_sns_hatena_restapi_callback` および `vew_sns_facebook_restapi_callback` では、リクエストされた URL が自サイトのものかを以下のように検証していました。

```php
if ( false === strpos( preg_replace( '/^https?:\/\//', '', $link_url ), preg_replace( '/^https?:\/\//', '', $siteurl ) ) ) {
    // 403
}
```

scheme を正規表現で除去したうえで `strpos()` の部分文字列一致で「site URL を含むか」を判定していたため、攻撃者が制御するホスト名に自サイトのホスト名を含めることでバリデーションを迂回できる余地がありました。

例: 自サイトが `https://example.com` の場合、`https://example.com.attacker.com/foo` も `strpos` 的にはマッチしてしまい、外部 URL に対するシェア数取得を許してしまう状態でした。

## 変更内容

両コールバックで以下のように修正しました。

```php
$link_host = wp_parse_url( $link_url, PHP_URL_HOST );
$site_host = wp_parse_url( $siteurl, PHP_URL_HOST );

if ( empty( $link_host ) || empty( $site_host ) || 0 !== strcasecmp( $link_host, $site_host ) ) {
    $response = new WP_REST_Response( array() );
    $response->set_status( 403 );
    return $response;
}
```

ポイント:

1. `wp_parse_url( ..., PHP_URL_HOST )` でホスト名のみを抽出して比較するため、パス・クエリ部分を巧妙に組んだ迂回ができない
2. `strcasecmp()` で大文字小文字を無視した完全一致比較（`EXAMPLE.com` と `example.com` は同一とみなす、DNS の仕様に合わせる）
3. `empty()` ガードでホスト抽出に失敗した不正 URL（スキームなし・空文字など）も 403 で弾く
4. サブドメインは許可しない（完全一致のみ）

## 変更ファイル

- `inc/sns/function-sns-btns.php` — `vew_sns_hatena_restapi_callback` / `vew_sns_facebook_restapi_callback` の URL 検証ロジックを変更
- `readme.txt` — Changelog に `[ Security Fix ][ SNS Share Button ]` 項目を追記

## 確認手順

### 前提条件

- 本ブランチを WordPress テスト環境にインストール（`vk-all-in-one-expansion-unit` 有効化）
- 「SNS シェアボタン」モジュールを有効化
- Facebook 側を試す場合は ExUnit 設定 > SNS で `fbAccessToken` を設定（未設定でも 403 / 503 の切り分けは可能）
- 確認に使うサイトURLを `https://example.test` と仮定（実環境のホスト名に読み替えてください）
- ターミナルから `curl` で REST API を直接叩く

REST API エンドポイント:

- はてな: `GET /wp-json/vew/v1/hatena_count?linkurl=<URL>`
- Facebook: `GET /wp-json/vew/v1/facebook_count?linkurl=<URL>`

※ `linkurl` の `/` は実装の都合上 `-#-` に置換して渡す必要があります（`Avoiding Apache config "AllowEncodedSlashes" option issue` の都合）。

### 手順

#### Before（修正前の挙動 = 脆弱性が残っている状態）

1. master ブランチなど修正前のコードで起動する
2. はてな: `curl -i 'https://example.test/wp-json/vew/v1/hatena_count?linkurl=https:-#-example.test.attacker.com-#-foo'`
   → ✗ 200 OK が返り、外部 URL でもシェア数取得処理に進んでしまう（迂回成功）
3. Facebook も同様に `linkurl=https:-#-example.test.attacker.com-#-foo` でリクエスト
   → ✗ 200 OK（fbAccessToken 未設定なら 503）に進んでしまい、403 で弾かれない

#### After（修正後の確認手順）

##### ケース1: 自サイトの URL（正常系）

1. はてな: `curl -i 'https://example.test/wp-json/vew/v1/hatena_count?linkurl=https:-#-example.test-#-foo'`
   → ✓ 200 OK が返る（または はてな API 側の応答に応じて 503）。少なくとも 403 にはならない
2. Facebook: `curl -i 'https://example.test/wp-json/vew/v1/facebook_count?linkurl=https:-#-example.test-#-foo'`
   → ✓ 200 OK（fbAccessToken 未設定の場合は 503）。403 にはならない

##### ケース2: 攻撃者ホスト経由の迂回試行（脆弱性ケース）

1. はてな: `curl -i 'https://example.test/wp-json/vew/v1/hatena_count?linkurl=https:-#-example.test.attacker.com-#-foo'`
   → ✓ **403** が返る（ホスト名が完全一致しないため拒否）
2. Facebook: `curl -i 'https://example.test/wp-json/vew/v1/facebook_count?linkurl=https:-#-example.test.attacker.com-#-foo'`
   → ✓ **403** が返る

##### ケース3: 完全に外部の URL

1. はてな: `curl -i 'https://example.test/wp-json/vew/v1/hatena_count?linkurl=https:-#-www.google.com-#-'`
   → ✓ **403** が返る
2. Facebook: `curl -i 'https://example.test/wp-json/vew/v1/facebook_count?linkurl=https:-#-www.google.com-#-'`
   → ✓ **403** が返る

##### ケース4: 大文字小文字違い（DNS と同様に許容されるべきケース）

1. はてな: `curl -i 'https://example.test/wp-json/vew/v1/hatena_count?linkurl=https:-#-EXAMPLE.test-#-foo'`
   → ✓ 200 OK（`strcasecmp` により大文字小文字差は同一ホストとみなされる）
2. Facebook も同様に `linkurl=https:-#-EXAMPLE.test-#-foo` でリクエスト
   → ✓ 200 OK（fbAccessToken 未設定の場合は 503）

##### ケース5: サブドメイン（仕様上拒否）

1. はてな: `curl -i 'https://example.test/wp-json/vew/v1/hatena_count?linkurl=https:-#-sub.example.test-#-foo'`
   → ✓ **403**（issue 方針通り、サブドメインは許可しない）
2. Facebook も同様
   → ✓ **403**

##### ケース6: 不正な URL（ホスト抽出失敗）

1. はてな: `curl -i 'https://example.test/wp-json/vew/v1/hatena_count?linkurl=not-a-url'`
   → ✓ **403**（`wp_parse_url` でホストが取れず `empty()` ガードで弾かれる）

##### 通常画面でのデグレ確認

1. 投稿に SNS シェアボタンを表示するページを開く
2. はてな / Facebook のシェア数表示が、自サイトのページ URL では今まで通り表示される（または API レスポンスに応じた表示になる）ことを確認
   → ✓ 自サイトの URL についてはこれまでと同じ挙動で、シェア数取得が壊れていない

## スクリーンショット

純粋なサーバー側ロジック（REST API バリデーション）の修正で、表示・UI への影響はないため省略します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* HatenaおよびFacebookの共有数取得REST APIのURL検証ロジックを改善しました。従来の簡易的なホスト名チェック方式から、より正確で厳格なホスト名の抽出と照合プロセスに変更しました。大文字小文字を区別しない正確なマッチングを実装しており、サブドメインは除外されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1335)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->