### PR TITLE
[ 開発環境 ] 既存 e2e テスト (cta / promotion-alert) の failing を修正

### DIFF
--- a/tests/e2e/cta.spec.ts
+++ b/tests/e2e/cta.spec.ts
@@ -1,137 +1,288 @@
-import { test, expect } from '@playwright/test';
-// const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+/**
+ * CTA - e2e テスト
+ *
+ * Call to Action 機能の主要シナリオを検証する:
+ *
+ * 1. CTA 未登録の状態で投稿に CTA ブロックを挿入すると
+ *    「No CTA registered.」というアラートが出る
+ * 2. CTA 投稿を 1 件作成（Test CTA）
+ * 3. 通常投稿に CTA ブロックを追加し、Test CTA を選択すると
+ *    本文がプレビュー表示される
+ * 4. CTA を一括削除して別の CTA を 1 件作っておく
+ * 5. 既存の "Post with CTA" を再オープンすると
+ *    「Specified CTA does not exist.」エラーが表示される
+ *
+ * WordPress 6.x のブロックエディタは編集領域が
+ * `editor-canvas` iframe 内に描画されるため、本文・タイトル等の
+ * 操作はすべて `editorFrame(page)` 経由で行う。
+ * ブロック追加ボタンの aria-label は WP の更新により
+ * "Add block" → "Block Inserter" に変わっている。
+ */
+import { test, expect, type Page, type FrameLocator } from '@playwright/test';
+import { execFileSync } from 'child_process';
 
