### PR TITLE
[ 仕様変更 ] vendor/vk-admin に残る VK_Custom_Html_Control / VK_Custom_Text_Control を除去するため vk-admin を 0.8.0 に更新

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"wp-coding-standards/wpcs": "^3.1"
 	},
 	"require": {
-		"vektor-inc/vk-admin": "^0.7.0",
+		"vektor-inc/vk-admin": "^0.8.0",
 		"vektor-inc/vk-breadcrumb": "^0.2.9",
 		"vektor-inc/vk-helpers": "^0.3.0",
 		"vektor-inc/font-awesome-versions": "^0.7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d15c63df2b4cb75f5cad366c0b537b9f",
+    "content-hash": "0088113d042fdb3bae6902230fbf3205",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
@@ -60,16 +60,16 @@
         },
         {
             "name": "vektor-inc/vk-admin",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/vk-admin.git",
-                "reference": "2e8fa3dc7505c4103282accfa218efb42e8384d4"
+                "reference": "8643dbad5ceceb0b3a0935e6b1fcbf4e420deb36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/vk-admin/zipball/2e8fa3dc7505c4103282accfa218efb42e8384d4",
-                "reference": "2e8fa3dc7505c4103282accfa218efb42e8384d4",
+                "url": "https://api.github.com/repos/vektor-inc/vk-admin/zipball/8643dbad5ceceb0b3a0935e6b1fcbf4e420deb36",
+                "reference": "8643dbad5ceceb0b3a0935e6b1fcbf4e420deb36",
                 "shasum": ""
             },
             "require-dev": {
@@ -85,10 +85,6 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "src/VK_Custom_Html_Control.php",
-                    "src/VK_Custom_Text_Control.php"
-                ],
                 "psr-4": {
                     "VektorInc\\VK_Admin\\": "src/"
                 }
@@ -106,9 +102,9 @@
             "description": "Vektor Admin Component",
             "support": {
                 "issues": "https://github.com/vektor-inc/vk-admin/issues",
-                "source": "https://github.com/vektor-inc/vk-admin/tree/0.7.0"
+                "source": "https://github.com/vektor-inc/vk-admin/tree/0.8.0"
             },
-            "time": "2026-05-23T03:21:55+00:00"
+            "time": "2026-05-23T23:43:46+00:00"
         },
         {
             "name": "vektor-inc/vk-breadcrumb",

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,8 @@ e.g.
 
 [ Bug Fix ][ CTA ] Fixed a PHP 8.1+ deprecation notice from ltrim() emitted by the CTA block on the frontend for visitors without the edit_post capability.
 
+[ Spec Change ] Update vektor-inc/vk-admin from 0.7.0 to 0.8.0 to drop the duplicated VK_Custom_Html_Control / VK_Custom_Text_Control files that have been migrated to vk-helpers.
+
 [ Spec Change ] Update vektor-inc/vk-breadcrumb from 0.2.8 to 0.2.9 and vektor-inc/vk-helpers from 0.2.1 to 0.3.0. VK_Custom_Html_Control / VK_Custom_Text_Control classes now ship from vk-helpers instead of vk-admin.
 
 [ Bug Fix ][ Page Top Button ] Removed the unintended dark background, padding and border-radius inline style from the image preview on the ExUnit main setting page so the uploaded icon is no longer rendered with a black box.


### PR DESCRIPTION
## 概要

Issue #1370 の対応です。

`vendor/vektor-inc/vk-admin/src/` に `VK_Custom_Html_Control.php` と `VK_Custom_Text_Control.php` が重複して残っている問題を解消します。

これらのクラスは vk-helpers 0.3.0 に移行済みで、ExUnit 側のコード（`inc/pagetop-btn/pagetop-btn.php` 等）も既に vk-helpers 経由で動作していました。ただし `composer.json` の require 制約が `"vektor-inc/vk-admin": "^0.7.0"` のままだったため、これらの旧ファイルを削除済みの vk-admin 0.8.0 を取り込めず、vendor 配下に残り続けていました。

本 PR で require 制約を `^0.8.0` に引き上げ、`composer update vektor-inc/vk-admin` を実行することで vendor 内の重複ファイルを取り除きます。

なお `VkAdmin` クラス本体は vk-admin 0.8.0 でも引き続き提供されているため、`use VektorInc\VK_Admin\VkAdmin;` を行っている既存コードへの影響はありません。

## 変更内容

- `composer.json`: `vektor-inc/vk-admin` の制約を `^0.7.0` → `^0.8.0`
- `composer.lock`: `composer update vektor-inc/vk-admin` で vk-admin 0.8.0 を取り込み（autoload.files から旧クラスファイル参照も解消）
- `readme.txt`: changelog に `[ Spec Change ] Update vektor-inc/vk-admin from 0.7.0 to 0.8.0 ...` を1行追記（既存 changelog が全て英語のため英語で記載）

プラグイン自体のバージョン番号（`Stable tag`）は今回上げていません。純粋な依存整理であり、次のリリースに含める想定です。

## 関連 issue

Closes #1370

## 確認手順

### 前提条件

- ホスト側に composer がインストールされていること
- ExUnit を有効化した WordPress 環境

### 手順

1. 本ブランチ（`fix/1370-bump-vk-admin-0.8.0`）をチェックアウトする
2. プラグインルートで `composer install` を実行する
3. `ls vendor/vektor-inc/vk-admin/src/` を実行する
   → ✓ 表示されるのは `assets/`・`languages/`・`VkAdmin.php` の3つのみ
   → ✓ `VK_Custom_Html_Control.php` および `VK_Custom_Text_Control.php` が含まれていない
4. `composer show vektor-inc/vk-admin | grep versions` または `composer.lock` を確認する
   → ✓ バージョンが `0.8.0` になっている
5. WordPress 管理画面で「外観 > カスタマイズ > ページトップへ戻るボタン」セクションを開く
   → ✓ 見出し（`VK_Custom_Html_Control` 由来）が崩れず表示される
   → ✓ 「Width」「Height」入力欄（`VK_Custom_Text_Control` 由来）が崩れず表示され値を入力・保存できる
6. ExUnit 設定画面（管理画面 > ExUnit > メイン設定）、およびその他のカスタマイザーパネルを開く
   → ✓ PHP の Fatal Error / Warning / Deprecated 通知が出ない
7. （デグレ確認）ページトップへ戻るボタンの設定で画像 URL・width・height を変更し公開側を確認する
   → ✓ 設定どおりにボタンが表示される（既存機能の挙動に影響なし）

## 補足

- CodeRabbit 監視は呼び出し元（司）が引き取るため、本 PR 作成後の監視はスキップしてください

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発依存パッケージのバージョンを更新しました。

* **Documentation**
  * Changelog を更新し、パッケージの変更内容を記載しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/114