### PR TITLE
[ 開発環境 ] e2e テストのベースURLハードコードを相対パス化

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,8 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    /* CI 環境とローカル環境でポートが異なるため WP_BASE_URL で上書き可能にする。デフォルトは wp-env の testsPort (8889)。 */
+    baseURL: process.env.WP_BASE_URL || 'http://localhost:8889',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/tests/e2e/cta.spec.ts
+++ b/tests/e2e/cta.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
 test('CTA', async ({ page }) => {
 
   // login ///////////////////////////////////////////.
-  await page.goto('http://localhost:8889/wp-login.php');
+  await page.goto('/wp-login.php');
   await page.getByLabel('Username or Email Address').fill('admin');
   await page.getByLabel('Username or Email Address').press('Tab');
   await page.getByLabel('Password', { exact: true } ).fill('password');
@@ -13,7 +13,7 @@ test('CTA', async ({ page }) => {
   // Put CTA ( Not registered ) ///////////////////////////////////////////.
 
   // Got to New Post
-  await page.goto('http://localhost:8889/wp-admin/post-new.php');
+  await page.goto('/wp-admin/post-new.php');
 
   // 最初の投稿ダイアログを閉じる
   await page.waitForTimeout( 1000 );
@@ -47,7 +47,7 @@ test('CTA', async ({ page }) => {
   // Create New CTA ///////////////////////////////////////////.
 
   // Go to New CTA
-  await page.goto('http://localhost:8889/wp-admin/post-new.php?post_type=cta');
+  await page.goto('/wp-admin/post-new.php?post_type=cta');
   // Input CTA title
   await page.getByRole('textbox', { name: 'Add title' }).click();
   await page.getByRole('textbox', { name: 'Add title' }).fill('Test CTA');
@@ -60,12 +60,12 @@ test('CTA', async ({ page }) => {
   // 一応少し待つ。待たないとCTAを配置するテストでプルダウンの中に Test CTA が入っていなくて選択できない事がある。
   await page.waitForTimeout(1000);
   // Cheack CTA is created
-  await page.goto('http://localhost:8889/wp-admin/edit.php?post_type=cta');
+  await page.goto('/wp-admin/edit.php?post_type=cta');
 
 
   // Create New Post and Add CTA ///////////////////////////////////////////.
 
-  await page.goto('http://localhost:8889/wp-admin/post-new.php');
+  await page.goto('/wp-admin/post-new.php');
   // Input Post with CTA title
   await page.getByRole('textbox', { name: 'Add title' }).click();
   await page.getByRole('textbox', { name: 'Add title' }).fill('Post with CTA');
@@ -93,7 +93,7 @@ test('CTA', async ({ page }) => {
   await page.waitForTimeout(1000);
 
   // Delete CTA ///////////////////////////////////////////.
-  await page.goto('http://localhost:8889/wp-admin/edit.php?post_type=cta');
+  await page.goto('/wp-admin/edit.php?post_type=cta');
   await page.locator('#cb-select-all-1').check();
   await page.locator('#bulk-action-selector-top').selectOption('trash');
   await page.locator('#doaction').click();
@@ -113,12 +113,12 @@ test('CTA', async ({ page }) => {
   // 一応少し待つ。
   await page.waitForTimeout(1000);
   // Cheack CTA is created
-  await page.goto('http://localhost:8889/wp-admin/edit.php?post_type=cta');
+  await page.goto('/wp-admin/edit.php?post_type=cta');
 
 
   // Deleted CTA Test ///////////////////////////////////////////.
 
-  await page.goto('http://localhost:8889/wp-admin/edit.php');
+  await page.goto('/wp-admin/edit.php');
   await page.getByRole('link', { name: '“Post with CTA” (Edit)' }).click();
   // ******* CTAが登録されていないメッセージが表示されることを確認
   await expect(page.locator('.alert-title')).toContainText('Specified CTA does not exist.');
@@ -129,7 +129,7 @@ test('CTA', async ({ page }) => {
   await page.waitForTimeout(500); // これがないと次の goto が反応しない事がある
 
   // Delete "Test CTA 2" ///////////////////////////////////////////.
-  await page.goto('http://localhost:8889/wp-admin/edit.php?post_type=cta');
+  await page.goto('/wp-admin/edit.php?post_type=cta');
   await page.getByRole('link', { name: '“Test CTA 2” (Edit)' }).click();
   await page.waitForTimeout(500); // wait the "Move to trash" button
   await page.getByRole('button', { name: 'Move to trash' }).click();

--- a/tests/e2e/promotion-alert.spec.ts
+++ b/tests/e2e/promotion-alert.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('Promotion Disclosure', async ({ page }) => {
 
 	// login ///////////////////////////////////////////.
-	await page.goto('http://localhost:8889/wp-login.php');
+	await page.goto('/wp-login.php');
 	await page.getByLabel('Username or Email Address').fill('admin');
 	await page.getByLabel('Username or Email Address').press('Tab');
 	await page.getByLabel('Password', { exact: true }).fill('password');
@@ -11,7 +11,7 @@ test('Promotion Disclosure', async ({ page }) => {
 
 	// Create Test Post Type  ///////////////////////////////////////////.
 
-	await page.goto('http://localhost:8889/wp-admin/post-new.php?post_type=post_type_manage');
+	await page.goto('/wp-admin/post-new.php?post_type=post_type_manage');
 
 	await page.getByLabel('Add title').fill('Test Post Type');
 	await page.locator('#veu_post_type_id').fill('test-post-type');
@@ -21,7 +21,7 @@ test('Promotion Disclosure', async ({ page }) => {
 
 	// Alert Setting  ///////////////////////////////////////////.
 
-	await page.goto('http://localhost:8889/wp-admin/admin.php?page=vkExUnit_main_setting');
+	await page.goto('/wp-admin/admin.php?page=vkExUnit_main_setting');
 
 	// テスト対象の投稿タイプにチェック
 	await page.locator('#vkExUnit_PA').getByLabel(' Test Post Type').check();
@@ -29,13 +29,13 @@ test('Promotion Disclosure', async ({ page }) => {
 
 	// Create New Test Post  ///////////////////////////////////////////.
 
-	await page.goto('http://localhost:8889/wp-admin/post-new.php?post_type=test-post-type');
+	await page.goto('/wp-admin/post-new.php?post_type=test-post-type');
 
 	// 設定メタボックスがあるかどうか
 	await expect(page.locator('.veu_display_promotion_alert .veu_metabox_section_title')).toContainText('Promotion Disclosure Setting');
 
 	// Delete CTA ///////////////////////////////////////////.
-	await page.goto('http://localhost:8889/wp-admin/edit.php?post_type=post_type_manage');
+	await page.goto('/wp-admin/edit.php?post_type=post_type_manage');
 	await page.locator('#cb-select-all-1').check();
 	await page.locator('#bulk-action-selector-top').selectOption('trash');
 	await page.locator('#doaction').click();


### PR DESCRIPTION
## 概要

Closes #1326

`tests/e2e/cta.spec.ts` および `tests/e2e/promotion-alert.spec.ts` 内の `page.goto()` がベースURL（`http://localhost:8889`）をハードコードしていたため、CI 環境やローカル環境でポートが異なる場合にテストが失敗していました。

これを相対パスに変更し、Playwright の `baseURL` 設定で解決する形に統一します。あわせて `playwright.config.ts` でコメントアウトされていた `baseURL` を有効化し、`WP_BASE_URL` 環境変数で上書きできるようにします。

## 変更内容

- `tests/e2e/cta.spec.ts`: `page.goto('http://localhost:8889/...')` を相対パス `page.goto('/...')` に置換（9箇所）
- `tests/e2e/promotion-alert.spec.ts`: 同様に置換（5箇所）
- `playwright.config.ts`: コメントアウトされていた `baseURL` を有効化し、`process.env.WP_BASE_URL || 'http://localhost:8889'` の形で環境変数による上書きに対応

### 既存運用との整合

リポジトリ内には既に `WP_BASE_URL` 環境変数で baseURL を切り替える慣習があります（`tests/e2e/sns-share-count-rest-api.spec.ts` ・ `tests/e2e/post-type-manager-veu-taxonomy-empty-string.spec.ts`）。今回はこの慣習に合わせる形で `playwright.config.ts` の `baseURL` を有効化しました。

なお、上記2ファイルは個別に `process.env.WP_BASE_URL || 'http://localhost:3465'` を持っていますが、これは今回の issue のスコープ外のため未変更です。

## 確認手順

### 前提条件

- ローカルに wp-env が起動できる環境
- Node.js / npm がインストールされている
- ブランチ `fix/1326-e2e-base-url-hardcoded` をチェックアウト

### 手順

#### Before（修正前の挙動の確認）※参考

1. 修正前のブランチ（master）に戻る
2. wp-env のポートを変更した状態（例: `.wp-env.override.json` で `testsPort: 9107` を指定）で `npm run wp-env start` を実行
3. `npx playwright test tests/e2e/cta.spec.ts` を実行
   → ✗ `http://localhost:8889/wp-login.php` に接続できずタイムアウトでテスト失敗

#### After（修正後の確認手順）

1. このブランチをチェックアウト
2. ワークツリーのルートに `.wp-env.override.json` を作成（テスト時のポート競合を避けるため、8888・8889 以外のポートを指定）

   ```json
   {
     "port": 9106,
     "testsPort": 9107
   }
   ```

3. `npm install` で依存関係を整える
4. `npm run wp-env start` で wp-env を起動
5. テストサイトのベースURLを環境変数で指定して Playwright を実行する

   ```bash
   WP_BASE_URL=http://localhost:9107 npx playwright test tests/e2e/cta.spec.ts tests/e2e/promotion-alert.spec.ts
   ```

   → ✓ 相対パスが `WP_BASE_URL` で解決され、両テストが PASS する
6. 環境変数を指定せずに wp-env のデフォルトポート（testsPort: 8889）で起動した状態でも実行する

   ```bash
   npx playwright test tests/e2e/cta.spec.ts tests/e2e/promotion-alert.spec.ts
   ```

   → ✓ `playwright.config.ts` のフォールバック `http://localhost:8889` で解決され、両テストが PASS する（デグレ確認）

### 補足

- `tests/e2e/sns-share-count-rest-api.spec.ts` と `tests/e2e/post-type-manager-veu-taxonomy-empty-string.spec.ts` は今回スコープ外のため変更なし。動作も変わりません

## changelog

エンドユーザーに影響しない開発環境改善のため、`readme.txt` への記載は不要と判断しています（`rules/changelog.md` に従い、WordPress.org プラグインの readme.txt には `[ 開発環境 ]` を記載しないルール）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
