### PR TITLE
[ 不具合修正 ][ 構造化データ ] 著者ユーザーが取得できない場合に構造化データ出力で PHP Warning が発生する不具合を修正

### DIFF
--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -186,7 +186,13 @@ class VK_Article_Srtuctured_Data {
 
 		if ( ! $author_id ) {
 			// 表示中のページの投稿オブジェクトからユーザーIDを取得
+			// Get the user ID from the post object of the page being displayed.
 			global $post;
+			// global $post が null だったり post_author を持たない文脈では Warning を出さずに早期 return する。
+			// Bail out without raising a warning when global $post is null or has no post_author in the current context.
+			if ( ! isset( $post->post_author ) ) {
+				return;
+			}
 			$author_id = $post->post_author;
 		}
 
@@ -195,9 +201,11 @@ class VK_Article_Srtuctured_Data {
 			return;
 		}
 
+		// 存在しないユーザーIDの場合 get_userdata() は false を返すため、display_name 参照前にガードする。
+		// get_userdata() returns false for a non-existent user ID, so guard before referencing display_name.
 		$author      = get_userdata( $author_id );
 		$author_type = get_user_meta( $author_id, 'author_type', true );
-		$author_name = get_user_meta( $author_id, 'author_name', true ) ?: $author->display_name;
+		$author_name = get_user_meta( $author_id, 'author_name', true ) ?: ( $author ? $author->display_name : '' );
 		$author_url  = get_user_meta( $author_id, 'author_url', true ) ?: home_url( '/' );
 		if ( 'person' === $author_type ) {
 			$author_url = get_user_meta( $author_id, 'author_url', true ) ?: get_author_posts_url( $author_id );

--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -189,9 +189,11 @@ class VK_Article_Srtuctured_Data {
 			// Get the user ID from the post object of the page being displayed.
 			global $post;
 			// global $post が null だったり post_author を持たない文脈では Warning を出さずに早期 return する。
+			// docblock の @return array に合わせ、空配列を返して型契約を守る。
 			// Bail out without raising a warning when global $post is null or has no post_author in the current context.
+			// Return an empty array to honor the @return array contract in the docblock.
 			if ( ! isset( $post->post_author ) ) {
-				return;
+				return array();
 			}
 			$author_id = $post->post_author;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ] Fixed a warning in the article structured data output when the author user could not be retrieved.
+
 [ Bug Fix ] Fixed an issue where the Related Posts Settings section disappeared from the Customizer when both the Contact Section and Social Media Integration features were disabled.
 
 = 9.117.1 =

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -14,6 +14,7 @@ class Article_Structure_Test extends WP_UnitTestCase {
 		print '------------------------------------' . PHP_EOL;
 
 		// テスト用ユーザーを発行
+		// Create a test user.
 		$userdata = array(
 			'user_login'   => 'sutekivektor',
 			'user_url'     => 'https://vektor-inc.co.jp',
@@ -22,142 +23,147 @@ class Article_Structure_Test extends WP_UnitTestCase {
 		);
 		$user_id  = wp_insert_user( $userdata );
 
+		// 存在しないユーザーID（十分に大きな値）。get_userdata() が false を返す異常系の検証に使う。
+		// A non-existent user ID (a sufficiently large value), used for the abnormal case where get_userdata() returns false.
+		$invalid_user_id = 999999;
+		// 前提として当該ユーザーが存在しないことを確認しておく。
+		// Make sure beforehand that the user really does not exist.
+		$this->assertFalse( get_userdata( $invalid_user_id ) );
+
 		$test_data = array(
-			// 独自実装のユーザー情報フィールド : すべて埋められている場合 && person
+			// 正常系 : 独自実装のユーザー情報フィールドがすべて埋められている && person
+			// Normal case: all custom author fields are filled in && person.
 			array(
-				'author'  => array(
+				'test_condition_name' => '著者フィールドが全て入力済み && person の場合 => 入力値がそのまま返る',
+				'user_id'             => $user_id,
+				'author'              => array(
 					'author_type'   => 'person',
 					'author_name'   => 'vekutarou',
 					'author_url'    => 'https://vektor-inc.co.jp/author/vekutarou',
 					'author_sameAs' => 'https://twitter.com/vektor_inc',
 				),
-				'correct' => array(
+				'correct'             => array(
 					'@type'  => 'person',
 					'name'   => 'vekutarou',
 					'url'    => 'https://vektor-inc.co.jp/author/vekutarou',
 					'sameAs' => 'https://twitter.com/vektor_inc',
 				),
 			),
-			// チェック対象 : url
-			// 独自実装のユーザー情報フィールド : organization && url指定あり
+			// 正常系 : organization && url指定あり（チェック対象 : url）
+			// Normal case: organization && url provided (target: url).
 			array(
-				'author'  => array(
+				'test_condition_name' => 'organization && url 指定ありの場合 => 指定した url が返る',
+				'user_id'             => $user_id,
+				'author'              => array(
 					'author_type'   => 'organization',
 					'author_name'   => 'vekutarou',
 					'author_url'    => 'https://vektor-inc.co.jp/',
 					'author_sameAs' => 'https://twitter.com/vektor_inc',
 				),
-				'correct' => array(
+				'correct'             => array(
 					'@type'  => 'organization',
 					'name'   => 'vekutarou',
 					'url'    => 'https://vektor-inc.co.jp/',
 					'sameAs' => 'https://twitter.com/vektor_inc',
 				),
 			),
-			// チェック対象 : url
-			// 独自実装のユーザー情報フィールド : organization && url指定なし
+			// 正常系 : organization && url指定なし（チェック対象 : url）
+			// Normal case: organization && url not provided (target: url).
 			array(
-				'author'  => array(
+				'test_condition_name' => 'organization && url 指定なしの場合 => サイトトップ URL が返る',
+				'user_id'             => $user_id,
+				'author'              => array(
 					'author_type'   => 'organization',
 					'author_name'   => 'vekutarou',
 					'author_url'    => '',
 					'author_sameAs' => 'https://twitter.com/vektor_inc',
 				),
-				'correct' => array(
+				'correct'             => array(
 					'@type'  => 'organization',
 					'name'   => 'vekutarou',
 					'url'    => home_url( '/' ),
 					'sameAs' => 'https://twitter.com/vektor_inc',
 				),
 			),
-			// チェック対象 : url
-			// 独自実装のユーザー情報フィールド : person && url指定なし → 投稿者アーカイブのURL
+			// 正常系 : person && url指定なし → 投稿者アーカイブのURL（チェック対象 : url）
+			// Normal case: person && url not provided -> author archive URL (target: url).
 			array(
-				'author'  => array(
+				'test_condition_name' => 'person && url 指定なしの場合 => 投稿者アーカイブ URL が返る',
+				'user_id'             => $user_id,
+				'author'              => array(
 					'author_type'   => 'person',
 					'author_name'   => 'vekujirou',
 					'author_url'    => '',
 					'author_sameAs' => 'https://twitter.com/vektor_inc',
 				),
-				'correct' => array(
+				'correct'             => array(
 					'@type'  => 'person',
 					'name'   => 'vekujirou',
 					'url'    => get_author_posts_url( $user_id ),
 					'sameAs' => 'https://twitter.com/vektor_inc',
 				),
 			),
-			// チェック対象 : name
-			// 独自実装のユーザー情報フィールド : author_name 指定なし  → デフォルトのユーザーの表示名が適用されるか
+			// 正常系 : author_name 指定なし → デフォルトのユーザー表示名が適用されるか（チェック対象 : name）
+			// Normal case: author_name not provided -> the user's display name is applied (target: name).
 			array(
-				'author'  => array(
+				'test_condition_name' => 'author_name 指定なしの場合 => ユーザーの表示名が返る',
+				'user_id'             => $user_id,
+				'author'              => array(
 					'author_type'   => 'organization',
 					'author_name'   => '',
 					'author_url'    => '',
 					'author_sameAs' => 'https://twitter.com/vektor_inc',
 				),
-				'correct' => array(
+				'correct'             => array(
 					'@type'  => 'organization',
 					'name'   => 'vekujirou',
 					'url'    => home_url( '/' ),
 					'sameAs' => 'https://twitter.com/vektor_inc',
 				),
 			),
+			// 異常系 : 存在しないユーザーID → get_userdata() が false を返しても Warning を出さず name が空文字になるか
+			// 不具合: 修正前は false に対し $author->display_name へアクセスし Warning が発生していた。
+			// Abnormal case: a non-existent user ID -> even though get_userdata() returns false, no warning is raised and name becomes an empty string.
+			// Bug: before the fix, accessing $author->display_name on false raised a warning.
+			array(
+				'test_condition_name' => '存在しないユーザーIDの場合 => Warning を出さず name が空文字で返る',
+				'user_id'             => $invalid_user_id,
+				// 存在しないユーザーには user_meta を設定しないため空配列。
+				// No user_meta is set for a non-existent user, so this is empty.
+				'author'              => array(),
+				'correct'             => array(
+					'@type'  => '',
+					'name'   => '',
+					'url'    => home_url( '/' ),
+					'sameAs' => '',
+				),
+			),
 		);
 
 		foreach ( $test_data as $test_value ) {
+			// 各ケースで使用するユーザーIDを取得する。
+			// Get the user ID used by each case.
+			$target_user_id = $test_value['user_id'];
+
+			// ケースに応じてユーザーメタを設定する（存在しないユーザーの場合は author が空配列なので何もしない）。
+			// Set the user meta according to the case (for a non-existent user, author is empty so nothing happens).
 			foreach ( $test_value['author'] as $key => $value ) {
-				update_user_meta( $user_id, $key, $value );
+				update_user_meta( $target_user_id, $key, $value );
 			}
 
-			$return  = VK_Article_Srtuctured_Data::get_author_array( $user_id );
+			// WP_UnitTestCase は PHP の警告を例外に変換するため、
+			// 修正前は存在しないユーザーIDのケースでこの呼び出し自体が警告→例外で失敗する（red）。
+			// WP_UnitTestCase converts PHP warnings into exceptions, so before the fix
+			// the non-existent user case fails (red) here due to the warning being thrown.
+			$return  = VK_Article_Srtuctured_Data::get_author_array( $target_user_id );
 			$correct = $test_value['correct'];
 
-			// print PHP_EOL;
-
-			// print 'correct ::::' . PHP_EOL;
-			// var_dump( $correct );
-			// print 'return  ::::' . PHP_EOL;
-			// var_dump( $return );
-			$this->assertEquals( $correct, $return );
+			$this->assertEquals( $correct, $return, $test_value['test_condition_name'] );
 		}
 
 		// テストで発行したユーザーを削除
+		// Delete the user created for the test.
 		wp_delete_user( $user_id );
-	}
-
-	/**
-	 * 存在しないユーザーIDが渡された場合に Warning を出さず処理できるかを検証する。
-	 * Verify that no warning is raised when a non-existent user ID is passed.
-	 *
-	 * 不具合: get_userdata() が false を返す際に $author->display_name へアクセスして
-	 * "Attempt to read property display_name on false" の Warning が発生していた。
-	 * Bug: when get_userdata() returns false, accessing $author->display_name raised
-	 * "Attempt to read property display_name on false".
-	 */
-	function test_get_author_array_with_invalid_user() {
-
-		print PHP_EOL;
-		print '------------------------------------' . PHP_EOL;
-		print 'test_get_author_array_with_invalid_user' . PHP_EOL;
-		print '------------------------------------' . PHP_EOL;
-
-		// 存在しないユーザーID（十分に大きな値）を用意する。
-		// Prepare a user ID that does not exist (a sufficiently large value).
-		$invalid_user_id = 999999;
-		// 念のため当該ユーザーが存在しないことを確認する。
-		// Make sure the user really does not exist.
-		$this->assertFalse( get_userdata( $invalid_user_id ) );
-
-		// WP_UnitTestCase は PHP の警告を例外に変換するため、
-		// 修正前はこの呼び出し自体が警告→例外で失敗する（red）。
-		// WP_UnitTestCase converts PHP warnings into exceptions, so before the fix
-		// this call itself fails (red) due to the warning being thrown.
-		$return = VK_Article_Srtuctured_Data::get_author_array( $invalid_user_id );
-
-		// author_name メタも無いので display_name フォールバックは空文字になる。
-		// Since there is no author_name meta either, the display_name fallback is an empty string.
-		$this->assertIsArray( $return );
-		$this->assertSame( '', $return['name'] );
 	}
 
 

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -125,6 +125,41 @@ class Article_Structure_Test extends WP_UnitTestCase {
 		wp_delete_user( $user_id );
 	}
 
+	/**
+	 * 存在しないユーザーIDが渡された場合に Warning を出さず処理できるかを検証する。
+	 * Verify that no warning is raised when a non-existent user ID is passed.
+	 *
+	 * 不具合: get_userdata() が false を返す際に $author->display_name へアクセスして
+	 * "Attempt to read property display_name on false" の Warning が発生していた。
+	 * Bug: when get_userdata() returns false, accessing $author->display_name raised
+	 * "Attempt to read property display_name on false".
+	 */
+	function test_get_author_array_with_invalid_user() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_get_author_array_with_invalid_user' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		// 存在しないユーザーID（十分に大きな値）を用意する。
+		// Prepare a user ID that does not exist (a sufficiently large value).
+		$invalid_user_id = 999999;
+		// 念のため当該ユーザーが存在しないことを確認する。
+		// Make sure the user really does not exist.
+		$this->assertFalse( get_userdata( $invalid_user_id ) );
+
+		// WP_UnitTestCase は PHP の警告を例外に変換するため、
+		// 修正前はこの呼び出し自体が警告→例外で失敗する（red）。
+		// WP_UnitTestCase converts PHP warnings into exceptions, so before the fix
+		// this call itself fails (red) due to the warning being thrown.
+		$return = VK_Article_Srtuctured_Data::get_author_array( $invalid_user_id );
+
+		// author_name メタも無いので display_name フォールバックは空文字になる。
+		// Since there is no author_name meta either, the display_name fallback is an empty string.
+		$this->assertIsArray( $return );
+		$this->assertSame( '', $return['name'] );
+	}
+
 
 	function test_get_article_structure_array() {
 


### PR DESCRIPTION
## 概要

`inc/article-structure-data/class-vk-article-structure-data.php` の `get_author_array()` で、著者ユーザーオブジェクトが取得できない場合に PHP 8 系の Warning が発生する不具合を修正します。

Closes #1377

## 不具合の内容

- `get_userdata( $author_id )` は該当ユーザーが存在しない場合（削除済みユーザー、無効な author ID など）に `false` を返す。
- その状態で `$author->display_name` にアクセスするため `Warning: Attempt to read property "display_name" on false` が発生していた。
- 加えて `global $post` が `null` の文脈では `$post->post_author` 参照も潜在的に Warning を出しうる。

issue #1375（PR #1376）の e2e 動作確認中に検出された別件です。

## 修正内容

1. **display_name フォールバックのガード**
   `?: $author->display_name` を `?: ( $author ? $author->display_name : '' )` に変更。`get_userdata()` が `false` の場合は `display_name` を参照せず、`author_name` メタも無ければ空文字にフォールバックします。

2. **`global $post` の null ガード**
   `global $post` 取得直後に `if ( ! isset( $post->post_author ) ) { return; }` を追加。`$post` が `null` や `post_author` を持たない文脈では、既存の `return;` と整合する形で早期 return します。

正常系（`is_single()` で著者情報が取得できる場合）の挙動は変更していません。

## 確認手順

### 前提条件
- 存在しないユーザーID、または削除済みユーザーを著者（`post_author`）に持つ投稿を用意する。

### Before（修正前の再現手順）
1. 上記の投稿をフロントで個別表示する。
2. デバッグログ（`WP_DEBUG` 有効）またはフロント出力を確認する。
   → ✗ `Warning: Attempt to read property "display_name" on false` が発生する。

### After（修正後）
1. 同じ投稿をフロントで個別表示する。
   → ✓ Warning が発生しない。構造化データの `name` は空文字（author_name メタがあればその値）で出力される。
2. 通常の有効な著者を持つ投稿を表示する。
   → ✓ 従来どおり著者情報（display_name 等）が正しく出力される（デグレなし）。

## テスト（red→green）

`tests/test-article-structure.php` の既存テスト `test_get_author_array()` の `$test_data` 配列ループに、異常系ケースを追加しました（`rules/testing/phpunit.md` の配列駆動形式に準拠）。

- 存在しないユーザーID（`999999`）を渡すケースをループに追加し、Warning が出ないこと・`name` が空文字になることを検証（正常系 5 件＋異常系 1 件）。
- `WP_UnitTestCase` は PHP Warning を例外化するため、Warning が発生すれば即失敗します。
- **修正前**: `Attempt to read property "display_name" on false` で red を確認。
- **修正後**: `Article_Structure_Test` 全テスト OK（2 tests, 9 assertions）を wp-env + PHPUnit で確認。

## レビュー状況

- セキュリティレビュー（安藤）: PASS。schema.org 出力経路は `wp_kses` を通っており退行なし、情報漏えいリスクなし。
- UX レビュー: 純粋なロジック変更のため省略。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 記事の構造化データ出力において、存在しないユーザーIDから作成者情報を取得する際に発生していた警告を解決しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
