### PR TITLE
[ 不具合修正 ] vwu_register_css() 内の不要な veu_get_common_options() 呼び出しで環境により Fatal error が発生する不具合を修正

### DIFF
--- a/initialize.php
+++ b/initialize.php
@@ -63,8 +63,6 @@ add_action( 'after_setup_theme', 'veu_load_css_action' );
  * Regisyter vkExUnit css
  */
 function vwu_register_css() {
-	$options = veu_get_common_options();
-
 	wp_register_style( 'vkExUnit_common_style', plugins_url( '', __FILE__ ) . '/assets/css/vkExUnit_style.css', array(), VEU_VERSION, 'all' );
 }
 add_action( 'wp_enqueue_scripts', 'vwu_register_css', 3 );

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ] Removed an unnecessary veu_get_common_options() call in vwu_register_css() that could trigger a "Call to undefined function" fatal error when the enqueue hooks ran before the packages were loaded in some environments.
+
 = 9.117.0 =
 [ Feature ][ Page Top Button ] Added "Width" and "Height" settings (in pixels) so users can resize the page top button image from the main setting page and the Customizer. The default 40 x 38 px size is preserved when either value is left blank.
 


### PR DESCRIPTION
## 概要

特定の環境で、フロント／管理画面の表示時に以下の Fatal error が発生する不具合を修正します。

```
Fatal error: Uncaught Error: Call to undefined function veu_get_common_options()
in .../vk-all-in-one-expansion-unit/initialize.php:66
Stack trace: #0 .../class-wp-hook.php: vwu_register_css('')
```

## 原因

`vwu_register_css()`（`initialize.php`）は `wp_enqueue_scripts` / `admin_enqueue_scripts`（優先度3）に登録されていますが、その中で `veu_get_common_options()` を呼び出していました。この関数の定義は `inc/template-tags/package/template-tags-veu.php` にあり、読み込みは `veu_load_packages()` → `after_setup_theme`（優先度0）でのみ行われます。

通常のフック順では `after_setup_theme` が先に発火するため大半の環境では発生しませんが、他プラグイン・最適化系プラグイン・テーマとの読み込み順衝突や `after_setup_theme` 途中での中断などで ExUnit のパッケージ読み込みが未完了のまま enqueue フックが走ると、未定義関数の呼び出しとなり Fatal error になります。

さらに、この `$options = veu_get_common_options();` は **戻り値が関数内で一切使われていないデッドコード**でした。かつて bootstrap 用 CSS と通常 CSS を出し分けていた名残で、その分岐はコミット `6db85ef8` で既に削除されています。

## 修正内容

`vwu_register_css()` から不要な `$options = veu_get_common_options();` の1行を削除しました。`wp_register_style()` はこの値に依存していないため、CSS 登録の挙動は変わりません。これにより、パッケージ未読込状態でも Fatal error が発生しなくなります。

## 確認手順

### 前提条件
- 本プラグインを有効化した WordPress 環境

### Before（修正前の再現手順）
1. パッケージ読み込み（`after_setup_theme`）が未完了のまま enqueue フックが走る環境（読み込み順が衝突する他プラグイン併用環境など）でフロント／管理画面を開く
   → ✗ `Call to undefined function veu_get_common_options()` の Fatal error が発生

### After（修正後）
1. 通常のフロントページを開く
   → ✓ Fatal error が発生せず、`vkExUnit_common_style`（`assets/css/vkExUnit_style.css`）が従来どおり登録・出力される
2. 管理画面（投稿一覧・投稿編集画面など）を開く
   → ✓ Fatal error が発生しない
3. ExUnit の各機能の表示・スタイルが従来どおり適用されている
   → ✓ デグレがない

## 補足

- 純粋なロジック（デッドコード削除）の修正で表示への影響はないため、スクリーンショットは省略します。
- 新規関数の追加はないため PHPUnit テストの追加は行いません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * スタイル登録の処理を改善し、特定の環境での致命的なエラーを回避しました。これにより、すべての環境でスタイルが正常に適用されるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-all-in-one-expansion-unit/pull/1373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->