### PR TITLE
[ 仕様変更 ][ 構造化データ ] 記事の JSON-LD の image を ImageObject 形式（url/width/height）で出力するよう変更

### DIFF
--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -143,12 +143,11 @@ class VK_Article_Srtuctured_Data {
 
 		// $author_type = get_user_meta( $author_id, 'author_type', true );
 
+		// アイキャッチ画像を ImageObject 形式の配列で取得する（未設定や URL 取得失敗時は空配列）。
+		// Get the featured image as an ImageObject-formatted array (empty array when unset or when the URL cannot be retrieved).
+		$image = array();
 		if ( is_singular() ) {
-			if ( has_post_thumbnail() ) {
-				$image_url = get_the_post_thumbnail_url();
-			} else {
-				$image_url = '';
-			}
+			$image      = self::get_article_image_object();
 			$post_title = get_the_title();
 		}
 
@@ -156,7 +155,7 @@ class VK_Article_Srtuctured_Data {
 			'@context'      => 'https://schema.org/',
 			'@type'         => 'Article',
 			'headline'      => $post_title,
-			'image'         => $image_url,
+			'image'         => $image,
 			'datePublished' => get_the_time( 'c' ),
 			'dateModified'  => get_the_modified_time( 'c' ),
 			'author'        => self::get_author_array( $author_id ),
@@ -173,15 +172,70 @@ class VK_Article_Srtuctured_Data {
 		// ),
 		);
 
-		// アイキャッチ未設定なら image キーを除去する。
-		// 空文字の image は構造化データとして無意味なため、未設定時はキー自体を含めない。
-		// Remove the image key when no featured image is set.
-		// An empty image string is meaningless for structured data, so omit the key entirely when it is unset.
-		if ( empty( $image_url ) ) {
+		// アイキャッチ未設定や URL 取得失敗時は image が空配列になるため、image キーを除去する。
+		// 空の image は構造化データとして無意味なため、未設定時はキー自体を含めない。
+		// Remove the image key when the featured image is unset or its URL could not be retrieved (image is an empty array).
+		// An empty image is meaningless for structured data, so omit the key entirely when it is unset.
+		if ( empty( $article_array['image'] ) ) {
 			unset( $article_array['image'] );
 		}
 
 		return $article_array;
+	}
+
+	/**
+	 * アイキャッチ画像を ImageObject 形式の配列で返す
+	 *
+	 * 元画像（フル解像度）の URL と実寸を取得し、@type / url / width / height を持つ配列を返す。
+	 * url が取得できない場合は空配列を返し、呼び出し元で image キーを省略させる。
+	 * width / height が取得できない場合は、実寸と異なる値を出さないために該当キーを含めない。
+	 *
+	 * Return the featured image as an ImageObject-formatted array.
+	 * It retrieves the URL and the actual dimensions of the original (full-resolution) image
+	 * and returns an array with @type / url / width / height.
+	 * When the URL cannot be retrieved, an empty array is returned so the caller omits the image key.
+	 * When width / height cannot be retrieved, those keys are omitted so as not to output dimensions that differ from the actual size.
+	 *
+	 * @return array ImageObject 形式の配列、または取得できない場合は空配列。
+	 */
+	private static function get_article_image_object() {
+
+		// アイキャッチが未設定なら空配列を返す。
+		// Return an empty array when no featured image is set.
+		if ( ! has_post_thumbnail() ) {
+			return array();
+		}
+
+		// アイキャッチの添付ファイル ID を取得する。
+		// Get the attachment ID of the featured image.
+		$thumbnail_id = get_post_thumbnail_id( get_the_ID() );
+		if ( ! $thumbnail_id ) {
+			return array();
+		}
+
+		// 元画像（フル解像度）の URL・実寸を取得する。戻り値は [0]=url, [1]=width, [2]=height。
+		// Retrieve the URL and the actual dimensions of the original (full-resolution) image. The return value is [0]=url, [1]=width, [2]=height.
+		$image_src = wp_get_attachment_image_src( $thumbnail_id, 'full' );
+
+		// 取得失敗（false）や URL が空の場合は image を出さないために空配列を返す。
+		// Return an empty array so the image is not output when retrieval fails (false) or the URL is empty.
+		if ( ! is_array( $image_src ) || empty( $image_src[0] ) ) {
+			return array();
+		}
+
+		$image = array(
+			'@type' => 'ImageObject',
+			'url'   => $image_src[0],
+		);
+
+		// width / height が取得できた場合のみ追加する。実寸と異なる値は出さない。
+		// Add width / height only when they are available. Never output dimensions that differ from the actual size.
+		if ( ! empty( $image_src[1] ) && ! empty( $image_src[2] ) ) {
+			$image['width']  = $image_src[1];
+			$image['height'] = $image_src[2];
+		}
+
+		return $image;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,8 @@ e.g.
 
 [ Bug Fix ][ Article Structured Data ] Stopped outputting an empty "image" value in the JSON-LD when a post has no featured image, omitting the image field entirely instead.
 
+[ Spec Change ][ Article Structured Data ] Changed the JSON-LD "image" to the ImageObject format (url/width/height) and switched the source to the original full-resolution image.
+
 = 9.117.2 =
 [ Bug Fix ] Fixed a warning in the article structured data output when the author user could not be retrieved.
 

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -333,6 +333,36 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					),
 				),
 			),
