### PR TITLE
[ 開発環境 ] Composer を v2.8 系に固定して CI の認証エラーを回避

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -38,17 +38,19 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        # Composer 2.9.7 が JWT 形式の GITHUB_TOKEN (ghs_*.*.*) を
-        # "invalid characters" として弾くため、v2.8 系に固定
-        tools: composer:v2.8
-    - name: Setup Node 
+    - name: Setup Node
       uses: actions/setup-node@v1
       with:
         node-version: 20.x
     - name: install npm scripts
       run: npm install
     - name: install Composer Package
-      run: composer install
+      # GitHub Actions の GITHUB_TOKEN が JWT 入りの ghs_*.*.* 形式に変更され、
+      # Composer の OAuth トークン検証 (英数字 + アンダースコアのみ許可) を通らず
+      # "invalid characters" で失敗するため、auth.json から該当エントリを除去してから install する。
+      run: |
+        composer config --global --unset github-oauth.github.com || true
+        composer install
     - name: Install WP-CLI
       run: |
         curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -38,6 +38,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
+        tools: composer:v2.8
     - name: Setup Node 
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -38,6 +38,8 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
+        # Composer 2.9.7 が JWT 形式の GITHUB_TOKEN (ghs_*.*.*) を
+        # "invalid characters" として弾くため、v2.8 系に固定
         tools: composer:v2.8
     - name: Setup Node 
       uses: actions/setup-node@v1


### PR DESCRIPTION
## 概要

GitHub Actions の `GITHUB_TOKEN` が最近 JWT 入りの `ghs_*.*.*` 形式（ドット記号を含む）に変更された影響で、`shivammathur/setup-php@v2` がインストールする Composer 2.9.7 が `github-oauth` トークンを `invalid characters` として弾くようになり、PR の `build_check` ワークフローが `install Composer Package` ステップで失敗するようになっていた。

該当エラー（例: run #25783518409 PHP 7.4 ジョブ）:

\`\`\`
##[error]Your github oauth token for github.com contains invalid characters: "ghs_15368_eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ..."
In BaseIO.php line 143:
  Your github oauth token for github.com contains invalid characters
\`\`\`

`shivammathur/setup-php@v2` の `tools` で `composer:v2.8` を指定し、Composer のバージョンを 2.8 系（バリデーションが緩い世代）に固定して回避する。

## 変更点

- `.github/workflows/build_check.yml`: `setup-php` の `tools: composer:v2.8` を追加

## 確認手順

### 前提条件

- 本 PR を作成した上で、GitHub Actions の `Build Check & PHPUnit` ワークフローが走ること

### 手順

1. 本 PR の Checks タブを開く
2. `php unittest (7.4)`, `php unittest (8)`, `php unittest (8.1)` の各ジョブを開く
   → ✓ `install Composer Package` ステップが成功する（`Your github oauth token for github.com contains invalid characters` エラーが出ない）
3. `Setup PHP` ステップのログを開く
   → ✓ Composer のバージョンが `2.8.x` で表示される
4. 後続の `Build` / `Run Environment` ステップまで通り、3 ジョブとも緑になる
   → ✓ 全 PHP バージョンで PHPUnit まで完走する

## 補足

- Composer 2.9 系で OAuth token のバリデーションが厳格化された／GitHub Actions の `GITHUB_TOKEN` が `ghs_` JWT 形式に変わった、というプラットフォーム側の変化への対症療法であり、本プラグインの実装変更は含まない。
- 他の vk 系リポでも同じ構造の `build_check.yml` を使っているところは同様の症状が出る可能性が高い。横展開は別途検討。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **雑務**
  * ビルドワークフローの構成を更新し、Composerバージョンを固定しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1336)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->