### PR TITLE
[ 不具合修正 ] お問い合わせセクションとSNSが無効時にカスタマイザーから関連記事設定が消える不具合を修正

### DIFF
--- a/inc/related_posts/related_posts.php
+++ b/inc/related_posts/related_posts.php
@@ -252,6 +252,17 @@ function veu_get_related_posts_html() {
 /**********************************************
  * Customizer
  */
+// 関連記事機能が有効な場合、カスタマイザーパネルを有効化するフィルターにフックする.
+add_filter( 'veu_customize_panel_activation', 'veu_customize_panel_activation_related' );
+/**
+ * 関連記事のカスタマイザーパネルを有効化する.
+ *
+ * @return bool
+ */
+function veu_customize_panel_activation_related() {
+	return true;
+}
+
 if ( apply_filters( 'veu_customize_panel_activation', false ) ) {
 	add_action( 'customize_register', 'veu_customize_register_related' );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ] Fixed an issue where the Related Posts Settings section disappeared from the Customizer when both the Contact Section and Social Media Integration features were disabled.
+
 = 9.117.1 =
 [ Bug Fix ] Removed an unnecessary veu_get_common_options() call in vwu_register_css() that could trigger a "Call to undefined function" fatal error when the enqueue hooks ran before the packages were loaded in some environments.
 


### PR DESCRIPTION
## 関連フォーラム
https://vws.vektor-inc.co.jp/forums/topic/%e9%96%a2%e9%80%a3

## 概要

`veu_customize_panel_activation` フィルターのフック漏れによる不具合修正。

### 原因

カスタマイザーの「ExUnit設定」パネルは `veu_customize_panel_activation` フィルターに `true` を返すフックが1つ以上登録されている場合にのみ表示される仕組みになっています。

各機能の動作：
- お問い合わせセクション（`contact-section/customizer.php`）→ 自分で `add_filter` して `true` を返す ✅
- ソーシャルメディア連携（`sns/sns_customizer.php`）→ 自分で `add_filter` して `true` を返す ✅
- **関連記事（`related_posts/related_posts.php`）→ `add_filter` を登録していなかった** ❌

この状態でお問い合わせとSNSの両方を無効化すると、フィルターに `true` を返すものが誰もいなくなり、関連記事のカスタマイザーセクションの登録がスキップされていました。

### 修正内容

`related_posts.php` に `add_filter( 'veu_customize_panel_activation', 'veu_customize_panel_activation_related' )` を追加し、関連記事機能が有効な場合はパネルを自分で有効化するようにしました。

## 確認手順

### 前提条件
- VK All in One Expansion Unit が有効化されていること

### Before（修正前の再現手順）

1. 管理画面 > ExUnit >  有効化設定 を開く
2. 「お問い合わせセクション」と「ソーシャルメディア連携」の両方のチェックを外して保存する
3. 管理画面 > 外観 > カスタマイズ を開く
   → ✗ 「ExUnit設定」パネル自体が表示されない（関連記事設定が確認できない）

<img width="346" height="319" alt="スクリーンショット 2026-06-01 11 16 24" src="https://github.com/user-attachments/assets/7be7c321-1df5-41cc-bbd1-15f1f5b7502c" />


### After（修正後）

1. 管理画面 > ExUnit >  有効化設定 を開く
2. 「お問い合わせセクション」と「ソーシャルメディア連携」の両方のチェックを外して保存する
3. 管理画面 > 外観 > カスタマイズ を開く
   → ✓ 「ExUnit設定」パネルが表示され、「Related Settings」セクションが確認できる
4. 「お問い合わせセクション」または「ソーシャルメディア連携」を有効に戻した場合も同様に動作することを確認する
   → ✓ 各機能の設定セクションも正しく表示される

<img width="338" height="350" alt="スクリーンショット 2026-06-01 11 13 39" src="https://github.com/user-attachments/assets/de3a4f41-82cb-4462-9d4d-cc752811b0b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Customizer で「Contact Section」と「Social Media Integration」が両方無効化された場合に「Related Posts Settings」セクションが表示されなくなる不具合を修正しました。これにより、他のセクションの状態に関わらず、Related Posts設定が常に利用可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->