+			// 異常系 : アイキャッチ設定済みだが wp_get_attachment_image_src() が false（URL 取得失敗）を返す => image キー自体が出力されない
+			// Abnormal case: featured image is set but wp_get_attachment_image_src() returns false (URL retrieval fails) -> the image key itself is not output.
+			array(
+				'test_condition_name' => 'アイキャッチ設定済みだが画像 URL が取得できない場合 => image キーが出力されない',
+				'post_data'           => array(
+					'post_title'   => 'Post Org No Url',
+					'post_status'  => 'publish',
+					'post_content' => 'Post Test Org No Url',
+					'post_author'  => $test_users['org_02']['user_id'],
+				),
+				// アイキャッチは設定するが、フィルターで wp_get_attachment_image_src() を false に上書きした状態を再現する。
+				// Set a featured image, but reproduce a state where wp_get_attachment_image_src() is forced to false via a filter.
+				'set_thumbnail'       => true,
+				'false_image_src'     => true,
+				// image キーが出力されないことを検証するため、correct には image を含めない。
+				// To verify the image key is not output, correct does not contain image.
+				'correct'             => array(
+					'@context'      => 'https://schema.org/',
+					'@type'         => 'Article',
+					'headline'      => 'Post Org No Url',
+					'datePublished' => 'ここは投稿作成してから上書きする',
+					'dateModified'  => 'ここは投稿作成してから上書きする',
+					'author'        => array(
+						'@type'  => $test_users['org_02']['user_meta']['author_type'],
+						'name'   => $test_users['org_02']['user_meta']['author_name'],
+						'url'    => $test_users['org_02']['user_meta']['author_url'],
+						'sameAs' => $test_users['org_02']['user_meta']['author_sameAs'],
+					),
+				),
+			),
 			// 個別の投稿ページじゃないページで空で返ってきてるか？
 			/**
 			 * get_author_structure_array()はとにかくそのページの著者の配列データ$author_arrayを作る
@@ -366,7 +396,19 @@ class Article_Structure_Test extends WP_UnitTestCase {
 				// 実寸が取得できない状況を再現する（width/height キーが出ないことを検証するため）。
 				// For the strip_image_size case, force the width/height of wp_get_attachment_image_src to 0
 				// to reproduce a situation where the dimensions cannot be retrieved (to verify the width/height keys are omitted).
-				if ( ! empty( $test_value['strip_image_size'] ) ) {
+				if ( ! empty( $test_value['false_image_src'] ) ) {
+					// false_image_src が true のケースでは、wp_get_attachment_image_src を false に潰し、
+					// URL（および実寸）が一切取得できない状況を再現する（image キー自体が出ないことを検証するため）。
+					// For the false_image_src case, force wp_get_attachment_image_src to false
+					// to reproduce a situation where the URL (and dimensions) cannot be retrieved at all (to verify the image key itself is omitted).
+					$filter_callback = function () {
+						return false;
+					};
+					add_filter( 'wp_get_attachment_image_src', $filter_callback );
+
+					// このケースでは correct に image を含めないため、上書きは行わない。
+					// In this case correct does not contain image, so no overwrite is performed.
+				} elseif ( ! empty( $test_value['strip_image_size'] ) ) {
 					$filter_callback = function ( $image ) {
 						if ( is_array( $image ) ) {
 							$image[1] = 0;
@@ -378,7 +420,11 @@ class Article_Structure_Test extends WP_UnitTestCase {
 
 					// 実寸を消したケースの期待値は url のみの ImageObject。
 					// The expected value for the stripped-size case is an ImageObject with url only.
-					$image_full                     = wp_get_attachment_image_src( $attachment_id, 'full' );
+					// この期待値算出には実寸が必要なため、いったんフィルターを外して取得し、再度付け直す。
+					// The expected value needs the real dimensions, so temporarily remove the filter to retrieve them, then add it back.
+					remove_filter( 'wp_get_attachment_image_src', $filter_callback );
+					$image_full = wp_get_attachment_image_src( $attachment_id, 'full' );
+					add_filter( 'wp_get_attachment_image_src', $filter_callback );
 					$test_value['correct']['image'] = array(
 						'@type' => 'ImageObject',
 						'url'   => $image_full[0],

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -260,10 +260,10 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					// ),
 				),
 			),
-			// 正常系 : アイキャッチ設定済み => image が出力される（組織投稿の場合）
-			// Normal case: featured image is set -> image is output (organization post).
+			// 正常系 : アイキャッチ設定済み => image が ImageObject 形式（url/width/height 込み）で出力される（組織投稿の場合）
+			// Normal case: featured image is set -> image is output as an ImageObject (with url/width/height) (organization post).
 			array(
-				'test_condition_name' => 'アイキャッチ設定済みの場合 => image が出力される',
+				'test_condition_name' => 'アイキャッチ設定済みの場合 => image が ImageObject 形式（url/width/height）で出力される',
 				// 'target_url' => get_permalink( $data['post_id_org'] ),
 				'post_data'           => array(
 					'post_title'   => 'Post Org',
@@ -271,13 +271,15 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					'post_content' => 'Post Test Org',
 					'post_author'  => $test_users['org_02']['user_id'],
 				),
-				// アイキャッチを設定するケース。実際の URL はループ内で correct に上書きする。
-				// Case where a featured image is set. The actual URL is overwritten into correct inside the loop.
+				// アイキャッチを設定するケース。実際の URL・実寸はループ内で correct に上書きする。
+				// Case where a featured image is set. The actual URL and dimensions are overwritten into correct inside the loop.
 				'set_thumbnail'       => true,
 				'correct'             => array(
 					'@context'      => 'https://schema.org/',
 					'@type'         => 'Article',
 					'headline'      => 'Post Org',
+					// image はループ内で ImageObject 形式（url/width/height）に上書きする。
+					// image is overwritten into the ImageObject format (url/width/height) inside the loop.
 					'image'         => 'ここはアイキャッチ設定してから上書きする',
 					'datePublished' => 'ここは投稿作成してから上書きする',
 					'dateModified'  => 'ここは投稿作成してから上書きする',
@@ -300,6 +302,37 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					// ),
 				),
 			),
+			// 異常系 : アイキャッチ設定済みだが実寸（width/height）が取得できない => url のみの ImageObject が出力される
+			// Abnormal case: featured image is set but the dimensions (width/height) cannot be retrieved -> an ImageObject with url only is output.
+			array(
+				'test_condition_name' => 'アイキャッチ設定済みだが実寸が取得できない場合 => width/height を含まない ImageObject が出力される',
+				'post_data'           => array(
+					'post_title'   => 'Post Org No Size',
+					'post_status'  => 'publish',
+					'post_content' => 'Post Test Org No Size',
+					'post_author'  => $test_users['org_02']['user_id'],
+				),
+				// アイキャッチは設定するが、フィルターで実寸を消した状態を再現する。
+				// Set a featured image, but reproduce a state where the dimensions are stripped via a filter.
+				'set_thumbnail'       => true,
+				'strip_image_size'    => true,
+				'correct'             => array(
+					'@context'      => 'https://schema.org/',
+					'@type'         => 'Article',
+					'headline'      => 'Post Org No Size',
+					// image はループ内で width/height なしの ImageObject に上書きする。
+					// image is overwritten into an ImageObject without width/height inside the loop.
+					'image'         => 'ここはアイキャッチ設定してから上書きする',
+					'datePublished' => 'ここは投稿作成してから上書きする',
+					'dateModified'  => 'ここは投稿作成してから上書きする',
+					'author'        => array(
+						'@type'  => $test_users['org_02']['user_meta']['author_type'],
+						'name'   => $test_users['org_02']['user_meta']['author_name'],
+						'url'    => $test_users['org_02']['user_meta']['author_url'],
+						'sameAs' => $test_users['org_02']['user_meta']['author_sameAs'],
+					),
+				),
+			),
 			// 個別の投稿ページじゃないページで空で返ってきてるか？
 			/**
 			 * get_author_structure_array()はとにかくそのページの著者の配列データ$author_arrayを作る
@@ -320,14 +353,47 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			$test_value['correct']['dateModified']  = get_the_modified_time( 'c', $target_post_id );
 
 			// set_thumbnail が true のケースではダミー添付ファイルを作成しアイキャッチに設定する。
-			// 実際に出力される image URL を取得し、期待値（correct['image']）へ反映する。
+			// 元画像（フル解像度）の URL・実寸を取得し、ImageObject 形式の期待値（correct['image']）へ反映する。
 			// For cases with set_thumbnail true, create a dummy attachment and set it as the featured image.
-			// Retrieve the actual image URL output and reflect it into the expected value (correct['image']).
+			// Retrieve the URL and the actual dimensions of the original (full-resolution) image and reflect them into the expected ImageObject value (correct['image']).
+			$filter_callback = null;
 			if ( ! empty( $test_value['set_thumbnail'] ) ) {
 				$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg', $target_post_id );
 				set_post_thumbnail( $target_post_id, $attachment_id );
-				$attachment_ids[]               = $attachment_id;
-				$test_value['correct']['image'] = wp_get_attachment_url( $attachment_id );
+				$attachment_ids[] = $attachment_id;
+
+				// strip_image_size が true のケースでは、wp_get_attachment_image_src の width/height を 0 に潰し、
+				// 実寸が取得できない状況を再現する（width/height キーが出ないことを検証するため）。
+				// For the strip_image_size case, force the width/height of wp_get_attachment_image_src to 0
+				// to reproduce a situation where the dimensions cannot be retrieved (to verify the width/height keys are omitted).
+				if ( ! empty( $test_value['strip_image_size'] ) ) {
+					$filter_callback = function ( $image ) {
+						if ( is_array( $image ) ) {
+							$image[1] = 0;
+							$image[2] = 0;
+						}
+						return $image;
+					};
+					add_filter( 'wp_get_attachment_image_src', $filter_callback );
+
+					// 実寸を消したケースの期待値は url のみの ImageObject。
+					// The expected value for the stripped-size case is an ImageObject with url only.
+					$image_full                     = wp_get_attachment_image_src( $attachment_id, 'full' );
+					$test_value['correct']['image'] = array(
+						'@type' => 'ImageObject',
+						'url'   => $image_full[0],
+					);
+				} else {
+					// 通常ケースの期待値は元画像（フル解像度）の url/width/height 込み ImageObject。
+					// The expected value for the normal case is an ImageObject with url/width/height of the original (full-resolution) image.
+					$image_full                     = wp_get_attachment_image_src( $attachment_id, 'full' );
+					$test_value['correct']['image'] = array(
+						'@type'  => 'ImageObject',
+						'url'    => $image_full[0],
+						'width'  => $image_full[1],
+						'height' => $image_full[2],
+					);
+				}
 			}
 
 			// Move to test page
@@ -341,6 +407,12 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			// print 'return  ::::' . $return['author'] . PHP_EOL;
 
 			$this->assertEquals( $correct, $return, $test_value['test_condition_name'] );
+
+			// このケースで追加したフィルターを後始末する（後続ケースへ影響させない）。
+			// Clean up the filter added in this case so it does not affect subsequent cases.
+			if ( null !== $filter_callback ) {
+				remove_filter( 'wp_get_attachment_image_src', $filter_callback );
+			}
 
 			// テスト投稿削除
 			wp_delete_post( $target_post_id );


### PR DESCRIPTION
## 概要

記事ページの構造化データ（JSON-LD / schema.org Article）の `image` を、これまでの URL 文字列ではなく Google 推奨の `ImageObject` 形式（`@type` / `url` / `width` / `height`）で出力するよう変更します。

`get_post_thumbnail_id()` → `wp_get_attachment_image_src( $id, 'full' )` で元画像（フル解像度）の URL と実寸を取得します。実寸をハードコードせず動的取得することで、リッチリザルトテストでの寸法不整合を防ぎます。

Close #1389

## 変更内容

- アイキャッチがある場合、`image` を `ImageObject` 形式で出力（`@type` / `url` / `width` / `height`）
- 画像 URL のソースを、テーマ依存の縮小サイズから **元画像（`full`）の実寸 URL** に変更
- `width` / `height` が取得できない場合は、実寸と異なる値を出さないため当該キーを省略
- URL が取得できない／アイキャッチ未設定の場合は `image` キーごと省略（#1390 の挙動を踏襲）
- サイトロゴ等のフォールバックは実装しない（Article の `image` は「記事を表す画像」が要件のため。`publisher.logo` は別 issue で検討）
- テスタビリティのため画像配列生成を `get_article_image_object()` に切り出し

## 確認手順

### 前提条件
- VK All in One Expansion Unit を有効化し、構造化データ（Article）の出力が有効な状態
- アイキャッチ画像を設定した投稿を1件以上用意（幅・高さがわかる画像）

### After（確認手順）

#### 1. アイキャッチありの記事
1. アイキャッチを設定した投稿の公開ページを開く
2. ページのソースを表示し、`<!-- [ VK All in One Expansion Unit Article Structure Data ] -->` 直後の `<script type="application/ld+json">` を確認する
   → ✓ `image` が以下のように `ImageObject` 形式で出力される
   ```json
   "image": {
     "@type": "ImageObject",
     "url": "https://.../wp-content/uploads/.../xxxx.jpg",
     "width": 1200,
     "height": 630
   }
   ```
   → ✓ `url` が元画像（フルサイズ）を指し、`width` / `height` がその画像の実寸と一致する
3. [リッチリザルトテスト](https://search.google.com/test/rich-results) に当該 URL を通す
   → ✓ image 周りで寸法不整合などの指摘が出ない

#### 2. アイキャッチなしの記事（デグレ確認）
1. アイキャッチを設定していない投稿の公開ページを開く
2. 同様に JSON-LD を確認する
   → ✓ `image` キー自体が出力されない（#1390 の挙動が維持されている）

## テスト

PHPUnit（`tests/test-article-structure.php`）に以下3パターンを追加し、green を確認済み:
- (a) アイキャッチあり → `url` / `width` / `height` を含む `ImageObject` が出力される
- (b) 実寸取得失敗（`wp_get_attachment_image_src` をフィルタで width/height = 0 に上書き）→ `url` のみの `ImageObject`
- (c) アイキャッチなし → `image` キーが出力されない

実行結果: `OK (2 tests, 10 assertions)`

## レビュー
- セキュリティレビュー（安藤）: PASS（JSON-LD 出力経路は従来どおり `wp_kses( json_encode(...), array() )` を経由。新たなエスケープ欠落なし）

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON-LD構造化データの image が ImageObject（url/width/height）形式に対応しました。

* **Bug Fixes**
  * アイキャッチ取得失敗時は image キー自体を構造化データから除外するようにしました。
  * 実寸情報が取得できない場合は幅/高さを含めない振る舞いに変更しました。

* **Tests**
  * 構造化データ周りのテストを更新・拡張し、新しい期待値と異常系を追加しました。

* **Documentation**
  * readme の変更履歴に ImageObject 化の記載を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->