### PR TITLE
[ 不具合修正 ][ CTA ] フロントエンドで CTA ブロック表示時に PHP 8.1+ の Deprecated 通知が出る不具合を修正

### DIFF
--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -304,8 +304,9 @@ function veu_cta_block_callback( $attributes, $content ) {
 					$content .= '</div>';
 
 					// Display Edit Button.
-					$url = esc_url( get_edit_post_link( $cta_post->ID ) );
-					if ( $url ) {
+					$edit_link = get_edit_post_link( $cta_post->ID );
+					if ( $edit_link ) {
+						$url      = esc_url( $edit_link );
 						$content .= '<div class="veu_adminEdit veu_adminEdit_cta"><a href="' . $url . '" class="btn btn-default" target="_blank">' . __( 'Edit CTA', 'vk-all-in-one-expansion-unit' ) . '</a></div>';
 					}
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ e.g.
 
 == Changelog ==
 
-[ Bug Fix ][ CTA ] Fixed a PHP 8.1+ deprecation notice (`ltrim(): Passing null to parameter #1 ($string) of type string is deprecated`) emitted on the frontend when the CTA feature is enabled. The block renderer passed the return value of `get_edit_post_link()` directly to `esc_url()`, but `get_edit_post_link()` returns `null` for users without `edit_post` capability (e.g. logged-out visitors). The return value is now checked before being passed to `esc_url()`.
+[ Bug Fix ][ CTA ] Fixed a PHP 8.1+ deprecation notice ("ltrim(): Passing null to parameter #1 ($string) of type string is deprecated") emitted by the CTA block on the frontend for visitors without the edit_post capability.
 
 [ Spec Change ] Update vektor-inc/vk-breadcrumb from 0.2.8 to 0.2.9 and vektor-inc/vk-helpers from 0.2.1 to 0.3.0. The shared `VK_Custom_Html_Control` / `VK_Custom_Text_Control` classes now ship from vk-helpers (autoloaded via composer) instead of vk-admin.
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ CTA ] Fixed a PHP 8.1+ deprecation notice (`ltrim(): Passing null to parameter #1 ($string) of type string is deprecated`) emitted on the frontend when the CTA feature is enabled. The block renderer passed the return value of `get_edit_post_link()` directly to `esc_url()`, but `get_edit_post_link()` returns `null` for users without `edit_post` capability (e.g. logged-out visitors). The return value is now checked before being passed to `esc_url()`.
+
 [ Spec Change ] Update vektor-inc/vk-breadcrumb from 0.2.8 to 0.2.9 and vektor-inc/vk-helpers from 0.2.1 to 0.3.0. The shared `VK_Custom_Html_Control` / `VK_Custom_Text_Control` classes now ship from vk-helpers (autoloaded via composer) instead of vk-admin.
 
 [ Bug Fix ][ Page Top Button ] Removed the unintended dark background, padding and border-radius inline style from the page top button image preview (`<img id="thumb_pagetop_image_url">`) on the ExUnit main setting page so that the uploaded icon is no longer rendered with a black box around it.


### PR DESCRIPTION
## 概要

CTA 機能を有効化した状態でフロントエンドのページを表示すると、以下の PHP 8.1+ の Deprecated 通知が出る不具合を修正します。

```
Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/wp-includes/formatting.php on line 4487
```

## 原因

[inc/call-to-action/package/block/index.php:307](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/blob/master/inc/call-to-action/package/block/index.php#L307) で `get_edit_post_link()` の戻り値を直接 `esc_url()` に渡していました。

`get_edit_post_link()` は対象記事の `edit_post` 権限を持たないユーザー（未ログインのフロントエンド訪問者など）に対して `null` を返します。WordPress の `esc_url()` は `'' === $url` の早期 return では `null` をすり抜けてしまい、内部の `ltrim( $url )` に `null` が渡って PHP 8.1+ で Deprecated 通知が発生していました。

## 修正内容

`get_edit_post_link()` の戻り値を一度変数に受け、`null` / 空でない場合のみ `esc_url()` に渡すように変更しました。

```php
// Before
$url = esc_url( get_edit_post_link( $cta_post->ID ) );
if ( $url ) {
    $content .= '<div class="veu_adminEdit veu_adminEdit_cta"><a href="' . $url . '" ...';
}

// After
$edit_link = get_edit_post_link( $cta_post->ID );
if ( $edit_link ) {
    $url      = esc_url( $edit_link );
    $content .= '<div class="veu_adminEdit veu_adminEdit_cta"><a href="' . $url . '" ...';
}
```

なお、これにより「ログインユーザーに対しては従来どおり Edit ボタンが表示される」「ログイン外には Edit ボタンが表示されない」という従来の挙動は変わりません。

## 確認手順

### 前提条件

- PHP 8.1 以上で動作している WordPress 環境
- ExUnit の **CTA** 機能を有効化（管理画面 > ExUnit > メイン設定 > CTA を有効化）
- CTA を 1 つ作成し、固定ページなどに `CTA` ブロックを配置して公開
- `wp-config.php` に以下を設定し、PHP の Deprecated 通知が画面に出るようにする
  ```php
  define( 'WP_DEBUG', true );
  define( 'WP_DEBUG_DISPLAY', true );
  ```

### Before（修正前の再現手順）

1. ログアウト状態にする（または `edit_post` 権限を持たないユーザーでログインする）
2. CTA ブロックを配置した固定ページをフロントエンドで開く
   → ✗ ページ上部または該当 CTA ブロック付近に以下の Deprecated 通知が表示される
   ```
   Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/wp-includes/formatting.php on line 4487
   ```

### After（修正後の確認手順）

1. ログアウト状態にする
2. CTA ブロックを配置した固定ページをフロントエンドで開く
   → ✓ Deprecated 通知が表示されない
   → ✓ CTA の本文・ボタンは従来どおり正しく表示される（Edit ボタンは表示されない）
3. 管理者でログインした状態で、同じページをフロントエンドで開く
   → ✓ Deprecated 通知が表示されない
   → ✓ CTA の下に「Edit CTA」ボタンが従来どおり表示され、クリックすると CTA の編集画面が新規タブで開く
4. CTA ブロックを配置していない固定ページ（CTA メタボックスのみ設定したページなど）でも閲覧
   → ✓ デグレなし

## スクリーンショット

純粋な PHP 側のロジック修正で表示には影響しないため省略します（CTA ブロック・Edit CTA ボタンの見た目に変更はありません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * CTA機能が有効の際、PHP 8.1以降のフロントエンドで発生していた非推奨警告を修正しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->