-test('CTA', async ({ page }) => {
+const ADMIN_USER = 'admin';
+const ADMIN_PASS = 'password';
 
-  // login ///////////////////////////////////////////.
-  await page.goto('/wp-login.php');
-  await page.getByLabel('Username or Email Address').fill('admin');
-  await page.getByLabel('Username or Email Address').press('Tab');
-  await page.getByLabel('Password', { exact: true } ).fill('password');
-  await page.getByLabel('Password', { exact: true } ).press('Enter');
+// wp-env の tests-cli コンテナ経由で wp-cli を実行するヘルパー。
+// e2e は testsPort (デフォルト 8889) のテスト用 WordPress を使うため、
+// データ初期化も tests-cli コンテナで行う必要がある。
+const runWpCli = ( args: string[] ): string => {
+	return execFileSync(
+		'npx',
+		[ 'wp-env', 'run', 'tests-cli', 'wp', ...args ],
+		{
+			encoding: 'utf-8',
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+		}
+	);
+};
 
-  // Put CTA ( Not registered ) ///////////////////////////////////////////.
+// Block Editor 本文の iframe (editor-canvas) ロケータ。
+const editorFrame = ( page: Page ): FrameLocator =>
+	page.frameLocator( '[name="editor-canvas"]' );
 
-  // Got to New Post
-  await page.goto('/wp-admin/post-new.php');
+// 投稿 / CTA 投稿をすべて強制削除して初期化する。
+// テスト用の Test CTA / Post with CTA 等の残骸を取り除く。
+const resetPosts = (): void => {
+	for ( const postType of [ 'post', 'cta' ] ) {
+		try {
+			const ids = runWpCli( [
+				'post',
+				'list',
+				`--post_type=${ postType }`,
+				'--post_status=any',
+				'--format=ids',
+			] ).trim();
+			if ( ids ) {
+				runWpCli( [
+					'post',
+					'delete',
+					'--force',
+					...ids.split( /\s+/ ),
+				] );
+			}
+		} catch ( _e ) {
+			// 取得・削除失敗は無視（テストを止めない）
+		}
+	}
+};
 
-  // 最初の投稿ダイアログを閉じる
-  await page.waitForTimeout( 1000 );
-  // Check if the modal is visible
-  const isModalVisible = await page.isVisible( '.components-modal__frame' );
-  // If the modal is visible, click the close button
-  if ( isModalVisible ) {
-	  await page.click( 'button[aria-label="Close"]' );
-  }
+// 編集画面で Welcome guide modal が表示されたら閉じる。
+const closeWelcomeModalIfPresent = async ( page: Page ): Promise<void> => {
+	const isModalVisible = await page.isVisible( '.components-modal__frame' );
+	if ( isModalVisible ) {
+		await page.click( 'button[aria-label="Close"]' );
+		await page.waitForTimeout( 300 );
+	}
+};
 
-  // ブロック追加
-  await page.getByRole('button', { name: 'Add block' }).click();
-  // CTAブロックを検索
-  await page.getByPlaceholder('Search').fill('cta');
-  // CTAブロックを追加
-  await page.getByRole('option', { name: 'CTA' }).click();
+// Block Editor の編集領域 (iframe) が初期化されるまで待つ。
+const waitForBlockEditorReady = async ( page: Page ): Promise<void> => {
+	await editorFrame( page )
+		.locator( '[contenteditable="true"]' )
+		.first()
+		.waitFor( { timeout: 15000 } );
+};
 
-  // ******* CTAが登録されていないメッセージが表示されることを確認
-  await expect(page.locator('.veu-cta-block-edit-alert .alert-title')).toContainText('No CTA registered.');
+// CTA ブロックを Block Inserter から挿入する。
+// WP 6.x の Block Inserter は docked サイドバー型で、検索結果に
+// "Blocks" listbox と "Block patterns" listbox の両方が現れるため、
+// "Blocks" listbox 内に絞り、完全一致 "CTA" を選択する。
+const insertCtaBlock = async ( page: Page ): Promise<void> => {
+	await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+	await page.getByRole( 'searchbox', { name: 'Search' } ).fill( 'cta' );
+	await page
+		.getByRole( 'listbox', { name: 'Blocks' } )
+		.getByRole( 'option', { name: 'CTA', exact: true } )
+		.click();
+	// 挿入後、Block Inserter を閉じる（docked のため自動で閉じない）。
+	const closeBtn = page.getByRole( 'button', {
+		name: 'Close Block Inserter',
+	} );
+	if ( ( await closeBtn.count() ) > 0 ) {
+		await closeBtn.click();
+	}
+};
 
-  // Save Check
-  await page.getByRole('region', { name: 'Editor top bar' }).getByRole('button', { name: 'Publish' }).click();
-  await page.getByRole('button', { name: 'Publish' }).nth(1).click();
-  await page.waitForTimeout(1000);
-  await page.getByRole('button', { name: 'Close panel' }).click();
-  await page.getByRole('region', { name: 'Editor settings' }).getByRole('button', { name: 'Post' }).click();
-  await page.getByRole('button', { name: 'Move to trash' }).click();
-  // 完了まで待つ（完了判定の書き方がわかったら書き換え）
-  await page.waitForTimeout(1000);
+// 投稿を公開する。Block Editor の Publish ボタン → 確認パネルの Publish。
+// WP の更新でボタン構成が変わっても極力動作するよう、複数の locator を試す。
+const publishPost = async ( page: Page ): Promise<void> => {
+	// 1) Top bar の Publish ボタン（公開パネルを開く）。
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Publish', exact: true } )
+		.click();
 
-  // Create New CTA ///////////////////////////////////////////.
+	// 2) 公開パネル内の確定 Publish ボタンを探す。
+	//    role=region の名前は WP のバージョンで異なるため、
+	//    まずは "Editor publish" 領域内、見つからなければページ全体から
+	//    最後に現れた Publish ボタンを使う。
+	const publishRegion = page.getByRole( 'region', {
+		name: 'Editor publish',
+	} );
+	let confirmBtn = publishRegion.getByRole( 'button', {
+		name: 'Publish',
+		exact: true,
+	} );
+	if ( ( await confirmBtn.count() ) === 0 ) {
+		// fallback: ページ全体の Publish ボタン (top bar 以外)
+		confirmBtn = page.getByRole( 'button', {
+			name: 'Publish',
+			exact: true,
+		} );
+	}
+	// 公開パネルが表示されるまで少し待つ。
+	await page.waitForTimeout( 500 );
+	await confirmBtn.last().click();
 
-  // Go to New CTA
-  await page.goto('/wp-admin/post-new.php?post_type=cta');
-  // Input CTA title
-  await page.getByRole('textbox', { name: 'Add title' }).click();
-  await page.getByRole('textbox', { name: 'Add title' }).fill('Test CTA');
-  await page.getByRole('textbox', { name: 'Add title' }).press('Enter');
-  // Input CTA content
-  await page.getByRole('document', { name: 'Empty block; start writing or type forward slash to choose a block' }).first().fill('This is Test CTA');
-  // Publish CTA
-  await page.getByRole('region', { name: 'Editor top bar' }).getByRole('button', { name: 'Publish' }).click();
-  await page.getByRole('button', { name: 'Publish' }).nth(1).click();
-  // 一応少し待つ。待たないとCTAを配置するテストでプルダウンの中に Test CTA が入っていなくて選択できない事がある。
-  await page.waitForTimeout(1000);
-  // Cheack CTA is created
-  await page.goto('/wp-admin/edit.php?post_type=cta');
+	// 公開完了を確実に反映させる。
+	await page.waitForTimeout( 1500 );
+};
 
+test.describe( 'CTA', () => {
+	test.describe.configure( { mode: 'serial' } );
+	test.setTimeout( 90 * 1000 );
 
-  // Create New Post and Add CTA ///////////////////////////////////////////.
+	test.beforeAll( () => {
+		resetPosts();
+	} );
 
-  await page.goto('/wp-admin/post-new.php');
-  // Input Post with CTA title
-  await page.getByRole('textbox', { name: 'Add title' }).click();
-  await page.getByRole('textbox', { name: 'Add title' }).fill('Post with CTA');
-  // ブロック追加
-  await page.getByRole('button', { name: 'Add block' }).click();
-  // CTAブロックを検索
-  await page.getByPlaceholder('Search').fill('cta');
-  // CTAブロックを追加
-  await page.getByRole('option', { name: 'CTA' }).click();
+	test.afterAll( () => {
+		resetPosts();
+	} );
 
-  // ******* CTAを選択するように促すメッセージが表示されることを確認
-  await expect(page.locator('.veu-cta-block-edit-alert')).toContainText('Please select CTA from Setting sidebar.');
+	test.beforeEach( async ( { page } ) => {
+		// ログイン。
+		await page.goto( '/wp-login.php' );
+		await page.getByLabel( 'Username or Email Address' ).fill( ADMIN_USER );
+		await page
+			.getByLabel( 'Password', { exact: true } )
+			.fill( ADMIN_PASS );
+		await page
+			.getByLabel( 'Password', { exact: true } )
+			.press( 'Enter' );
+		await page.waitForURL( /wp-admin\// );
+	} );
 
-  // 作成済みのCTAを選択
-  await page.locator('#veu-cta-block-select').selectOption({ label: 'Test CTA' });
+	test( 'CTA 未登録 → ブロック追加で No CTA registered メッセージ', async ( {
+		page,
+	} ) => {
+		// --- 通常投稿で CTA ブロックを追加（CTA 未登録の状態） ---
+		await page.goto( '/wp-admin/post-new.php' );
+		await closeWelcomeModalIfPresent( page );
+		await waitForBlockEditorReady( page );
 
-  // ******* 作成したCTAが表示されることを確認
-  await expect(page.locator('.veu-cta-block p')).toContainText('This is Test CTA');
+		await insertCtaBlock( page );
 
-  // 作成したCTAが配置された状態で保存
-  await page.getByRole('region', { name: 'Editor top bar' }).getByRole('button', { name: 'Publish' }).click();
-  await page.getByRole('button', { name: 'Publish' }).nth(1).click();
+		// CTA が登録されていないメッセージ（ブロック本文は iframe 内）。
+		await expect(
+			editorFrame( page ).locator(
+				'.veu-cta-block-edit-alert .alert-title'
+			)
+		).toContainText( 'No CTA registered.' );
+	} );
 
-  // 一応少し待つ。待たないとCTAを配置するテストでプルダウンの中に Test CTA が入っていなくて選択できない事がある。
-  await page.waitForTimeout(1000);
+	test( 'CTA 投稿を作成 → 通常投稿で選択 → 本文プレビュー / 後で削除すると Specified CTA does not exist', async ( {
+		page,
+	} ) => {
+		// --- CTA 投稿 "Test CTA" を作成 ---
+		await page.goto( '/wp-admin/post-new.php?post_type=cta' );
+		await closeWelcomeModalIfPresent( page );
+		await waitForBlockEditorReady( page );
 
-  // Delete CTA ///////////////////////////////////////////.
-  await page.goto('/wp-admin/edit.php?post_type=cta');
-  await page.locator('#cb-select-all-1').check();
-  await page.locator('#bulk-action-selector-top').selectOption('trash');
-  await page.locator('#doaction').click();
-  // Add CTA 2 ///////////////////////////////////////////.
-  // 登録済みのCTAが削除された場合のメッセージの確認用
-  // CTAが存在しない状態の場合、CTAブロックは「CTA自体がない」というメッセージになるため、
-  // ダミーで適当なCTAを登録しておく
-  await page.locator('#wpbody-content').getByRole('link', { name: 'Add New' }).click();
-  await page.getByRole('textbox', { name: 'Add title' }).click();
-  await page.getByRole('textbox', { name: 'Add title' }).fill('Test CTA 2');
-  await page.getByRole('textbox', { name: 'Add title' }).press('Enter');
-  // Input CTA content
-  await page.getByRole('document', { name: 'Empty block; start writing or type forward slash to choose a block' }).first().fill('This is Test CTA 2');
-  // Publish CTA
-  await page.getByRole('region', { name: 'Editor top bar' }).getByRole('button', { name: 'Publish' }).click();
-  await page.getByRole('button', { name: 'Publish' }).nth(1).click();
-  // 一応少し待つ。
-  await page.waitForTimeout(1000);
-  // Cheack CTA is created
-  await page.goto('/wp-admin/edit.php?post_type=cta');
+		// タイトルと本文は iframe 内。
+		const ctaTitle = editorFrame( page ).getByLabel( 'Add title' );
+		await ctaTitle.click();
+		await ctaTitle.fill( 'Test CTA' );
 
+		// 本文プレースホルダー "Type / to choose a block" をクリック → タイプ。
+		// 最新の Block Editor では空の本文は textbox role を持たず、
+		// 「Add default block」ボタンとして表示されるためそれにフォーカスする。
+		await editorFrame( page )
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'This is Test CTA' );
 
-  // Deleted CTA Test ///////////////////////////////////////////.
+		// 公開（Editor top bar の Publish ボタンクリック → 公開パネルが開く）。
+		await publishPost( page );
 
-  await page.goto('/wp-admin/edit.php');
-  await page.getByRole('link', { name: '“Post with CTA” (Edit)' }).click();
-  // ******* CTAが登録されていないメッセージが表示されることを確認
-  await expect(page.locator('.alert-title')).toContainText('Specified CTA does not exist.');
+		// --- 通常投稿で CTA ブロックを追加し Test CTA を選択 ---
+		await page.goto( '/wp-admin/post-new.php' );
+		await closeWelcomeModalIfPresent( page );
+		await waitForBlockEditorReady( page );
 
-  // Delete "Post with CTA"
-  await page.waitForTimeout(500); // wait the "Move to trash" button
-  await page.getByRole('button', { name: 'Move to trash' }).click();
-  await page.waitForTimeout(500); // これがないと次の goto が反応しない事がある
+		const postTitle = editorFrame( page ).getByLabel( 'Add title' );
+		await postTitle.click();
+		await postTitle.fill( 'Post with CTA' );
 
-  // Delete "Test CTA 2" ///////////////////////////////////////////.
-  await page.goto('/wp-admin/edit.php?post_type=cta');
-  await page.getByRole('link', { name: '“Test CTA 2” (Edit)' }).click();
-  await page.waitForTimeout(500); // wait the "Move to trash" button
-  await page.getByRole('button', { name: 'Move to trash' }).click();
+		await insertCtaBlock( page );
 
-});
+		// CTA を選択するように促すメッセージ確認。
+		await expect(
+			editorFrame( page ).locator( '.veu-cta-block-edit-alert' )
+		).toContainText( 'Please select CTA from Setting sidebar.' );
+
+		// CTA ブロックを選択状態にする（Inspector を Block tab に切替え可能にするため）。
+		await editorFrame( page ).locator( '.veu-cta-block-edit' ).click();
+
+		// 右サイドバーの "Block" tab に切替え。CTA SelectControl は
+		// InspectorControls 内のため、ブロック選択中に "Block" tab を開かないと
+		// レンダリングされない。
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Block' } )
+			.click();
+
+		// セレクトボックスから Test CTA を選択（メインフレーム側）。
+		await page
+			.locator( '#veu-cta-block-select' )
+			.selectOption( { label: 'Test CTA' } );
+
+		// 選択後、本文プレビューに本文文字列が現れること（プレビューは iframe 内の ServerSideRender）。
+		await expect(
+			editorFrame( page ).locator( '.veu-cta-block' )
+		).toContainText( 'This is Test CTA' );
+
+		// 投稿を公開。
+		await publishPost( page );
+
+		// --- 既存 CTA をすべてゴミ箱へ ---
+		await page.goto( '/wp-admin/edit.php?post_type=cta' );
+		await page.locator( '#cb-select-all-1' ).check();
+		await page
+			.locator( '#bulk-action-selector-top' )
+			.selectOption( 'trash' );
+		await page.locator( '#doaction' ).click();
+
+		// --- 「CTA がまったく無い状態」を避けるためダミー CTA を 1 件作成 ---
+		// CTA が完全に 0 件だと CTA ブロック側のアラートが
+		// 「No CTA registered.」に切り替わってしまうため、別ケースを再現する。
+		await page.goto( '/wp-admin/post-new.php?post_type=cta' );
+		await closeWelcomeModalIfPresent( page );
+		await waitForBlockEditorReady( page );
+
+		const cta2Title = editorFrame( page ).getByLabel( 'Add title' );
+		await cta2Title.click();
+		await cta2Title.fill( 'Test CTA 2' );
+		await editorFrame( page )
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'This is Test CTA 2' );
+
+		await publishPost( page );
+
+		// --- 削除済み CTA を参照している投稿を再オープン ---
+		await page.goto( '/wp-admin/edit.php' );
+		await page
+			.getByRole( 'link', { name: '“Post with CTA” (Edit)' } )
+			.click();
+		await waitForBlockEditorReady( page );
+		await closeWelcomeModalIfPresent( page );
+
+		// 指定 CTA が存在しないメッセージ確認。
+		await expect(
+			editorFrame( page ).locator( '.alert-title' )
+		).toContainText( 'Specified CTA does not exist.' );
+	} );
+} );

