### PR TITLE
[ 不具合修正 ][ 構造化データ ] 記事でアイキャッチ未設定時に JSON-LD へ空の image が出力される不具合を修正

### DIFF
--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -173,6 +173,14 @@ class VK_Article_Srtuctured_Data {
 		// ),
 		);
 
+		// アイキャッチ未設定なら image キーを除去する。
+		// 空文字の image は構造化データとして無意味なため、未設定時はキー自体を含めない。
+		// Remove the image key when no featured image is set.
+		// An empty image string is meaningless for structured data, so omit the key entirely when it is unset.
+		if ( empty( $image_url ) ) {
+			unset( $article_array['image'] );
+		}
+
 		return $article_array;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,8 @@ e.g.
 
 [ Spec Change ][ Page Top Button ] The focus indicator now follows the silhouette of an uploaded image, and the show / hide animation respects the reduced motion preference.
 
+[ Bug Fix ][ Article Structured Data ] Stopped outputting an empty "image" value in the JSON-LD when a post has no featured image, omitting the image field entirely instead.
+
 = 9.117.2 =
 [ Bug Fix ] Fixed a warning in the article structured data output when the author user could not be retrieved.
 

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -221,20 +221,24 @@ class Article_Structure_Test extends WP_UnitTestCase {
 		// apply_filters( 'post_thumbnail_url', $thumbnail_url, $post, $size );
 
 		$test_data = array(
+			// 正常系 : アイキャッチ未設定 => image キー自体が出力されない
+			// Normal case: no featured image -> the image key itself is not output.
 			array(
+				'test_condition_name' => 'アイキャッチ未設定の場合 => image キーが出力されない',
 				// 'target_url' => get_permalink( $data['post_id_person'] ),
-				'post_data'     => array(
+				'post_data'           => array(
 					'post_title'   => 'Post Person',
 					'post_status'  => 'publish',
 					'post_content' => 'Post Test',
 					'post_author'  => $test_users['person_01']['user_id'],
 				),
-				'thumbnail_url' => 'https://image_person.com',
-				'correct'       => array(
+				// アイキャッチを設定しないケース。
+				// Case where no featured image is set.
+				'set_thumbnail'       => false,
+				'correct'             => array(
 					'@context'      => 'https://schema.org/',
 					'@type'         => 'Article',
 					'headline'      => 'Post Person',
-					'image'         => '',
 					'datePublished' => 'ここは投稿作成してから上書きする',
 					'dateModified'  => 'ここは投稿作成してから上書きする',
 					'author'        => array(
@@ -256,21 +260,25 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					// ),
 				),
 			),
-			// 組織投稿の場合
+			// 正常系 : アイキャッチ設定済み => image が出力される（組織投稿の場合）
+			// Normal case: featured image is set -> image is output (organization post).
 			array(
+				'test_condition_name' => 'アイキャッチ設定済みの場合 => image が出力される',
 				// 'target_url' => get_permalink( $data['post_id_org'] ),
-				'post_data'     => array(
+				'post_data'           => array(
 					'post_title'   => 'Post Org',
 					'post_status'  => 'publish',
 					'post_content' => 'Post Test Org',
 					'post_author'  => $test_users['org_02']['user_id'],
 				),
-				'thumbnail_url' => 'https://image_org.com',
-				'correct'       => array(
+				// アイキャッチを設定するケース。実際の URL はループ内で correct に上書きする。
+				// Case where a featured image is set. The actual URL is overwritten into correct inside the loop.
+				'set_thumbnail'       => true,
+				'correct'             => array(
 					'@context'      => 'https://schema.org/',
 					'@type'         => 'Article',
 					'headline'      => 'Post Org',
-					'image'         => '',
+					'image'         => 'ここはアイキャッチ設定してから上書きする',
 					'datePublished' => 'ここは投稿作成してから上書きする',
 					'dateModified'  => 'ここは投稿作成してから上書きする',
 					'author'        => array(
@@ -301,19 +309,29 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			 */
 		);
 
+		// 後始末用に発行した添付ファイルIDを保持する。
+		// Keep created attachment IDs so they can be cleaned up afterward.
+		$attachment_ids = array();
+
 		foreach ( $test_data as $test_value ) {
 			$target_post_id = wp_insert_post( $test_value['post_data'] );
 
 			$test_value['correct']['datePublished'] = get_the_time( 'c', $target_post_id );
 			$test_value['correct']['dateModified']  = get_the_modified_time( 'c', $target_post_id );
 
+			// set_thumbnail が true のケースではダミー添付ファイルを作成しアイキャッチに設定する。
+			// 実際に出力される image URL を取得し、期待値（correct['image']）へ反映する。
+			// For cases with set_thumbnail true, create a dummy attachment and set it as the featured image.
+			// Retrieve the actual image URL output and reflect it into the expected value (correct['image']).
+			if ( ! empty( $test_value['set_thumbnail'] ) ) {
+				$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg', $target_post_id );
+				set_post_thumbnail( $target_post_id, $attachment_id );
+				$attachment_ids[]               = $attachment_id;
+				$test_value['correct']['image'] = wp_get_attachment_url( $attachment_id );
+			}
+
 			// Move to test page
 			$this->go_to( get_permalink( $target_post_id ) );
-
-			// add_filter( 'post_thumbnail_url', function( $thumbnail_url ) use ( $test_value) {
-			// $thumbnail_url = $test_value['thumbnail_url'];
-			// return $thumbnail_url;
-			// } );
 
 			$return  = VK_Article_Srtuctured_Data::get_article_structure_array();
 			$correct = $test_value['correct'];
@@ -322,12 +340,18 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			// print 'correct ::::' . $test_value['correct'] . PHP_EOL;
 			// print 'return  ::::' . $return['author'] . PHP_EOL;
 
-			$this->assertEquals( $correct, $return );
+			$this->assertEquals( $correct, $return, $test_value['test_condition_name'] );
 
 			// テスト投稿削除
 			wp_delete_post( $target_post_id );
 			// とりあえずトップに戻る
 			$this->go_to( home_url() );
+		}
+
+		// テストで発行した添付ファイルを削除する。
+		// Delete the attachments created during the test.
+		foreach ( $attachment_ids as $attachment_id ) {
+			wp_delete_attachment( $attachment_id, true );
 		}
 
 		// テストで発行したユーザーを削除 ///////////////////////////


### PR DESCRIPTION
## 概要

「Structured data - Article」機能が出力する記事の構造化データ（JSON-LD）で、アイキャッチ画像が未設定の投稿に対して `"image": ""`（空文字）が出力されていました。空文字は構造化データとして意味を持たないため、アイキャッチが無い場合は `image` フィールド自体を出力しないように修正します。

Closes #1388

## 変更内容

- `inc/article-structure-data/class-vk-article-structure-data.php` の `get_article_structure_array()` で、`$image_url` が空（アイキャッチ未設定）の場合は `$article_array` から `image` キーを `unset()` で除外。
- アイキャッチ有りの場合は従来どおり `headline` の直後に `image` を出力（出力順は不変）。
- 回帰テスト（`tests/test-article-structure.php`）を追加・更新。アイキャッチ未設定時は `image` キーが含まれないこと、設定時は実際の画像 URL が出力されることを検証。

## 確認手順

### 前提条件
- VK All in One Expansion Unit 有効化
- 管理画面 → VK All in One Expansion Unit → 機能管理 で「Structured data - Article」を有効化
- 投稿を2件用意（A: アイキャッチなし / B: アイキャッチあり）

### Before（修正前の再現手順）
1. アイキャッチを設定していない投稿 A の個別ページ（single）を開く
2. HTML ソースを表示し、`<!-- [ VK All in One Expansion Unit Article Structure Data ] -->` コメント内の JSON-LD を確認する
   → ✗ `"image": ""`（空文字）が出力されている

### After（修正後の確認手順）
1. 投稿 A（アイキャッチなし）の個別ページの JSON-LD を確認する
   → ✓ `image` フィールド自体が出力されない
2. 投稿 B（アイキャッチあり）の個別ページの JSON-LD を確認する
   → ✓ `image` フィールドにアイキャッチ画像の URL が出力される（デグレなし）
   → ✓ `image` は `headline` の直後に出力され、出力順は従来どおり

### 自動テスト
- `tests/test-article-structure.php` を wp-env / PHPUnit で実行し、アイキャッチ未設定＝`image` キーなし、設定済み＝`image` 出力、の両ケースが green になることを確認済み。

## 補足
- 純粋な出力ロジックの修正で、フロント・管理画面の見た目に影響はないためスクリーンショットは省略。
- ImageObject 形式化の改善は本 PR のスコープ外（別 issue で対応）。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * アイキャッチ画像が未設定の投稿で、JSON-LD の空の image フィールドが出力されないよう修正しました（image フィールドを省略）。
* **ドキュメント**
  * 変更点をチェンジログに追記しました。
* **テスト**
  * アイキャッチ有無のケースを明確化したテストを追加・改善し、ダミー添付の作成と後片付け・識別性向上を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->