### PR TITLE
[ Security Fix ][ Page Top Button ] サニタイザ強化と sanitize/render の整合改善

### DIFF
--- a/inc/pagetop-btn/_scss/_pagetop-btn.scss
+++ b/inc/pagetop-btn/_scss/_pagetop-btn.scss
@@ -20,6 +20,9 @@
 	background-size: 50%;
 	background-repeat: no-repeat;
 	background-position: center;
+	opacity: 0;
+	transition: opacity 0.3s;
+	text-decoration: none;
 
 	// When a user-uploaded image is applied via the inline `--veu_` override,
 	// use `contain` so that the entire image fits the button without being
@@ -38,16 +41,13 @@
 		background-color: transparent;
 		box-shadow: none;
 	}
-	opacity: 0;
-	transition: opacity 0.3s;
-	text-decoration: none;
-	&:hover {  
+	&:hover {
 		transition: opacity 0.3s;
 		color: transparent;
 		text-decoration: none;
 	}
 	.customize-partial-edit-shortcut-button {
-		left:-40px;
+		left: -40px;
 	}
 }
 .scrolled .page_top_btn{

--- a/inc/pagetop-btn/pagetop-btn.php
+++ b/inc/pagetop-btn/pagetop-btn.php
@@ -42,7 +42,7 @@ function veu_add_pagetop() {
  * `--veu_page_top_button_url` を上書きする。
  * テスト容易性のためマークアップ生成を関数化している。
  *
- * @param array $options vkExUnit_pagetop オプション配列。配列以外が渡された場合は空配列として扱う。
+ * @param mixed $options vkExUnit_pagetop オプション配列。配列以外が渡された場合は空配列として扱う。
  * @return string The page top button HTML.
  */
 function veu_pagetop_render( $options = array() ) {

--- a/inc/pagetop-btn/pagetop-btn.php
+++ b/inc/pagetop-btn/pagetop-btn.php
@@ -42,10 +42,20 @@ function veu_add_pagetop() {
  * `--veu_page_top_button_url` を上書きする。
  * テスト容易性のためマークアップ生成を関数化している。
  *
- * @param array $options vkExUnit_pagetop オプション配列。
+ * @param array $options vkExUnit_pagetop オプション配列。配列以外が渡された場合は空配列として扱う。
  * @return string The page top button HTML.
  */
 function veu_pagetop_render( $options = array() ) {
+	// Defensive guard: callers may pass non-array values (null, string, etc.)
+	// either by mistake or via legacy code paths. Type-hint cannot be added
+	// without breaking backward compatibility, so normalize to an empty array
+	// here and let wp_parse_args() backfill defaults below.
+	// 後方互換のため引数の型宣言は付けず、配列以外が渡された場合は空配列として
+	// 扱うガードを入れる。後段の wp_parse_args() でデフォルト値を補完する。
+	if ( ! is_array( $options ) ) {
+		$options = array();
+	}
+
 	// Backfill defaults so callers can pass partial arrays / option output as-is.
 	// 不足キーをデフォルト値で補完。
 	$options = wp_parse_args( $options, veu_pagetop_default() );
@@ -100,10 +110,29 @@ function veu_pagetop_sanitize_image_url( $value ) {
 
 	// Reject values that contain characters which would let an attacker
 	// break out of the `url("...")` context (quotes, parens, backslash,
-	// control chars, internal whitespace).
+	// control chars including C0 / DEL / C1, internal whitespace).
+	// The `u` modifier enables UTF-8 mode so that multi-byte C1 controls
+	// (U+0080-U+009F) are matched as a single code point rather than
+	// individual bytes.
 	// `url("...")` のコンテキストから脱出可能な文字（クォート・括弧・
 	// バックスラッシュ・制御文字・内部空白）を含む場合は拒否する。
-	if ( preg_match( '/[\s"\'\\\\()]|[\x00-\x1F\x7F]/', $value ) ) {
+	// `u` 修飾子で UTF-8 モードを有効化し、C1 制御文字 (U+0080-U+009F) も
+	// マルチバイト文字として一括りに検出する。
+	if ( preg_match( '/[\s"\'\\\\()]|[\x00-\x1F\x7F]|[\x{0080}-\x{009F}]/u', $value ) ) {
+		return '';
+	}
+
+	// Reject URL-encoded variants of the dangerous characters above. Browsers
+	// may decode `%22` / `%27` / `%28` / `%29` / `%5C` inside `url("...")`,
+	// allowing an attacker to break out even though the raw value passed the
+	// first regex. Detection is case-insensitive so that `%5C` and `%5c`
+	// (both valid encodings of the backslash) are caught equally.
+	// 上記の危険文字を URL エンコードした表現も拒否する。ブラウザは
+	// `url("...")` 内の `%22` などをデコードしうるため、生クォート等を
+	// 弾いただけでは脱出を防げない。URL の percent-encoding は大文字小文字
+	// が等価（例: `%5C` と `%5c` はどちらもバックスラッシュ）なので、
+	// 取りこぼさないよう case-insensitive で判定する。
+	if ( preg_match( '/%(22|27|28|29|5C)/i', $value ) ) {
 		return '';
 	}
 
@@ -470,7 +499,12 @@ function veu_pagetop_sanitize( $input ) {
 		$input = array();
 	}
 	if ( isset( $input['hide_mobile'] ) ) {
-		$output['hide_mobile'] = esc_attr( $input['hide_mobile'] );
+		// Use the shared boolean sanitizer to match the Customizer setting's
+		// sanitize_callback (`veu_sanitize_boolean`) and keep the stored
+		// representation consistent across both entry points.
+		// カスタマイザ側の sanitize_callback と揃えるため共通の
+		// veu_sanitize_boolean() を使用し、保存形式（bool）を統一する。
+		$output['hide_mobile'] = veu_sanitize_boolean( $input['hide_mobile'] );
 	}
 	if ( isset( $input['image_url'] ) ) {
 		$output['image_url'] = veu_pagetop_sanitize_image_url( $input['image_url'] );

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,10 @@ e.g.
 
 == Changelog ==
 
+[ Security Fix ][ Page Top Button ] Hardened the page top button image URL sanitizer (`veu_pagetop_sanitize_image_url()`) to close additional CSS injection vectors that bypassed the initial sanitizer added in the previous release. The control-character check now uses the PCRE `u` modifier and an explicit `[\x{0080}-\x{009F}]` range so multi-byte C1 control characters are rejected, and a new case-insensitive check rejects URL-encoded representations of the dangerous characters (`%22` / `%27` / `%28` / `%29` / `%5C`) which browsers may decode inside `url("...")`.
+
+[ Spec Change ][ Page Top Button ] Unified the `hide_mobile` sanitizer in the ExUnit main setting page (`veu_pagetop_sanitize()`) to use the shared `veu_sanitize_boolean()` callback, matching the Customizer setting's `sanitize_callback` so the stored value is consistently a boolean across both entry points. Also added a defensive `is_array()` guard to `veu_pagetop_render()` so that non-array arguments fall back to the default options array instead of triggering warnings.
+
 [ Bug Fix ] Fixed stylelint `font-family-name-quotes` violations. The SCSS source for the Font Awesome 5 family now uses the standard `"Font Awesome 5 Free"` quoted form instead of the escaped `Font Awesome\ 5 Free` notation, and the gulp-clean-css invocation in gulpfile.js is configured with `level: { 1: { removeQuotes: false } }` so that the minifier preserves the surrounding quotes for font-family names that require them (e.g. `"vk_sns"`).
 
 [ Feature ][ Page Top Button ] Added an "image" setting so users can upload their own icon for the page top button from the ExUnit main setting page and the Customizer. The selected image URL is applied via an inline `style` attribute that overrides the `--veu_page_top_button_url` CSS custom property, so themes / custom CSS that already override the legacy `--ver_page_top_button_url` continue to work unchanged. The URL is sanitized with a dedicated sanitizer that rejects values containing quotes, parentheses, whitespace or control characters, and only allows image extensions (svg / png / jpg / jpeg / gif / webp) to mitigate CSS injection.

--- a/tests/test-pagetop-btn.php
+++ b/tests/test-pagetop-btn.php
@@ -151,6 +151,16 @@ class Test_Pagetop_Btn extends WP_UnitTestCase {
 				'expected'            => '',
 			),
 			array(
+				'test_condition_name' => 'URL エンコードされた開き括弧（%28）を含む値は弾く',
+				'input'               => 'https://example.com/a%28.png',
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => 'URL エンコードされたバックスラッシュ（%5C）を含む値は弾く',
+				'input'               => 'https://example.com/a%5C.png',
+				'expected'            => '',
+			),
+			array(
 				'test_condition_name' => '多重拡張子（evil.png.php）は最後の拡張子で判定され弾く',
 				'input'               => 'https://example.com/evil.png.php',
 				'expected'            => '',

--- a/tests/test-pagetop-btn.php
+++ b/tests/test-pagetop-btn.php
@@ -129,6 +129,47 @@ class Test_Pagetop_Btn extends WP_UnitTestCase {
 				'input'               => '"><script>alert(1)</script>',
 				'expected'            => '',
 			),
+			// 追加の境界値テスト（issue #1347 / PR #1345 のレビュー対応）。
+			array(
+				'test_condition_name' => 'data: スキームは esc_url_raw で除去され空文字になる',
+				'input'               => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => 'URL エンコードされたダブルクォート（%22）を含む値は弾く',
+				'input'               => 'https://example.com/a%22.png',
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => 'URL エンコードされたシングルクォート（%27）を含む値は弾く',
+				'input'               => 'https://example.com/a%27.png',
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => 'URL エンコードされた閉じ括弧（%29）を含む値は弾く',
+				'input'               => 'https://example.com/a%29.png',
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => '多重拡張子（evil.png.php）は最後の拡張子で判定され弾く',
+				'input'               => 'https://example.com/evil.png.php',
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => '大文字スキーム（HTTPS://）は esc_url_raw で小文字化され許可',
+				'input'               => 'HTTPS://example.com/image.png',
+				'expected'            => 'https://example.com/image.png',
+			),
+			array(
+				'test_condition_name' => 'U+0080 (C1 制御文字) を含む値は弾く',
+				'input'               => "https://example.com/a\xC2\x80.png",
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => 'U+009F (C1 制御文字) を含む値は弾く',
+				'input'               => "https://example.com/a\xC2\x9F.png",
+				'expected'            => '',
+			),
 		);
 
 		foreach ( $test_cases as $case ) {
@@ -175,6 +216,20 @@ class Test_Pagetop_Btn extends WP_UnitTestCase {
 				'expected_contains'   => '<a href="#top" id="page_top" class="page_top_btn">PAGE TOP</a>',
 				'expected_not'        => array( 'evil.php', 'style=', 'has-image' ),
 			),
+			// 防御的プログラミングの検証: 配列以外が渡されても空配列扱いでデフォルト出力に
+			// フォールバックする事を確認する（issue #1347 項目3）。
+			array(
+				'test_condition_name' => '境界値: 配列以外（null）を渡してもデフォルト出力にフォールバックする',
+				'options'             => null,
+				'expected_contains'   => '<a href="#top" id="page_top" class="page_top_btn">PAGE TOP</a>',
+				'expected_not'        => array( 'style=', 'has-image' ),
+			),
+			array(
+				'test_condition_name' => '境界値: 配列以外（文字列）を渡してもデフォルト出力にフォールバックする',
+				'options'             => 'invalid string',
+				'expected_contains'   => '<a href="#top" id="page_top" class="page_top_btn">PAGE TOP</a>',
+				'expected_not'        => array( 'style=', 'has-image' ),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {
@@ -207,13 +262,13 @@ class Test_Pagetop_Btn extends WP_UnitTestCase {
 
 		$test_cases = array(
 			array(
-				'test_condition_name' => '正常系1: 全部入りで両方サニタイズされる',
+				'test_condition_name' => '正常系1: 全部入りで両方サニタイズされる（hide_mobile は bool に正規化）',
 				'input'               => array(
 					'hide_mobile' => 'true',
 					'image_url'   => 'https://example.com/a.png',
 				),
 				'expected'            => array(
-					'hide_mobile' => 'true',
+					'hide_mobile' => true,
 					'image_url'   => 'https://example.com/a.png',
 				),
 			),
@@ -224,6 +279,17 @@ class Test_Pagetop_Btn extends WP_UnitTestCase {
 				),
 				'expected'            => array(
 					'image_url' => 'https://example.com/b.svg',
+				),
+			),
+			array(
+				'test_condition_name' => '正常系3: hide_mobile=false 相当の値（空文字）は bool の false に正規化',
+				'input'               => array(
+					'hide_mobile' => '',
+					'image_url'   => 'https://example.com/c.png',
+				),
+				'expected'            => array(
+					'hide_mobile' => false,
+					'image_url'   => 'https://example.com/c.png',
 				),
 			),
 			array(
@@ -246,7 +312,8 @@ class Test_Pagetop_Btn extends WP_UnitTestCase {
 
 		foreach ( $test_cases as $case ) {
 			$actual = veu_pagetop_sanitize( $case['input'] );
-			$this->assertEquals( $case['expected'], $actual, $case['test_condition_name'] );
+			// 厳密比較で型まで一致しているかを確認する（bool と 'true' などの取り違えを防ぐ）。
+			$this->assertSame( $case['expected'], $actual, $case['test_condition_name'] );
 		}
 	}
 


### PR DESCRIPTION
## 概要

PR #1345 で追加された「ページトップへ戻るボタンの画像アップロード機能」に対して、安藤・CodeRabbit のレビュー（LOW/INFO）で挙がった改善 4 項目を実装。テスト追加の過程で `veu_pagetop_sanitize_image_url()` が URL エンコードされたクォート/括弧と U+0080-U+009F の C1 制御文字を素通りすることが判明したため、サニタイザの正規表現も併せて強化している。

Closes #1347

関連: #1345

## 変更内容

### 1. `veu_pagetop_sanitize_image_url()` のサニタイザ強化（セキュリティ防御）

`inc/pagetop-btn/pagetop-btn.php`

- 制御文字の正規表現に `u` 修飾子を付け、`[\x{0080}-\x{009F}]` で C1 制御文字をマルチバイト単位で検出するように変更。従来のバイト単位判定では UTF-8 2 バイトの C1 制御文字を取りこぼしていた
- `%(22|27|28|29|5C)/i` のチェックを追加し、`%22` / `%27` / `%28` / `%29` / `%5C` （クォート・括弧・バックスラッシュの URL エンコード版、大文字小文字非区別）を弾く。ブラウザは `url(\"...\")` 内で `%22` などをデコードしうるため、生クォート等を弾いただけでは CSS injection を防げない

### 2. `veu_pagetop_sanitize()` の `hide_mobile` サニタイズ統一

- `esc_attr()` → `veu_sanitize_boolean()` に変更し、カスタマイザ側 `sanitize_callback` と保存形式（bool）を統一

### 3. `veu_pagetop_render()` の防御的プログラミング

- 引数に `is_array()` ガードを追加。配列以外（null/string 等）が渡された場合は空配列にフォールバックしデフォルト出力を返す
- 後方互換維持のため型宣言（`array`）ではなく `is_array()` で対応

### 4. SCSS `&.has-image` のネスト位置整え

`inc/pagetop-btn/_scss/_pagetop-btn.scss`

- 通常プロパティ → ネスト擬似クラス / `&.has-image` / 子セレクタ の順に並び替え、stylelint warning を解消
- 出力 CSS は差分ゼロ（並び替えだけで最終出力は変わらない）

### 5. PHPUnit テストの追加・改善

`tests/test-pagetop-btn.php`

- `veu_pagetop_sanitize_image_url()` に境界値テスト追加: `data:` スキーム / URL エンコード `%22 %27 %29` / 多重拡張子（`evil.png.php`）/ 大文字スキーム（`HTTPS://`）/ U+0080 / U+009F
- `veu_pagetop_render()` に `options=null` / `options='invalid string'` の異常系テストを追加
- `veu_pagetop_sanitize()` の既存テストで `assertEquals`（緩い比較）を `assertSame`（厳密比較）に変更し、`hide_mobile` の bool 化に伴う型不一致を検出可能にした
- `hide_mobile=''` の正常系ケースも追加

## 確認手順

### 前提条件

- vk-all-in-one-expansion-unit プラグインを有効化
- wp-env が起動済み（`npm start`）

### 1. PHPUnit テスト

\`\`\`bash
composer install
npx wp-env start
npm run phpunit -- --filter Test_Pagetop_Btn
\`\`\`

→ ✓ `OK (6 tests, 68 assertions)` と表示される（全テスト PASS）

### 2. ページトップボタンの動作確認（背景画像なし）

1. 管理画面 > 外観 > カスタマイズ > Page Top Button を開く
2. 「Page top button image」が **未設定** の状態のまま「公開」
3. フロント側でページを十分にスクロールする
   → ✓ デフォルトの矢印アイコン（`--ver_page_top_button_url` / `--veu_page_top_button_url` のフォールバック）が表示される
   → ✓ `<a class=\"page_top_btn\">` に `style` 属性が付かない、`has-image` クラスも付かない

### 3. ページトップボタンの動作確認（背景画像あり）

1. カスタマイザの「Page top button image」で任意の PNG / SVG をアップロード
2. 「公開」してフロント側でページをスクロール
   → ✓ アップロードした画像が `contain` で表示される（フィットして枠なし）
   → ✓ `<a class=\"page_top_btn has-image\" style=\"--veu_page_top_button_url:url(&quot;...&quot;);\">` の形になる

### 4. モバイル非表示オプション（hide_mobile）

1. ExUnit メイン設定画面（管理画面 > ExUnit 設定 > Page Top Button）で「Do not display on touch screen devices」を ON にして保存
2. モバイル UA でフロントを表示
   → ✓ ボタンが表示されない
3. メイン設定画面で OFF に戻して保存
   → ✓ モバイルでもボタンが表示される
   → ✓ オプション値が bool (`true`/`false`) として保存される（`get_option('vkExUnit_pagetop')` で確認可能）

### 5. サニタイザの境界値（オプションで手動検証する場合）

WP-CLI で option を直接書き込んでフロント側の挙動を確認:

\`\`\`bash
# URL エンコードクォート → 弾かれること
wp option update vkExUnit_pagetop '{\"image_url\":\"https://example.com/a%22.png\"}' --format=json
\`\`\`

→ ✓ フロント側で `<a class=\"page_top_btn\">`（has-image なし・style なし）になる

## スクリーンショット

純粋なロジック修正・コメント整理・テスト追加が中心で、表示への影響は **PR #1345 のリリース済み機能から変わらない**（SCSS の並び替えで出力 CSS が差分ゼロ、サニタイザ強化は本来通すべき値を引き続き通すのみ）。Before/After で見た目に変化はないため省略。

## レビュー対応経緯（参考）

- 安藤・植草の事前レビューはいずれも PASS
- 植草から低優先度の指摘 1 件（URL エンコード防御コメントの `%2A` 例示が実装と整合しない）→ コメントを `%5C` / `%5c` の例に差し替えて対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 画像URLサニタイズを強化し、危険な入力をより確実に拒否。設定値の正規化（配列ガード・真偽値統一）で動作安定性を向上。

* **Style**
  * ページトップボタンの初期表示・ホバー時の見た目と遷移を整理・最適化。

* **Tests**
  * 境界値やXSS系ケース、設定正規化の自動テストを拡充。

* **Documentation**
  * 変更内容をリリースノートに追記。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->