### PR TITLE
[ 不具合修正 ] メインクエリに投稿タイプを配列指定したアーカイブで Body Class が PHP Warning（Array to string conversion）を出す不具合を修正

### DIFF
--- a/inc/add-body-class.php
+++ b/inc/add-body-class.php
@@ -54,7 +54,9 @@ function veu_add_body_class( $class ) {
 	if ( is_archive() || is_singular() || ( is_home() && ! is_front_page() ) ) {
 		if ( function_exists( 'vk_get_post_type' ) ) {
 			$post_type_info = vk_get_post_type();
-			if ( ! empty( $post_type_info['slug'] ) ) {
+			// slug は vk_get_post_type() 側で文字列に正規化されるが、フィルター等で配列が返るケースに備えて文字列のみ連結する.
+			// これにより "Array to string conversion" Warning を確実に防止する.
+			if ( ! empty( $post_type_info['slug'] ) && is_string( $post_type_info['slug'] ) ) {
 				$class[] = 'post-type-' . $post_type_info['slug'];
 			} // if ( ! empty( $post_type_info['slug'] ) ) {
 		} // if ( function_exists( 'vk_get_post_type' ) ) {

--- a/inc/template-tags/package/template-tags.php
+++ b/inc/template-tags/package/template-tags.php
@@ -88,6 +88,12 @@ if ( ! function_exists( 'vk_get_post_type' ) ) {
 		if ( ! $postType['slug'] ) {
 			if ( isset( $wp_query->query_vars['post_type'] ) && $wp_query->query_vars['post_type'] ) {
 				$postType['slug'] = $wp_query->query_vars['post_type'];
+				// メインクエリに post_type を配列で指定した場合（例: pre_get_posts で array( 'event', 'page' ) を set）への対策.
+				// slug は文字列前提で利用されるため、配列の場合は先頭要素を採用して文字列に正規化する.
+				// これをしないと後続の 'post-type-' . $slug 等で "Array to string conversion" Warning が発生する.
+				if ( is_array( $postType['slug'] ) ) {
+					$postType['slug'] = ! empty( $postType['slug'] ) ? reset( $postType['slug'] ) : '';
+				}
 			} else {
 				// Case of no post type query
 				if ( ! empty( $wp_query->queried_object->taxonomy ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ] Fixed an "Array to string conversion" PHP warning and an invalid "post-type-Array" body class that occurred on archives whose main query sets post_type to an array and that have no matching posts.
+
 [ Bug Fix ] Fixed an issue where the Related Posts Settings section disappeared from the Customizer when both the Contact Section and Social Media Integration features were disabled.
 
 = 9.117.1 =

--- a/tests/test-add-body-class.php
+++ b/tests/test-add-body-class.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Class AddBodyClassTest
+ *
+ * @package vektor-inc/vk-all-in-one-expansion-unit
+ */
+
+/**
+ * Test case for veu_add_body_class().
+ * veu_add_body_class() のテストケース.
+ */
+class AddBodyClassTest extends WP_UnitTestCase {
+
+	/**
+	 * Test for veu_add_body_class().
+	 * veu_add_body_class() のテスト.
+	 *
+	 * 主目的は、カテゴリー（タクソノミー）アーカイブのメインクエリに
+	 * post_type を「配列」で指定し、かつ該当投稿が無い場合に、
+	 * vk_get_post_type() が配列の slug を返してしまい
+	 * 'post-type-' . $slug で PHP の "Array to string conversion" Warning が
+	 * 発生する不具合を再発防止することです。
+	 * .phpunit.xml で convertWarningsToExceptions="true" のため、
+	 * Warning が発生すると例外に変換されてテストが失敗します。
+	 *
+	 * @return void
+	 */
+	public function test_veu_add_body_class() {
+
+		// テスト用のカスタム投稿タイプ event を登録する.
+		register_post_type(
+			'event',
+			array(
+				'has_archive' => true,
+				'public'      => true,
+				'label'       => 'Event',
+			)
+		);
+
+		// テスト用のカテゴリーを作成する.
+		$category_id = self::factory()->category->create(
+			array(
+				'slug' => 'no-post-category',
+				'name' => 'No Post Category',
+			)
+		);
+
+		// テストの配列.
+		$test_cases = array(
+			array(
+				'test_condition_name'   => 'カテゴリーアーカイブ + メインクエリ post_type が配列 + 該当投稿なし => Array to string conversion の Warning が出ず post-type クラスは付与される',
+				// メインクエリに post_type を配列で指定した状況を再現する.
+				'query_vars_post_type'  => array( 'event', 'page' ),
+				'input_class'           => array( 'foo' ),
+				// 配列の先頭要素 'event' が slug として採用され、文字列クラスになることを期待する.
+				'expected_contains'     => array( 'foo', 'post-type-event' ),
+				// クラスに 'post-type-Array' が混入していないこと（配列が文字列化されていないこと）.
+				'expected_not_contains' => 'post-type-Array',
+			),
+			array(
+				'test_condition_name'   => 'カテゴリーアーカイブ + メインクエリ post_type が単一文字列 + 該当投稿なし => その投稿タイプの post-type クラスが付与される',
+				// 配列ではなく単一文字列を指定した正常系（従来どおりの挙動が維持されること）.
+				'query_vars_post_type'  => 'event',
+				'input_class'           => array( 'baz' ),
+				'expected_contains'     => array( 'baz', 'post-type-event' ),
+				'expected_not_contains' => 'post-type-Array',
+			),
+			array(
+				'test_condition_name'   => 'カテゴリーアーカイブ + post_type 指定なし + 該当投稿なし => タクソノミーから解決した post-type クラスが付与される',
+				'query_vars_post_type'  => null,
+				'input_class'           => array( 'bar' ),
+				// post_type 未指定時はタクソノミー category の object_type[0] = 'post' になる.
+				'expected_contains'     => array( 'bar', 'post-type-post' ),
+				'expected_not_contains' => 'post-type-Array',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+
+			// カテゴリーアーカイブに移動する（is_archive() / is_category() を真にする）.
+			// go_to() はグローバル $wp_query を新しいオブジェクトに差し替えるため、移動後に取得し直す.
+			$this->go_to( get_category_link( $category_id ) );
+
+			// 該当投稿が無い状況のため get_post_type() は false になる.
+			// メインクエリの post_type を上書きして再現シナリオを作る（移動後の $wp_query を直接操作する）.
+			if ( null !== $case['query_vars_post_type'] ) {
+				$GLOBALS['wp_query']->query_vars['post_type'] = $case['query_vars_post_type'];
+			}
+
+			// テスト対象関数を実行（Warning が出れば convertWarningsToExceptions により失敗する）.
+			$actual = veu_add_body_class( $case['input_class'] );
+
+			// 期待するクラスが含まれていること.
+			foreach ( $case['expected_contains'] as $expected_class ) {
+				$this->assertContains( $expected_class, $actual, $case['test_condition_name'] );
+			}
+
+			// 配列が文字列化された 'post-type-Array' が含まれていないこと.
+			$this->assertNotContains( $case['expected_not_contains'], $actual, $case['test_condition_name'] );
+		}
+
+		// 後始末.
+		wp_delete_category( $category_id );
+		unregister_post_type( 'event' );
+	}
+}


### PR DESCRIPTION
## 概要

Closes #1375

`pre_get_posts` 等でアーカイブのメインクエリに投稿タイプ（`post_type`）を**配列**で指定し、かつそのアーカイブに該当する投稿が1件も無い場合に、`body_class` 出力時に PHP の `Warning: Array to string conversion` が発生する不具合を修正します。body のクラスにも `post-type-Array` という不正な値が混入していました。

### 発生経路

1. カテゴリー等のアーカイブで、メインクエリに `post_type => array( 'event', 'page' )` のように配列が指定される（例: `pre_get_posts` での `$query->set()`）。
2. そのアーカイブに該当投稿が無いと、`inc/template-tags/package/template-tags.php` の `vk_get_post_type()` L87 `get_post_type()` が `false` を返す。
3. L89-90 で `$wp_query->query_vars['post_type']`（＝配列）をそのまま `$postType['slug']` に代入してしまい、**slug が配列**になる。
4. `inc/add-body-class.php` の `$class[] = 'post-type-' . $post_type_info['slug'];` で配列を文字列連結 → `Array to string conversion` Warning が発生。

> 補足: 当初の切り分け（`is_singular()` 時の `$post` が null になる経路）は誤りで、関連フォーラムの URL も issue 本文で取り消されています。本 PR は再切り分け後の正しい原因に対する修正です。

### 変更内容

- `inc/template-tags/package/template-tags.php`（`vk_get_post_type()`）: **根本修正**。`query_vars['post_type']` が配列の場合は先頭要素を採用して slug を文字列に正規化。これによりパンくず等、本関数の他の利用箇所も配列起因の不具合から守られます。
- `inc/add-body-class.php`: 防御として `is_string()` ガードを追加（フィルター `vkExUnit_postType_custom` 等で slug に配列が返るケースに備える）。
- `tests/test-add-body-class.php`: 本不具合の再現テストを新規追加。
- `readme.txt`: changelog に `[ 不具合修正 ]` を追記。

## 確認手順

### 前提条件

- PHP 8 系（本 PR の自動テストは PHP 8.3 環境で実行）
- ExUnit を有効化
- カスタム投稿タイプ（例: `event`）を登録し、以下を `functions.php` 等に追加:

```php
add_action( 'pre_get_posts', function( $query ) {
    if ( is_admin() || ! $query->is_main_query() ) { return; }
    if ( $query->is_category() ) {
        $query->set( 'post_type', array( 'event', 'page' ) );
    }
});
```

### 手順

#### Before（修正前の再現手順）

1. 投稿が1件も無いカテゴリーのアーカイブページを開く
   → ✗ `Warning: Array to string conversion`（`inc/add-body-class.php`）が発生し、body に `post-type-Array` クラスが付与される

#### After（修正後）

1. 同じく投稿が無いカテゴリーアーカイブを開く
   → ✓ Warning が発生しない。body には配列の先頭要素を採用した `post-type-event` クラスが付与される（`post-type-Array` は付与されない）
2. 通常の投稿一覧・カスタム投稿タイプアーカイブ・個別投稿を表示する
   → ✓ 従来どおりの `post-type-*` クラスが付与される（デグレなし）

## テスト

`tests/test-add-body-class.php` を追加しました。`.phpunit.xml` の `convertWarningsToExceptions="true"` を利用し、`Array to string conversion` Warning が出るとテストが失敗する仕組みで検証しています。

- 異常系: カテゴリーアーカイブ + メインクエリ `post_type` が配列 + 該当投稿なし → Warning が出ず、`post-type-event` が付与され `post-type-Array` は付与されない
- 正常系: メインクエリ `post_type` が単一文字列 → `post-type-event` が付与される
- 境界値: `post_type` 指定なし → タクソノミーから解決した `post-type-post` が付与される

実行結果:

- PHPUnit: `OK (1 test, 9 assertions)`（PHP 8.3.31 / wp-env tests-cli）
- 修正前のコードに対してこのテストを流すと `Array to string conversion` で失敗することを確認済み（テストがバグを正しく捕捉していることを検証）
- フルスイートでも本テストは PASS。既存の失敗（CTA・post-type-manager の一部）は本 PR の変更とは無関係で、変更前（master 相当）でも同様に失敗することを確認済み
- phpcs（`.phpcs.xml` / WordPress ルールセット）: 追加した `tests/test-add-body-class.php` はクリーン。`inc/add-body-class.php`・`inc/template-tags/package/template-tags.php` の既存指摘は本 PR の変更行に起因せず、変更前後でエラー件数は同一（最小修正方針）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * アーカイブ等で投稿タイプが配列指定された場合に発生していたPHP 8の「Array to string conversion」警告を回避する修正を行いました（出力されるボディクラスが正しく生成されます）。

* **テスト**
  * 上記挙動を確認するユニットテストを追加しました。

* **ドキュメント**
  * チェンジログに修正内容を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

