### PR TITLE
[ 開発環境 ] e2e テストの待機戦略改善とガイドライン整備

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 ## E2E Test
 
+e2e テストの実行方法・待機戦略・Mobile UA 検証などの開発者向けガイドラインは [`tests/e2e/README.md`](./tests/e2e/README.md) を参照してください。
+
 ### テストを作成
 
 Playwriteは操作を自動的トラッキングしてコードを出力してくれます。

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -164,13 +164,15 @@ await page.locator('#user_login').fill('admin');
 
 UI から事前条件を作るとセットアップで落ちて本質が見えなくなります。option / 投稿 / ユーザー等の初期化は wp-cli を `execFileSync` で叩いてください（シェル解釈を経由しないため、JSON にクォートや空白が含まれていても安全に渡せます）。
 
+コンテナは必ず **`tests-cli`** を指定してください。Playwright のテスト対象は wp-env の **tests** サイト（デフォルト 8889）を向いているため、`cli` コンテナ（development サイト）で option を書き換えてもテスト側 DB には反映されません。
+
 ```ts
 import { execFileSync } from 'child_process';
 
 const runWpCli = ( args: string[] ): string =>
     execFileSync(
         'npx',
-        [ 'wp-env', 'run', 'cli', 'wp', ...args ],
+        [ 'wp-env', 'run', 'tests-cli', 'wp', ...args ],
         { encoding: 'utf-8', stdio: [ 'ignore', 'pipe', 'pipe' ] }
     );
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,210 @@
+# e2e テスト ガイドライン
+
+VK All in One Expansion Unit の e2e テスト（Playwright）を書く / メンテナンスする開発者向けのガイドです。プロジェクト固有の運用と、過去に踏んだ落とし穴をまとめてあります。
+
+vk-agents 共通ルール（`rules/testing/e2e.md`）と合わせて参照してください。共通ルールに書かれている「ベースURLは相対パス」「ポート指定は `.wp-env.override.json`」「テストコードにはコメントを多めに」などはここでは繰り返さないので、必ず一度目を通すこと。
+
+---
+
+## 1. e2e テストの実行方法
+
+### 前提
+
+- wp-env で WordPress 環境が起動していること
+- Node.js / npm 依存パッケージがインストール済みであること
+
+### 環境の準備
+
+```bash
+# 依存パッケージのインストール（初回 or package.json 更新時）
+npm install
+
+# wp-env を起動
+npx wp-env start
+```
+
+並列で別タスクが wp-env を動かしている場合は、ポート衝突を避けるため worktree ルートに `.wp-env.override.json` を置いて `port` / `testsPort` をずらしてください（直接 `.wp-env.json` を書き換えないこと）。
+
+```json
+{
+    "port": 9108,
+    "testsPort": 9109
+}
+```
+
+ベース URL は `playwright.config.ts` の `baseURL` か `WP_BASE_URL` 環境変数で切り替えられます。ポートを変えた場合は実行時に `WP_BASE_URL` を渡すと安全です。
+
+```bash
+WP_BASE_URL=http://localhost:9109 npx playwright test
+```
+
+### 基本コマンド
+
+```bash
+# 全テスト実行（ヘッドレス）
+npx playwright test
+
+# UI モードで実行（テストを選択しながら確認できる）
+npx playwright test --ui
+
+# 単一ファイルのみ実行
+npx playwright test tests/e2e/pagetop-btn-image.spec.ts
+
+# 単一テストのみ実行（タイトル部分一致）
+npx playwright test -g 'デフォルト（画像未設定）'
+
+# 直近の HTML レポートを開く
+npx playwright show-report
+```
+
+---
+
+## 2. 待機戦略のベストプラクティス
+
+### `waitForLoadState('networkidle')` は使わない
+
+Playwright 公式が非推奨にしています（「Avoid waiting for `networkidle`」）。WordPress 管理画面は heartbeat API や非同期トラッキング等で常に通信が走るため、`networkidle` は不安定な待機になりやすく、CI で flaky な失敗を生みます。
+
+「画面上で何が起きてほしいか」を起点に、その状態を表す要素を `waitFor()` / `expect(...).toBeVisible()` で待ってください。
+
+### 代替パターン
+
+| 場面 | 推奨の待機 |
+|---|---|
+| ログイン直後の管理画面 | `await page.locator('#wpadminbar').waitFor()` |
+| 設定保存後の通知 | `await page.locator('.notice-success').waitFor()` |
+| 任意の要素の出現 | `await expect(locator).toBeVisible()` |
+| URL 遷移 | `await page.waitForURL(/wp-admin\//)`（正規表現で寛容に） |
+
+### NG / OK の例
+
+ログイン直後:
+
+```ts
+// NG: 通信が止まるのを待つだけで、wp-admin が描画されたかは保証されない
+await page.locator('#wp-submit').click();
+await page.waitForLoadState('networkidle');
+
+// OK: 管理バーが出るまで待つ。i18n に依存しない id ベース
+await page.locator('#wp-submit').click();
+await page.waitForURL(/wp-admin\//);
+await page.locator('#wpadminbar').waitFor();
+```
+
+設定保存後:
+
+```ts
+// NG: networkidle では「保存できた」状態かが不明
+await page.locator('#submit').click();
+await page.waitForLoadState('networkidle');
+
+// OK: 成功通知が表示されるのを待つ
+await page.locator('#submit').click();
+await page.locator('.notice-success').waitFor();
+```
+
+---
+
+## 3. Mobile UA / `wp_is_mobile()` 検証
+
+`wp_is_mobile()` の挙動を e2e で検証する場合、**UA 文字列だけを差し替える方式はデスクトップ判定されて失敗します**。
+
+### 問題
+
+WordPress Core の `wp_is_mobile()` は Client Hints の `Sec-CH-UA-Mobile` ヘッダーを最優先で見ます。Playwright で UA 文字列だけ差し替えても、Chromium は `Sec-CH-UA-Mobile: ?0`（デスクトップ）を送り続けるため、`wp_is_mobile()` は false を返します。
+
+### NG: UA 文字列のみ差し替え
+
+```ts
+// 動かない。Sec-CH-UA-Mobile: ?0 が送られて wp_is_mobile() が false になる
+const context = await browser.newContext({
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) ...',
+});
+```
+
+### OK: `devices` プリセットを使う
+
+```ts
+import { test, expect, devices } from '@playwright/test';
+
+test.use({ ...devices['iPhone 12'] });
+
+test('wp_is_mobile() が true として扱われる UI が出る', async ({ page }) => {
+    await page.goto('/');
+    // ...
+});
+```
+
+`devices['iPhone 12']` には `isMobile: true` が含まれており、これにより `Sec-CH-UA-Mobile: ?1` が自動で送られます。`wp_is_mobile()` も期待通り true を返します。
+
+ファイル全体ではなく `test.describe` ブロック内だけで切り替えたい場合も `test.use({ ...devices['iPhone 12'] })` を `describe` の中に書けば OK です。
+
+### 参考
+
+- 関連 issue: [#1349](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1349)
+- 知見の元になった PR: [#1345](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1345)
+
+---
+
+## 4. その他 best practices
+
+### i18n 耐性のあるセレクタを使う
+
+WordPress 管理画面は言語設定でラベル文字列が変わります。テキストではなく **id / 安定的に付与される CSS クラス** をセレクタに使ってください。
+
+```ts
+// NG: 日本語環境で "Username or Email Address" は "ユーザー名またはメールアドレス" に変わる
+await page.getByLabel('Username or Email Address').fill('admin');
+
+// OK: id は Core で安定して付与される
+await page.locator('#user_login').fill('admin');
+```
+
+### state 初期化は wp-cli 経由で
+
+UI から事前条件を作るとセットアップで落ちて本質が見えなくなります。option / 投稿 / ユーザー等の初期化は wp-cli を `execFileSync` で叩いてください（シェル解釈を経由しないため、JSON にクォートや空白が含まれていても安全に渡せます）。
+
+```ts
+import { execFileSync } from 'child_process';
+
+const runWpCli = ( args: string[] ): string =>
+    execFileSync(
+        'npx',
+        [ 'wp-env', 'run', 'cli', 'wp', ...args ],
+        { encoding: 'utf-8', stdio: [ 'ignore', 'pipe', 'pipe' ] }
+    );
+
+// 例: vkExUnit_pagetop オプションを削除
+runWpCli( [ 'option', 'delete', 'vkExUnit_pagetop' ] );
+```
+
+`execSync` で文字列連結すると、引数のクォート崩しや空白で壊れます。必ず `execFileSync` + 引数配列で渡してください。
+
+### URL アサートは正規表現で寛容に
+
+```ts
+// NG: クエリパラメーターが付くと落ちる
+await page.waitForURL('/wp-admin/index.php');
+
+// OK: パスの一部だけ一致を要求
+await page.waitForURL(/wp-admin\//);
+```
+
+### 例外を握りつぶさない
+
+`try/catch` で例外を完全に握りつぶすと、wp-env が落ちている等の本質的な障害も「スキップ」になって気付けません。**握りつぶすケースは「ここでこのメッセージが返ることが想定内」と確証が持てる範囲だけ**にしてください（`pagetop-btn-image.spec.ts` の `resetPagetopOption` を参照）。
+
+### 固定 sleep は使わない
+
+`page.waitForTimeout(5000)` 等の固定待機は flaky の温床です。要素 / URL / 状態を待つ API（`waitFor` / `toBeVisible` / `waitForURL`）に置き換えてください。
+
+---
+
+## 5. 参考リンク
+
+- Playwright 公式ベストプラクティス: <https://playwright.dev/docs/best-practices>
+- Playwright devices プリセット: <https://playwright.dev/docs/emulation>
+- wp-env コマンドリファレンス: <https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/>
+- vk-agents 共通ルール（e2e）: `rules/testing/e2e.md`
+- 関連 issue: [#1349](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1349)
+- 関連 PR: [#1345](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1345)

--- a/tests/e2e/active-setting.spec.ts
+++ b/tests/e2e/active-setting.spec.ts
@@ -36,7 +36,13 @@ test('Active Setting first save respects selections', async ({ page }) => {
   await widgetCheckbox.setChecked(true);
 
   await page.locator('#submit').click();
-  await page.waitForLoadState('networkidle');
+  // Settings API ( form action="options.php" ) は保存後に元の管理画面へ
+  // リダイレクトする。下の expect(...).not.toBeChecked() / toBeChecked() の
+  // 自動 retry が、リダイレクト後にチェックボックスが再描画され、
+  // 設定値が反映されるところまでを待ってくれるため、ここで
+  // waitForLoadState('networkidle') を挟む必要はない。
+  // networkidle は heartbeat 等で安定しないため使わない
+  // （tests/e2e/README.md 参照）。
 
   const metaCheckboxAfter = page.locator('#checkbox_active_metaDescription');
   const widgetCheckboxAfter = page.locator('#vew_widget_enable_input_post_list');

--- a/tests/e2e/pagetop-btn-image.spec.ts
+++ b/tests/e2e/pagetop-btn-image.spec.ts
@@ -21,13 +21,17 @@ import { execFileSync } from 'child_process';
 const ADMIN_USER = 'admin';
 const ADMIN_PASS = 'password';
 
-// wp-env の cli コンテナ経由で wp-cli を実行するためのヘルパー。
+// wp-env の `tests-cli` コンテナ経由で wp-cli を実行するためのヘルパー。
+// `tests-cli` を使うのは、Playwright のテスト対象 ( WP_BASE_URL ) が
+// wp-env の **tests** サイト（デフォルト 8889 / override 後 9109）を
+// 向いているため。`cli` ( development サイト ) で option を書き換えても
+// テスト側 DB には反映されないので、必ず `tests-cli` を使うこと。
 // shell 経由ではなく execFileSync で引数を配列のまま渡すことで、
 // JSON 等にクォートや空白が含まれてもシェル解釈を経由しない。
 const runWpCli = ( args: string[] ): string => {
 	return execFileSync(
 		'npx',
-		[ 'wp-env', 'run', 'cli', 'wp', ...args ],
+		[ 'wp-env', 'run', 'tests-cli', 'wp', ...args ],
 		{
 			encoding: 'utf-8',
 			stdio: [ 'ignore', 'pipe', 'pipe' ],
@@ -84,8 +88,10 @@ test.describe( 'Page Top Button image upload (#1342)', () => {
 		await page.locator( '#user_pass' ).fill( ADMIN_PASS );
 		await page.locator( '#wp-submit' ).click();
 		// ダッシュボードのロード完了まで待つ。
+		// networkidle は WP の heartbeat 等で安定しないため、
+		// 管理バー（id ベース・i18n 非依存）が描画されたことで判断する。
 		await page.waitForURL( /wp-admin\// );
-		await page.waitForLoadState( 'networkidle' );
+		await page.locator( '#wpadminbar' ).waitFor();
 	} );
 
 	test.afterAll( () => {
@@ -113,7 +119,9 @@ test.describe( 'Page Top Button image upload (#1342)', () => {
 		await page.goto(
 			'/wp-admin/admin.php?page=vkExUnit_main_setting#vkExUnit_pagetop'
 		);
-		await page.waitForLoadState( 'networkidle' );
+		// ページトップセクションが描画され、操作対象の入力欄が DOM に存在することで
+		// 画面ロード完了を判定する（networkidle は管理画面の常時通信で不安定）。
+		await page.locator( '#pagetop_image_url' ).waitFor();
 
 		// 画像 URL を直接テキストフィールドに入力する
 		// （メディアライブラリ操作は wp-env の挙動が不安定なため URL 直入力で検証）。
@@ -138,7 +146,14 @@ test.describe( 'Page Top Button image upload (#1342)', () => {
 		// `#submit` は各セクションごとに重複しているので
 		// `#pagetopSetting` セクション内のものを明示的に指定する。
 		await page.locator( '#pagetopSetting #submit' ).click();
-		await page.waitForLoadState( 'networkidle' );
+		// VK ExUnit のメイン設定ページは保存後に `.notice-success` を
+		// 出さず、同じページに POST して再描画されるだけ。そのため
+		// 「フォームが再描画され、URL 入力欄に保存した値が反映されている」
+		// ことを toHaveValue() の retry で待つことで保存完了とみなす。
+		// networkidle は WP の heartbeat 等で安定しないため使わない。
+		await expect( page.locator( '#pagetop_image_url' ) ).toHaveValue(
+			sampleUrl
+		);
 
 		// フロントで出力を確認。
 		await page.goto( '/?p=1' );
@@ -179,7 +194,8 @@ test.describe( 'Page Top Button image upload (#1342)', () => {
 		await page.goto(
 			'/wp-admin/admin.php?page=vkExUnit_main_setting#vkExUnit_pagetop'
 		);
-		await page.waitForLoadState( 'networkidle' );
+		// 画像 URL 入力欄の描画を待ってから値を検証する。
+		await page.locator( '#pagetop_image_url' ).waitFor();
 		const urlInput = page.locator( '#pagetop_image_url' );
 		await urlInput.scrollIntoViewIfNeeded();
 		await expect( urlInput ).toHaveValue( sampleUrl );
@@ -194,7 +210,9 @@ test.describe( 'Page Top Button image upload (#1342)', () => {
 
 		// 保存（pagetop セクション内の submit ボタン）。
 		await page.locator( '#pagetopSetting #submit' ).click();
-		await page.waitForLoadState( 'networkidle' );
+		// 保存完了は「URL 入力欄が空のまま再描画されていること」で判定する。
+		// `.notice-success` は VK ExUnit のメイン設定ページでは表示されない。
+		await expect( page.locator( '#pagetop_image_url' ) ).toHaveValue( '' );
 
 		// フロントで style 属性が消えていることを確認。
 		await page.goto( '/?p=1' );
@@ -212,7 +230,8 @@ test.describe( 'Page Top Button image upload (#1342)', () => {
 		await page.goto(
 			'/wp-admin/admin.php?page=vkExUnit_main_setting#vkExUnit_pagetop'
 		);
-		await page.waitForLoadState( 'networkidle' );
+		// 画像 URL 入力欄の描画を待ってからペイロード入力に進む。
+		await page.locator( '#pagetop_image_url' ).waitFor();
 
 		// CSS injection を試す payload（クォート・括弧・空白を含む）。
 		const payload =
@@ -224,13 +243,11 @@ test.describe( 'Page Top Button image upload (#1342)', () => {
 
 		// 保存（pagetop セクション内の submit ボタン）。
 		await page.locator( '#pagetopSetting #submit' ).click();
-		await page.waitForLoadState( 'networkidle' );
-
-		// 保存後、URL フィールドが空になっていること（サニタイザーが空文字を返したため）。
-		const urlAfter = await page
-			.locator( '#pagetop_image_url' )
-			.inputValue();
-		expect( urlAfter ).toBe( '' );
+		// 保存完了 + サニタイズ結果（空文字）が UI に反映されたことを
+		// toHaveValue() の retry で待つ。サニタイザーが空文字を返す想定なので、
+		// この assertion 自体が「保存後にフォームが再描画され、値が反映された」
+		// 状態の判定を兼ねている。
+		await expect( page.locator( '#pagetop_image_url' ) ).toHaveValue( '' );
 
 		// フロント側にも style 属性が付かないこと。
 		await page.goto( '/?p=1' );


### PR DESCRIPTION
## 概要

issue #1349 への対応。Playwright の e2e テストで `wp_is_mobile()` 検証が UA 文字列差し替えだけでは動かない件をきっかけに、e2e の運用ガイドラインを整備し、既存テストで使われていた非推奨の待機（`waitForLoadState('networkidle')`）を文脈に応じた要素待ちに置換する。

- `tests/e2e/README.md` を新規追加し、開発者向けに以下のガイドラインをまとめた:
  - e2e テストの実行方法（wp-env 前提・ポート衝突回避のための `.wp-env.override.json`）
  - 待機戦略のベストプラクティス（`networkidle` を使わない理由と代替パターン）
  - Mobile UA / `wp_is_mobile()` 検証は `@playwright/test` の `devices` プリセット（`isMobile: true` 自動付与）を使う
  - i18n 耐性のあるセレクタ（id ベース）／ state 初期化は wp-cli を `execFileSync` 経由／URL アサートは正規表現で寛容に
- 既存 e2e の `waitForLoadState('networkidle')` を、文脈ごとに適切な要素待ちへ置換:
  - ログイン直後 → `await page.locator('#wpadminbar').waitFor()`
  - 設定画面表示直後 → 操作対象の入力欄（例: `#pagetop_image_url`）の `waitFor()`
  - 保存後 → 保存値が UI に反映されているか（`expect(...).toHaveValue(...)` の auto-retry）／ Settings API ではこの後の assertion の auto-wait に任せる
- `pagetop-btn-image.spec.ts` の `runWpCli` ヘルパーを `cli` から `tests-cli` コンテナに変更（テスト対象が wp-env の **tests** サイトを見ているのに、`cli` 経由で **development** サイトの DB を書き換えていたため、option 操作の効果がテスト側に届かず serial mode 間でゴミが残るバグを解消）
- `readme.md` に `tests/e2e/README.md` へのリンクを追加

エンドユーザー向けの動作には影響しない（テストコード・ドキュメントのみ）ため、`readme.txt` の Changelog は更新していない（`[ Dev Environment ]` 変更は WordPress.org の `readme.txt` には記載しないルールに従う）。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `tests/e2e/README.md`（新規） | e2e 開発者向けガイドライン |
| `tests/e2e/pagetop-btn-image.spec.ts` | `networkidle` × 7 を要素待ちに置換 + `cli` → `tests-cli` |
| `tests/e2e/active-setting.spec.ts` | `networkidle` × 1 を削除（直後の assertion の auto-wait に委ねる） |
| `readme.md` | 新規 README へのリンクを追記 |

## 確認手順

### 前提条件

- リポジトリ ルートで `composer install` / `npm install` 済み
- `.wp-env.override.json` で他の wp-env と衝突しないポートを指定（例: `{\"port\": 9108, \"testsPort\": 9109}`）
- `npx wp-env start` 済み

### 手順

#### Before（修正前の挙動 / 比較用）

1. master を checkout して同じ環境を用意
2. `WP_BASE_URL=http://localhost:9109 npx playwright test tests/e2e/pagetop-btn-image.spec.ts` を実行
   → ✗ テストの total 時間が長め（`networkidle` 解消待ちで毎ステップ無駄が乗る）。`tests-cli` ではなく `cli` を叩いている関係で、serial mode 内で前テストの option が残るとフロント側の has-image 判定が崩れる可能性がある（環境依存）

#### After（修正後の確認手順）

1. `tests/e2e/pagetop-btn-image.spec.ts` を実行
   ```bash
   WP_BASE_URL=http://localhost:9109 npx playwright test tests/e2e/pagetop-btn-image.spec.ts
   ```
   → ✓ 4 件全 PASS（手元では 15 秒台で完走）
2. `tests/e2e/active-setting.spec.ts` を実行
   ```bash
   WP_BASE_URL=http://localhost:9109 npx playwright test tests/e2e/active-setting.spec.ts
   ```
   → ✓ wp-env から見て wp-cli パスが解決できないので skip（元仕様通り。テストの assertion 自体には触っていないため回帰なし）
3. `tests/e2e/README.md` の各章（実行方法／待機戦略／Mobile UA／best practices／参考リンク）が読める
   → ✓ ガイドラインとして自己完結している
4. `readme.md` の冒頭に `tests/e2e/README.md` へのリンクが追加されている
   → ✓ 既存の codegen 説明等は触っていない

## スクリーンショット

UI / 表示に影響する変更は無いため省略。

## 関連

- issue #1349
- 知見の元: PR #1345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

このPRはテストとドキュメンテーションの改善で、エンドユーザーへの直接的な機能変更はありません。

* **Tests**
  * E2Eテストの待機戦略を改善（networkidle非推奨→URL/要素待機、固定sleep廃止、例外握りつぶし回避）
  * UI同期判定を安定化（入力欄値や要素の再描画で検証）
  * モバイルUA検証にdevicesプリセット利用

* **Documentation**
  * E2E実行手順・待機戦略・セットアップ等の開発者向けガイドを追加・拡充

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->