### PR TITLE
[ 不具合修正 ][ ページトップへ戻るボタン ] メイン設定画面の画像プレビューから黒背景のインラインスタイルを削除

### DIFF
--- a/inc/pagetop-btn/pagetop-btn.php
+++ b/inc/pagetop-btn/pagetop-btn.php
@@ -344,7 +344,7 @@ function veu_pagetop_admin() {
 <th><?php esc_html_e( 'Page top button image', 'vk-all-in-one-expansion-unit' ); ?></th>
 <td>
 	<div class="veu_pagetop_image_preview"<?php echo $preview_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 固定文字列のみ。 ?>>
-		<img id="thumb_pagetop_image_url" src="<?php echo esc_url( $image_url ); ?>" alt="" style="max-width:120px;height:auto;background:rgba(0,0,0,0.8);padding:6px;border-radius:4px;" />
+		<img id="thumb_pagetop_image_url" src="<?php echo esc_url( $image_url ); ?>" alt="" style="max-width:120px;height:auto;" />
 	</div>
 	<p>
 		<input type="text" name="vkExUnit_pagetop[image_url]" id="pagetop_image_url" value="<?php echo esc_attr( $image_url ); ?>" style="width:60%;" />

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Page Top Button ] Removed the unintended dark background, padding and border-radius inline style from the page top button image preview (`<img id="thumb_pagetop_image_url">`) on the ExUnit main setting page so that the uploaded icon is no longer rendered with a black box around it.
+
 [ Spec Change ][ Page Top Button ] Changed the "Configure with live preview in the Customizer" link on the ExUnit main setting page to open in a new tab (`target="_blank"` with `rel="noopener noreferrer"`) so that opening the Customizer no longer interrupts editing on the main setting page.
 
 = 9.116.0 =


### PR DESCRIPTION
## 概要

ExUnit メイン設定画面（管理画面 > ExUnit > メイン設定）の「ページトップへ戻るボタン」セクションにある画像プレビュー（`<img id="thumb_pagetop_image_url">`）に、装飾用のインラインスタイル `background:rgba(0,0,0,0.8);padding:6px;border-radius:4px;` がハードコードされており、アップロードしたアイコンが黒い枠（黒背景＋余白＋角丸）に囲まれて表示される不具合がありました。

`inc/pagetop-btn/pagetop-btn.php:347` のインラインスタイルから `background` / `padding` / `border-radius` の3項目を削除し、サイズ制約（`max-width:120px;height:auto;`）のみを残しています。

カスタマイザー側のプレビューは partial render の別経路で、この問題には該当しません。また、フロントエンドの `.page_top_btn` の背景（`_pagetop-btn.scss`）はデフォルトアイコン表示のための仕様なので変更していません。

closes #1359

## 変更内容

- `inc/pagetop-btn/pagetop-btn.php` 347行目
  - Before: `style="max-width:120px;height:auto;background:rgba(0,0,0,0.8);padding:6px;border-radius:4px;"`
  - After: `style="max-width:120px;height:auto;"`
- `readme.txt` の Changelog に英語で1行追記

## 確認手順

### 前提条件

- 本ブランチ（`fix/pagetop-admin-preview-background`）をチェックアウトし、WordPress 管理画面にログインできる状態にする
- ExUnit プラグインを有効化し、「ページトップへ戻るボタン」機能を有効にしておく（ExUnit > 有効化設定）

### 手順

#### Before（修正前の再現手順）

1. `master` ブランチ（または本 PR をチェックアウトする前の状態）に切り替える
2. 管理画面 > ExUnit > メイン設定 を開く
3. 「ページトップへ戻るボタン」セクションまでスクロールする
4. 「ページトップボタン用画像」の項目を確認する
   → ✗ プレビュー画像の周囲に黒い背景（半透明の黒）と余白・角丸が表示されている
5. 「画像を選択」から任意の PNG / SVG アイコンをアップロードする
   → ✗ アップロードした画像も黒い枠に囲まれて表示される

#### After（修正後の確認手順）

1. 本ブランチに切り替える
2. 管理画面 > ExUnit > メイン設定 を開く
3. 「ページトップへ戻るボタン」セクションまでスクロールする
4. 「ページトップボタン用画像」の項目を確認する
   → 画像プレビューの周囲に黒い背景・余白・角丸が表示されない
   → プレビュー画像のサイズ（最大 120px 幅）は維持されている
5. 「画像を選択」から任意の PNG / SVG アイコンをアップロードする
   → アップロードした画像が黒い枠なしで表示される
6. 外観 > カスタマイズ > ExUnit ページトップボタン を開く
   → カスタマイザーのプレビュー（partial render 経路）は従来通り問題なく表示される
7. 公開側のページを開き、ページトップへ戻るボタンの表示を確認する
   → フロントエンドの `.page_top_btn` の背景（デフォルトアイコン表示のための仕様）はそのまま残っている（デグレなし）

## スクリーンショット

### Before（修正前）

管理画面プレビュー全体: 画像プレビューの周囲に黒い半透明の背景・余白・角丸が表示される。

![before-admin-pagetop-image-preview](https://raw.githubusercontent.com/vektor-inc/review-assets/main/vk-all-in-one-expansion-unit/pr-1365/before-admin-pagetop-image-preview.png)

サムネイル要素のみ拡大:

![before-admin-pagetop-thumb-only](https://raw.githubusercontent.com/vektor-inc/review-assets/main/vk-all-in-one-expansion-unit/pr-1365/before-admin-pagetop-thumb-only.png)

### After（修正後）

管理画面プレビュー全体: 黒背景・余白・角丸が除去され、画像本体のみが表示される。

![after-admin-pagetop-image-preview](https://raw.githubusercontent.com/vektor-inc/review-assets/main/vk-all-in-one-expansion-unit/pr-1365/after-admin-pagetop-image-preview.png)

サムネイル要素のみ拡大:

![after-admin-pagetop-thumb-only](https://raw.githubusercontent.com/vektor-inc/review-assets/main/vk-all-in-one-expansion-unit/pr-1365/after-admin-pagetop-thumb-only.png)

### デグレ確認（After のみ）

カスタマイザー側のページトップボタンセクション（partial render 経路）: 従来通りの表示で変化なし。

![after-customizer-pagetop-section](https://raw.githubusercontent.com/vektor-inc/review-assets/main/vk-all-in-one-expansion-unit/pr-1365/after-customizer-pagetop-section.png)

フロント側 `.page_top_btn`: デフォルトアイコン表示の背景仕様はそのまま残っている。

![after-front-pagetop-btn](https://raw.githubusercontent.com/vektor-inc/review-assets/main/vk-all-in-one-expansion-unit/pr-1365/after-front-pagetop-btn.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fix**
  * ページトップボタン機能の画像プレビュー表示を改善しました。以前は意図しないダークな背景と余白が適用されていましたが、これらを削除して表示を正常化しました。アップロードアイコンが黒いボックスなしで正しく表示されるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
