### PR TITLE
[ 仕様変更 ][ ページトップへ戻るボタン ] メイン設定画面のカスタマイザーへのリンクを別タブで開くように変更

### DIFF
--- a/inc/pagetop-btn/pagetop-btn.php
+++ b/inc/pagetop-btn/pagetop-btn.php
@@ -358,7 +358,7 @@ function veu_pagetop_admin() {
 		<?php esc_html_e( 'Images with a very different aspect ratio may show extra empty space.', 'vk-all-in-one-expansion-unit' ); ?><br />
 		<?php esc_html_e( 'Clearing the selection only removes this setting and does not delete the image from the Media Library.', 'vk-all-in-one-expansion-unit' ); ?><br />
 		<?php esc_html_e( 'If your theme or custom CSS overrides --veu_page_top_button_url, the theme value takes precedence and the image may not appear.', 'vk-all-in-one-expansion-unit' ); ?><br />
-		<a href="<?php echo esc_url( $customizer_url ); ?>"><?php esc_html_e( 'Configure with live preview in the Customizer', 'vk-all-in-one-expansion-unit' ); ?> &rarr;</a>
+		<a href="<?php echo esc_url( $customizer_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Configure with live preview in the Customizer', 'vk-all-in-one-expansion-unit' ); ?> &rarr;</a>
 	</p>
 </td>
 </tr>

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Spec Change ][ Page Top Button ] Changed the "Configure with live preview in the Customizer" link on the ExUnit main setting page to open in a new tab (`target="_blank"` with `rel="noopener noreferrer"`) so that opening the Customizer no longer interrupts editing on the main setting page.
+
 = 9.116.0 =
 [ Security Fix ][ Page Top Button ] Hardened the page top button image URL sanitizer (`veu_pagetop_sanitize_image_url()`) to close additional CSS injection vectors that bypassed the initial sanitizer added in the previous release. The control-character check now uses the PCRE `u` modifier and an explicit `[\x{0080}-\x{009F}]` range so multi-byte C1 control characters are rejected, and a new case-insensitive check rejects URL-encoded representations of the dangerous characters (`%22` / `%27` / `%28` / `%29` / `%5C`) which browsers may decode inside `url("...")`.
 


### PR DESCRIPTION
## 概要

ExUnit > メイン設定画面の「ページトップへ戻るボタン」セクションにある「Configure with live preview in the Customizer」リンクをクリックすると、メイン設定画面から Customizer に遷移してしまい、メイン設定での編集作業が中断する問題がありました。

このリンクに `target="_blank"` を付与して別タブで Customizer が開くようにし、メイン設定画面での作業を中断せずに Customizer を確認できるようにします。あわせて `target="_blank"` の標準セットとして `rel="noopener noreferrer"` も付与しています。

closes #1360

## 変更内容

- `inc/pagetop-btn/pagetop-btn.php`: 「Configure with live preview in the Customizer」リンクの `<a>` タグに `target="_blank" rel="noopener noreferrer"` を追加
- `readme.txt`: changelog に `[ Spec Change ][ Page Top Button ]` エントリを追記

## 確認手順

### 前提条件

- vk-all-in-one-expansion-unit を有効化したサイト
- 管理者権限でログインしていること

### 手順

#### Before（修正前の挙動）

1. 管理画面 > ExUnit > メイン設定 を開く
2. 「ページトップへ戻るボタン」セクションまでスクロールする
3. セクション末尾の「Configure with live preview in the Customizer →」リンクをクリックする
   → ✗ 同じタブで Customizer に遷移してしまい、メイン設定画面の作業が中断する

#### After（修正後の挙動）

1. 管理画面 > ExUnit > メイン設定 を開く
2. 「ページトップへ戻るボタン」セクションまでスクロールする
3. セクション末尾の「Configure with live preview in the Customizer →」リンクをクリックする
   → ✓ Customizer が **別タブ（新規ウィンドウ）** で開き、元のメイン設定画面はそのまま残る
4. ブラウザの開発者ツールで該当 `<a>` タグの属性を確認する
   → ✓ `target="_blank"` と `rel="noopener noreferrer"` が付与されている
5. メイン設定画面に戻り、ページトップへ戻るボタン以外の設定項目（他のリンクなど）が従来通り動作することを確認する
   → ✓ 他のリンク・設定の挙動に影響がない（デグレなし）

## スクリーンショット

UI 上の表示自体は変更がない（リンクテキストや配置は同じで、クリック時の遷移先タブのみ変更）ため省略します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **仕様変更**
  * 管理画面のページトップ設定にある「Customizerでライブプレビュー」リンクが別タブで開くようになりました（新しいタブでのプレビュー遷移・動作が安定）。変更は更新履歴にも追記されています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/92