--- a/tests/e2e/cta.spec.ts
+++ b/tests/e2e/cta.spec.ts
@@ -44,36 +44,51 @@ const editorFrame = ( page: Page ): FrameLocator =>
 
 // 投稿 / CTA 投稿をすべて強制削除して初期化する。
 // テスト用の Test CTA / Post with CTA 等の残骸を取り除く。
+// セットアップ失敗が flake の原因にならないよう、wp-cli の失敗は throw で表面化する。
+// （wp-env が立っていない・コンテナ取得不能などの致命的な状況は早期に検出したい）
 const resetPosts = (): void => {
 	for ( const postType of [ 'post', 'cta' ] ) {
+		let ids: string;
 		try {
-			const ids = runWpCli( [
+			ids = runWpCli( [
 				'post',
 				'list',
 				`--post_type=${ postType }`,
 				'--post_status=any',
 				'--format=ids',
 			] ).trim();
-			if ( ids ) {
-				runWpCli( [
-					'post',
-					'delete',
-					'--force',
-					...ids.split( /\s+/ ),
-				] );
-			}
-		} catch ( _e ) {
-			// 取得・削除失敗は無視（テストを止めない）
+		} catch ( e ) {
+			const message = e instanceof Error ? e.message : String( e );
+			throw new Error(
+				`resetPosts: failed to list ${ postType } via tests-cli: ${ message }`
+			);
+		}
+		if ( ! ids ) {
+			continue;
+		}
+		try {
+			runWpCli( [
+				'post',
+				'delete',
+				'--force',
+				...ids.split( /\s+/ ),
+			] );
+		} catch ( e ) {
+			const message = e instanceof Error ? e.message : String( e );
+			throw new Error(
+				`resetPosts: failed to delete ${ postType } posts via tests-cli: ${ message }`
+			);
 		}
 	}
 };
 
 // 編集画面で Welcome guide modal が表示されたら閉じる。
 const closeWelcomeModalIfPresent = async ( page: Page ): Promise<void> => {
-	const isModalVisible = await page.isVisible( '.components-modal__frame' );
-	if ( isModalVisible ) {
+	const modal = page.locator( '.components-modal__frame' );
+	if ( await modal.isVisible() ) {
 		await page.click( 'button[aria-label="Close"]' );
-		await page.waitForTimeout( 300 );
+		// 固定スリープではなく、モーダルが実際に閉じるまで待つ。
+		await modal.waitFor( { state: 'hidden', timeout: 5000 } );
 	}
 };
 
@@ -132,12 +147,27 @@ const publishPost = async ( page: Page ): Promise<void> => {
 			exact: true,
 		} );
 	}
-	// 公開パネルが表示されるまで少し待つ。
-	await page.waitForTimeout( 500 );
-	await confirmBtn.last().click();
+	// 公開パネルが完全に表示されてからクリックする（固定スリープ廃止）。
+	const target = confirmBtn.last();
+	await target.waitFor( { state: 'visible', timeout: 5000 } );
+	await target.click();
 
-	// 公開完了を確実に反映させる。
-	await page.waitForTimeout( 1500 );
+	// 公開完了を UI 状態で待つ。Block Editor は公開後に top bar の
+	// Publish ボタンが "Saved" / "Update" 表示に切替わるか、"Post published"
+	// スナックバーが表示されるため、いずれかを待機する。
+	const snackbar = page.locator( '.components-snackbar' ).filter( {
+		hasText: /Published|published/i,
+	} );
+	const savedBtn = page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: /^(Saved|Save|Update)$/, exact: false } );
+	await Promise.race( [
+		snackbar.first().waitFor( { state: 'visible', timeout: 10000 } ),
+		savedBtn.first().waitFor( { state: 'visible', timeout: 10000 } ),
+	] ).catch( () => {
+		// どちらも掴めなくても致命ではないため握りつぶす（後続の goto で
+		// ページ遷移すれば自然に確定する）。
+	} );
 };
 
 test.describe( 'CTA', () => {
@@ -274,8 +304,11 @@ test.describe( 'CTA', () => {
 
 		// --- 削除済み CTA を参照している投稿を再オープン ---
 		await page.goto( '/wp-admin/edit.php' );
+		// アクセシブルネームに含まれる引用符は WordPress / ロケールにより
+		// "…" / "..." / "&quot;" など揺らぐため、タイトル部分のみで部分一致させる。
 		await page
-			.getByRole( 'link', { name: '“Post with CTA” (Edit)' } )
+			.getByRole( 'link', { name: /Post with CTA/i } )
+			.first()
 			.click();
 		await waitForBlockEditorReady( page );
 		await closeWelcomeModalIfPresent( page );

--- a/tests/e2e/promotion-alert.spec.ts
+++ b/tests/e2e/promotion-alert.spec.ts
@@ -35,32 +35,65 @@ const runWpCli = ( args: string[] ): string => {
 };
 
 // テスト用 CPT 設定投稿（post_type_manage）と Promotion 設定をリセット。
-// option / 投稿の不存在エラーは握りつぶす（reset 用なので未存在は OK）。
+// option / 投稿が未存在の場合だけ握りつぶし、それ以外の wp-cli 失敗は
+// セットアップ起因の flake を防ぐため throw で表面化する。
 const resetPromotionAlertState = (): void => {
 	try {
 		runWpCli( [ 'option', 'delete', 'vkExUnit_PA' ] );
-	} catch ( _e ) {
-		// option が無い場合は無視
+	} catch ( e ) {
+		// wp-cli は未存在 option を delete しようとすると
+		// "Could not delete '...' option. Does it exist?" を返す。
+		// これだけは想定内として握りつぶし、それ以外は再 throw する。
+		const stderr =
+			e && typeof e === 'object' && 'stderr' in e
+				? String( ( e as { stderr?: unknown } ).stderr ?? '' )
+				: '';
+		const message = e instanceof Error ? e.message : String( e );
+		const haystack = `${ stderr }\n${ message }`;
+		const isMissingOption =
+			/Could not delete\s+'vkExUnit_PA'\s+option\.\s*Does it exist\?/i.test(
+				haystack
+			) ||
+			( /vkExUnit_PA/.test( haystack ) &&
+				/does(?:\s+not)?\s+exist/i.test( haystack ) );
+		if ( ! isMissingOption ) {
+			throw new Error(
+				`resetPromotionAlertState: failed to delete vkExUnit_PA option via tests-cli: ${ message }`
+			);
+		}
 	}
+
+	// post_type_manage 投稿を全削除（強制削除でゴミ箱経由しない）。
+	let ids: string;
 	try {
-		// post_type_manage 投稿を全削除（強制削除でゴミ箱経由しない）。
-		const ids = runWpCli( [
+		ids = runWpCli( [
 			'post',
 			'list',
 			'--post_type=post_type_manage',
 			'--post_status=any',
 			'--format=ids',
 		] ).trim();
-		if ( ids ) {
-			runWpCli( [
-				'post',
-				'delete',
-				'--force',
-				...ids.split( /\s+/ ),
-			] );
-		}
-	} catch ( _e ) {
-		// 失敗してもテスト続行
+	} catch ( e ) {
+		const message = e instanceof Error ? e.message : String( e );
+		throw new Error(
+			`resetPromotionAlertState: failed to list post_type_manage via tests-cli: ${ message }`
+		);
+	}
+	if ( ! ids ) {
+		return;
+	}
+	try {
+		runWpCli( [
+			'post',
+			'delete',
+			'--force',
+			...ids.split( /\s+/ ),
+		] );
+	} catch ( e ) {
+		const message = e instanceof Error ? e.message : String( e );
+		throw new Error(
+			`resetPromotionAlertState: failed to delete post_type_manage posts via tests-cli: ${ message }`
+		);
 	}
 };
 
@@ -135,12 +168,11 @@ test.describe( 'Promotion Disclosure', () => {
 			.waitFor( { timeout: 15000 } );
 
 		// Welcome guide modal が出る場合は閉じる。
-		const isModalVisible = await page.isVisible(
-			'.components-modal__frame'
-		);
-		if ( isModalVisible ) {
+		const modal = page.locator( '.components-modal__frame' );
+		if ( await modal.isVisible() ) {
 			await page.click( 'button[aria-label="Close"]' );
-			await page.waitForTimeout( 300 );
+			// 固定スリープではなく、モーダルが実際に閉じるまで待つ。
+			await modal.waitFor( { state: 'hidden', timeout: 5000 } );
 		}
 
 		// VK ExUnit の PluginSidebar アイコンをクリックして開く。
@@ -158,14 +190,8 @@ test.describe( 'Promotion Disclosure', () => {
 			} )
 		).toBeVisible();
 
-		// --- 後片付け: 作成した CPT 設定投稿を削除 ---
-		await page.goto(
-			'/wp-admin/edit.php?post_type=post_type_manage'
-		);
-		await page.locator( '#cb-select-all-1' ).check();
-		await page
-			.locator( '#bulk-action-selector-top' )
-			.selectOption( 'trash' );
-		await page.locator( '#doaction' ).click();
+		// 後片付けは afterAll の resetPromotionAlertState() に任せる。
+		// UI 経由のクリーンアップは失敗しても検出できないため、
+		// wp-cli ベースの確実な削除に一本化する。
 	} );
 } );

--- a/tests/e2e/promotion-alert.spec.ts
+++ b/tests/e2e/promotion-alert.spec.ts
@@ -1,42 +1,171 @@
+/**
+ * Promotion Disclosure - e2e テスト
+ *
+ * カスタム投稿タイプを作成し、メイン設定で「広告開示」の対象に
+ * チェックを入れた後、その投稿タイプの新規投稿画面で
+ * 広告開示の設定 UI（VK ExUnit 用 PluginSidebar 内の
+ * "Promotion Disclosure Setting" パネル）が表示されることを検証する。
+ *
+ * WordPress 6.x のブロックエディタでは、従来の VEU 統合メタボックスは
+ * `__back_compat_meta_box` フラグにより非表示となり、設定 UI は
+ * 右上「VK All in One Expansion Unit」アイコンから開く PluginSidebar
+ * 内のパネルへ移行している。本テストはその挙動に追従している。
+ *
+ * テスト前後で wp-cli を使い、テスト用 CPT 作成データと
+ * `vkExUnit_PA` オプションを直接初期化する。
+ */
 import { test, expect } from '@playwright/test';
+import { execFileSync } from 'child_process';
 
-test('Promotion Disclosure', async ({ page }) => {
+const ADMIN_USER = 'admin';
+const ADMIN_PASS = 'password';
 
-	// login ///////////////////////////////////////////.
-	await page.goto('/wp-login.php');
-	await page.getByLabel('Username or Email Address').fill('admin');
-	await page.getByLabel('Username or Email Address').press('Tab');
-	await page.getByLabel('Password', { exact: true }).fill('password');
-	await page.getByLabel('Password', { exact: true }).press('Enter');
+// wp-env の tests-cli コンテナ経由で wp-cli を実行するヘルパー。
+// e2e は testsPort (デフォルト 8889) のテスト用 WordPress を使うため、
+// データ初期化も tests-cli コンテナで行う必要がある。
+const runWpCli = ( args: string[] ): string => {
+	return execFileSync(
+		'npx',
+		[ 'wp-env', 'run', 'tests-cli', 'wp', ...args ],
+		{
+			encoding: 'utf-8',
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+		}
+	);
+};
 
-	// Create Test Post Type  ///////////////////////////////////////////.
+// テスト用 CPT 設定投稿（post_type_manage）と Promotion 設定をリセット。
+// option / 投稿の不存在エラーは握りつぶす（reset 用なので未存在は OK）。
+const resetPromotionAlertState = (): void => {
+	try {
+		runWpCli( [ 'option', 'delete', 'vkExUnit_PA' ] );
+	} catch ( _e ) {
+		// option が無い場合は無視
+	}
+	try {
+		// post_type_manage 投稿を全削除（強制削除でゴミ箱経由しない）。
+		const ids = runWpCli( [
+			'post',
+			'list',
+			'--post_type=post_type_manage',
+			'--post_status=any',
+			'--format=ids',
+		] ).trim();
+		if ( ids ) {
+			runWpCli( [
+				'post',
+				'delete',
+				'--force',
+				...ids.split( /\s+/ ),
+			] );
+		}
+	} catch ( _e ) {
+		// 失敗してもテスト続行
+	}
+};
 
-	await page.goto('/wp-admin/post-new.php?post_type=post_type_manage');
+test.describe( 'Promotion Disclosure', () => {
+	// 全テストで同じ option / CPT を書き換えるため、シリアル実行。
+	test.describe.configure( { mode: 'serial' } );
 
-	await page.getByLabel('Add title').fill('Test Post Type');
-	await page.locator('#veu_post_type_id').fill('test-post-type');
-	await page.getByText('title', { exact: true }).click();
-	await page.getByText('editor', { exact: true }).click();
-	await page.getByRole('button', { name: 'Publish', exact: true }).click();
+	test.beforeEach( async ( { page } ) => {
+		// 既存の Promotion 設定をクリーンアップ。
+		resetPromotionAlertState();
 
-	// Alert Setting  ///////////////////////////////////////////.
+		// ログイン。
+		await page.goto( '/wp-login.php' );
+		await page.getByLabel( 'Username or Email Address' ).fill( ADMIN_USER );
+		await page
+			.getByLabel( 'Password', { exact: true } )
+			.fill( ADMIN_PASS );
+		await page
+			.getByLabel( 'Password', { exact: true } )
+			.press( 'Enter' );
+		await page.waitForURL( /wp-admin\// );
+	} );
 
-	await page.goto('/wp-admin/admin.php?page=vkExUnit_main_setting');
+	test.afterAll( () => {
+		resetPromotionAlertState();
+	} );
 
-	// テスト対象の投稿タイプにチェック
-	await page.locator('#vkExUnit_PA').getByLabel(' Test Post Type').check();
-	await page.locator('#on_setting').getByRole('button', { name: 'Save Changes' }).click();
+	test( 'CPT 作成 → 設定対象に追加 → 新規投稿の PluginSidebar に Promotion Disclosure Setting が表示される', async ( {
+		page,
+	} ) => {
+		// --- カスタム投稿タイプ "Test Post Type" を作成 ---
+		// post_type_manage は Classic Editor 画面なので Block Editor の
+		// iframe 対応は不要。
+		await page.goto( '/wp-admin/post-new.php?post_type=post_type_manage' );
+		await page.getByLabel( 'Add title' ).fill( 'Test Post Type' );
+		await page.locator( '#veu_post_type_id' ).fill( 'test-post-type' );
+		// supports の "title" / "editor" を有効化。
+		await page.getByText( 'title', { exact: true } ).click();
+		await page.getByText( 'editor', { exact: true } ).click();
+		await page
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+		// 公開後に編集画面 ( ?post=xxx ) へ遷移するのを待つ。
+		await page.waitForURL( /post=\d+/ );
 
-	// Create New Test Post  ///////////////////////////////////////////.
+		// --- メイン設定で Promotion Disclosure 対象に CPT を追加 ---
+		await page.goto( '/wp-admin/admin.php?page=vkExUnit_main_setting' );
+		await page
+			.locator( '#vkExUnit_PA' )
+			.getByLabel( ' Test Post Type' )
+			.check();
+		await page
+			.locator( '#on_setting' )
+			.getByRole( 'button', { name: 'Save Changes' } )
+			.click();
+		await page.waitForLoadState( 'domcontentloaded' );
 
-	await page.goto('/wp-admin/post-new.php?post_type=test-post-type');
+		// チェック保存後、もう一度開いて check 状態を確認。
+		const cpTypeCheckbox = page
+			.locator( '#vkExUnit_PA' )
+			.getByLabel( ' Test Post Type' );
+		await expect( cpTypeCheckbox ).toBeChecked();
 
-	// 設定メタボックスがあるかどうか
-	await expect(page.locator('.veu_display_promotion_alert .veu_metabox_section_title')).toContainText('Promotion Disclosure Setting');
+		// --- CPT 新規投稿画面（Block Editor）で PluginSidebar 確認 ---
+		await page.goto( '/wp-admin/post-new.php?post_type=test-post-type' );
+		await page.waitForLoadState( 'domcontentloaded' );
+		// Block Editor の初期化を待つ（editor-canvas iframe 出現待ち）。
+		await page
+			.frameLocator( '[name="editor-canvas"]' )
+			.locator( '[contenteditable="true"]' )
+			.first()
+			.waitFor( { timeout: 15000 } );
 
-	// Delete CTA ///////////////////////////////////////////.
-	await page.goto('/wp-admin/edit.php?post_type=post_type_manage');
-	await page.locator('#cb-select-all-1').check();
-	await page.locator('#bulk-action-selector-top').selectOption('trash');
-	await page.locator('#doaction').click();
-});
+		// Welcome guide modal が出る場合は閉じる。
+		const isModalVisible = await page.isVisible(
+			'.components-modal__frame'
+		);
+		if ( isModalVisible ) {
+			await page.click( 'button[aria-label="Close"]' );
+			await page.waitForTimeout( 300 );
+		}
+
+		// VK ExUnit の PluginSidebar アイコンをクリックして開く。
+		await page
+			.getByRole( 'button', {
+				name: 'VK All in One Expansion Unit',
+			} )
+			.click();
+
+		// PluginSidebar 内に "Promotion Disclosure Setting" パネルが
+		// 表示されることを確認。
+		await expect(
+			page.getByRole( 'button', {
+				name: 'Promotion Disclosure Setting',
+			} )
+		).toBeVisible();
+
+		// --- 後片付け: 作成した CPT 設定投稿を削除 ---
+		await page.goto(
+			'/wp-admin/edit.php?post_type=post_type_manage'
+		);
+		await page.locator( '#cb-select-all-1' ).check();
+		await page
+			.locator( '#bulk-action-selector-top' )
+			.selectOption( 'trash' );
+		await page.locator( '#doaction' ).click();
+	} );
+} );


### PR DESCRIPTION
## 概要

issue #1348 対応。`tests/e2e/` 配下の `cta.spec.ts` と `promotion-alert.spec.ts` が WordPress 6.x のブロックエディタ構造変化に追従できておらず failing していたのを修正する。

PR #1345 適用前から failing しており、本 PR は e2e テスト基盤の修正のみでエンドユーザー向けプロダクトコードへの変更は含まない。

Closes #1348

## 失敗していた根本原因

1. **本文・タイトルが iframe 内になった** — WordPress 6.x のブロックエディタは編集領域が `editor-canvas` という iframe 内に描画されるようになり、メインフレームから `getByLabel('Add title')` などが取得できなくなった
2. **`Add block` ボタンがリネームされた** — `aria-label="Add block"` だったブロック挿入ボタンが `Block Inserter` に変わった
3. **Block Inserter が docked 化** — 挿入後も自動で閉じない docked サイドバーに変わったため、明示的に閉じる必要が出てきた
4. **Promotion Alert メタボックスが PluginSidebar に移行** — `__back_compat_meta_box => true` の指定により、ブロックエディタ画面では旧来の VEU 統合メタボックスは非表示になり、設定 UI は右上「VK All in One Expansion Unit」アイコンから開く `PluginSidebar` 内のパネルへ移行している（issue #1322 の改修）
5. **シードデータ操作が dev コンテナを向いていた** — Playwright は `testsPort` (8889) の WordPress を使うが、`runWpCli` が `wp-env run cli`（dev 用コンテナ）を呼んでいたため、`tests-cli` (e2e と同じ DB) のデータをリセットできず、CTA 投稿の残骸を引きずって判定がズレていた

## 修正内容

### `tests/e2e/cta.spec.ts`

- 本文 / タイトル操作を `frameLocator('[name="editor-canvas"]')` 経由に変更
- `Add block` → `Block Inserter` にボタン名を変更
- 検索結果は `listbox "Blocks"` 内の `option "CTA"` を完全一致で選択（`Block patterns` の `Call to action with book links` パターンと衝突するため）
- 挿入後に `Close Block Inserter` で docked Inserter を閉じる
- 空本文は `Add default block` ボタンをクリックしてフォーカス → `page.keyboard.type()` で入力（旧来の `getByRole('document', ...)` は最新 Block Editor では textbox role を持たない）
- CTA SelectControl は `InspectorControls` 内なのでブロック選択 → `Editor settings` の `Block` タブに切替えてから操作
- 公開ボタン操作を `publishPost()` ヘルパーに切り出し（top bar の Publish → 公開パネルの Publish）
- 投稿の初期化を `tests-cli` コンテナ経由に切替え
- 元の長大なシナリオを 2 ケースに分割し可読性向上

### `tests/e2e/promotion-alert.spec.ts`

- ブロックエディタ環境では Promotion メタボックスが非表示になったため、`PluginSidebar` を開いて `Promotion Disclosure Setting` パネルが表示されることを検証する形に書き換え
- シードデータ操作（option / post 削除）を `tests-cli` コンテナ経由に変更
- option `vkExUnit_PA` と `post_type_manage` 投稿のリセットを `beforeEach` / `afterAll` で実施

## 確認手順

### 前提条件

- worktree ルートに `.wp-env.override.json`（`port: 9104, testsPort: 9105` 等）を作成（並列実行を避けるため任意のポートで可）
- `npm install` 済み
- `composer install` 済み
- `npm run build` でビルド済み（`build/editor-panel/index.js` が必要、PluginSidebar 検証のため）
- `npx wp-env start` 起動済み

### Before（修正前の再現手順）

1. master ブランチで以下を実行する
   ```
   WP_BASE_URL=http://localhost:9105 npx playwright test --project=chromium tests/e2e/cta.spec.ts tests/e2e/promotion-alert.spec.ts --reporter=list
   ```
   → ✗ `cta.spec.ts` は `Add block` ボタンが見つからず timeout、`promotion-alert.spec.ts` は `.veu_display_promotion_alert .veu_metabox_section_title` が見つからず timeout で両方 FAIL

### After（修正後）

1. 本 PR のブランチ（`fix/e2e-cta-promotion-alert-1348`）に切替え、同じコマンドを実行する
   ```
   WP_BASE_URL=http://localhost:9105 npx playwright test --project=chromium tests/e2e/cta.spec.ts tests/e2e/promotion-alert.spec.ts --reporter=list
   ```
   → ✓ 3 passed
   - `cta.spec.ts`: 2 ケース pass
     - `CTA 未登録 → ブロック追加で No CTA registered メッセージ`
     - `CTA 投稿を作成 → 通常投稿で選択 → 本文プレビュー / 後で削除すると Specified CTA does not exist`
   - `promotion-alert.spec.ts`: 1 ケース pass
     - `CPT 作成 → 設定対象に追加 → 新規投稿の PluginSidebar に Promotion Disclosure Setting が表示される`

### デグレ確認（他の e2e への影響なし）

1. 他の e2e ファイル（`active-setting.spec.ts` / `pagetop-btn-image.spec.ts` / `sns-share-count-rest-api.spec.ts`）をあわせて実行
   → ✓ 修正前と同じく pass する
2. `tests/e2e/post-type-manager-veu-taxonomy-empty-string.spec.ts` の 3 ケースは「port 9105 の wp-env wordpress コンテナが見つかりません」で failing するが、これは master でも同じ状態で failing しており、コンテナ名検出ロジックの別問題（本 PR とは無関係、別 issue 起票推奨）

## スコープ外（やらないこと）

- プロダクトコード（PHP / JS）の修正
  - 本 PR は e2e テスト基盤の修正のみで、`inc/` 配下や `src/` 配下のプロダクトコードは一切変更していない
- `tests/e2e/post-type-manager-veu-taxonomy-empty-string.spec.ts` の修正
  - master でも failing しているコンテナ名検出ロジックの問題。本 PR のスコープ外で、別 issue 起票が望ましい
- `pagetop-btn-image.spec.ts` の `runWpCli` も `cli` コンテナを向いていたが、現状 pass しているため本 PR のスコープ外として未修正

## changelog

e2e テスト基盤の修正のみでエンドユーザーには影響がないため、`readme.txt` の changelog 更新は不要（WP.org 配布上 `[ 開発環境 ]` は `readme.txt` に記載しない方針）。`CHANGELOG.md` は存在しない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CTA関連の E2E テストを再構成し、共通処理の抽出・前後の状態初期化・シリアル実行を導入。エディタの iframe 待機やモーダル自動クローズ、安定したブロック挿入や公開操作で信頼性を向上しました。
  * プロモーションアラートの E2E テストも同様に初期化・シリアル化・共通化を行い、サイドバー表示検証などの操作を堅牢化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->