### PR TITLE
[ 開発環境 ] 通常の PR は run-ci ラベル付与時のみ CI を実行するようゲート追加 (#1378)

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,18 +1,17 @@
 name: Build Check & PHPUnit
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - master
       - develop
-      - ^feature/.+
+      - "feature/**"
 
 jobs:
   php_unit:
     name: php unittest
+    if: contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,12 +1,12 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ develop ]
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ develop ]
 jobs:
   test:
     timeout-minutes: 60
+    if: contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## 概要

issue #1378 の確定仕様に基づき、デプロイ時以外の通常の PR では `run-ci` ラベルが付いているときだけ CI を実行するようにゲートを追加する。

push トリガーもゲート対象とするため、`build_check.yml` / `playwright.yml` 両方から `on.push` を削除し、`pull_request` トリガー + `run-ci` ラベル判定のみで起動する構成に変更する。

`release.yml`（Deploy to WordPress.org, tag push）は対象外で変更しない。

## 変更内容

### `.github/workflows/build_check.yml`（Build Check & PHPUnit）
- `on.push`（branches: master）を削除
- `on.pull_request.types: [opened, synchronize, reopened, labeled]` を追加（後付けラベルでの起動のため `labeled` が必須。types 明示でデフォルトが効かなくなるため opened/synchronize/reopened も明記）
- `on.pull_request.branches` の壊れた `^feature/.+` を glob の `"feature/**"` に修正（master / develop はそのまま）
- `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加

### `.github/workflows/playwright.yml`（Playwright Tests）
- `on.push`（branches: develop）を削除
- `on.pull_request.types: [opened, synchronize, reopened, labeled]` を追加（`branches: [ develop ]` はそのまま）
- `test` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加

## changelog について

GitHub Actions のワークフロー設定変更であり、エンドユーザーに影響しないため、`rules/changelog.md` の「更新不要なケース（GitHub Actions などのワークフロー設定）」に該当する。Fatal error 等のユーザー影響もないため readme.txt への追記は不要と判断した（wordpress.org 向け readme.txt は `[ 開発環境 ]` を記載しないルールにも合致）。

## 確認手順

### 前提条件
- 本ブランチを対象にした PR が存在する状態

### 手順

1. 本 PR に `run-ci` ラベルが **付いていない** 状態で push する
   → Build Check & PHPUnit / Playwright Tests のジョブが起動しない（`if` 条件で skip される）
2. 本 PR に `run-ci` ラベルを **付与** する
   → `labeled` イベントでワークフローが起動し、`if` 条件を満たして Build Check & PHPUnit / Playwright Tests のジョブが実行される
3. ラベルを付けたまま追加で push する（synchronize）
   → ジョブが実行される
4. master / develop へ直接 push する
   → どちらのワークフローも起動しない（`on.push` を削除したため）

## 関連 issue

refs #1378

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD ワークフローの起動条件を見直しました。push トリガーを削除し、プルリクエストのイベント種別と対象ブランチを明確化するとともに、特定ラベルが付与された場合のみ一部のビルド／テストジョブが実行されるよう制御を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->