### PR TITLE
[ 開発環境 ] active-setting.spec.ts のベースURLハードコードを相対パス化

### DIFF
--- a/tests/e2e/active-setting.spec.ts
+++ b/tests/e2e/active-setting.spec.ts
@@ -18,14 +18,14 @@ test('Active Setting first save respects selections', async ({ page }) => {
   }
 
   // login
-  await page.goto('http://localhost:8889/wp-login.php');
+  await page.goto('/wp-login.php');
   await page.getByLabel('Username or Email Address').fill('admin');
   await page.getByLabel('Username or Email Address').press('Tab');
   await page.getByLabel('Password', { exact: true }).fill('password');
   await page.getByLabel('Password', { exact: true }).press('Enter');
 
   // Go to Active Setting page
-  await page.goto('http://localhost:8889/wp-admin/admin.php?page=vkExUnit_setting_page');
+  await page.goto('/wp-admin/admin.php?page=vkExUnit_setting_page');
 
   const metaCheckbox = page.locator('#checkbox_active_metaDescription');
   await expect(metaCheckbox).toBeVisible();


### PR DESCRIPTION
## 概要

issue #1340 対応。

`tests/e2e/active-setting.spec.ts` で `page.goto()` の引数に `http://localhost:8889` がハードコードされており、`e2e.md` のベースURLルール（絶対URLのハードコード禁止）に違反していたのを修正。

2箇所を相対パスに置換し、`playwright.config.ts` の `baseURL`（環境変数 `WP_BASE_URL` で上書き可能、PR #1339 で対応済み）に解決させる構成にする。

closes #1340

## 変更内容

- `tests/e2e/active-setting.spec.ts` L21: `page.goto('http://localhost:8889/wp-login.php')` → `page.goto('/wp-login.php')`
- `tests/e2e/active-setting.spec.ts` L28: `page.goto('http://localhost:8889/wp-admin/admin.php?page=vkExUnit_setting_page')` → `page.goto('/wp-admin/admin.php?page=vkExUnit_setting_page')`

## 変更ファイル

- `tests/e2e/active-setting.spec.ts` (+2 / -2)

## 関連

- 同パターンの先行対応: #1339（issue #1326 対応）

## changelog 更新について

今回は `[ 開発環境 ]` 分類かつ `readme.txt` がエンドユーザー向けのため、`rules/changelog.md` の規則に従い changelog 更新は不要（PR #1339 と同じ判断）。`CHANGELOG.md` は本リポジトリには存在しない。

## 確認手順

### 前提条件

- Node.js / npm がインストール済み
- Docker（wp-env 用）が起動可能

### 手順

#### After（修正後 / デフォルトポート 8889 での確認）

1. 本ブランチ `fix/1340-e2e-hardcoded-base-url` をチェックアウトする
2. `npm ci` で依存関係をインストール
3. `npx wp-env start` で wp-env を起動（デフォルトポート: dev=8888 / tests=8889）
4. `npx playwright test tests/e2e/active-setting.spec.ts --project=chromium` を実行
   → ✓ テストが PASS する（ログイン → Active Setting 画面遷移 → チェックボックス保存検証が成功）

#### After（ポート違い環境でのベースURL解決確認）

1. リポジトリのルートに `.wp-env.override.json` を作成し、以下を記載
   ```json
   { "port": 9104, "testsPort": 9105 }
   ```
2. `npx wp-env stop && npx wp-env start` で wp-env を再起動
3. `WP_BASE_URL=http://localhost:9105 npx playwright test tests/e2e/active-setting.spec.ts --project=chromium` を実行
   → ✓ ポート 9105 でもテストが PASS する（`baseURL` が `WP_BASE_URL` 経由で解決されることを確認）
4. `WP_BASE_URL` を指定せずに `npx playwright test tests/e2e/active-setting.spec.ts --project=chromium` を実行
   → ✗ デフォルトの `http://localhost:8889` を見にいくため、ポート違い環境では失敗する（= 環境変数で正しく上書きできていることの裏付け）

#### デグレ確認

1. `cta.spec.ts` / `promotion-alert.spec.ts`（PR #1339 で同様の対応済み）も同時に実行
   ```
   npx playwright test tests/e2e/cta.spec.ts tests/e2e/promotion-alert.spec.ts --project=chromium
   ```
   → ✓ 既存テストが引き続き PASS する（相対パス + `baseURL` 解決の構成が壊れていないこと）

## スクリーンショット

純粋なテストコード修正（表示・UI への影響なし）のため省略。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **テスト**
  * e2eテストのURL参照方法を改善しました。相対URLを使用することでテストの柔軟性が向上しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1341)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->