### PR TITLE
[ 不具合修正 ][ ウィジェット ] PHP 8.x 環境でウィジェット保存時にエラーログへ PHP 警告が記録される不具合を修正

### DIFF
--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -535,7 +535,8 @@ class WP_Widget_VkExUnit_Contact_Section extends WP_Widget {
 	}
 
 	function update( $new_instance, $old_instance ) {
-		$instance['vertical'] = $new_instance['vertical'];
+		// Checkboxes are omitted from POST data when unchecked, so guard with isset() to avoid PHP 8.x undefined array key warning.
+		$instance['vertical'] = isset( $new_instance['vertical'] ) ? $new_instance['vertical'] : '';
 		return $instance;
 	}
 

--- a/inc/other-widget/widget-button.php
+++ b/inc/other-widget/widget-button.php
@@ -200,7 +200,8 @@ class WP_Widget_Button extends WP_Widget {
 		<select id="<?php echo $this->get_field_id( 'color' ); ?>" name="<?php echo $this->get_field_name( 'color' ); ?>">
 		<?php
 		if ( ! isset( $instance['color'] ) || ! $instance['color'] ) {
-			$instance['color'] = $default['color'];
+			// Use the value defined in defaults() to avoid referencing the undefined variable $default.
+			$instance['color'] = self::defaults()['color'];
 		}
 		foreach ( static::button_otherlabels() as $key => $label ) :
 			?>
@@ -228,7 +229,8 @@ class WP_Widget_Button extends WP_Widget {
 		$opt['linkurl']     = esc_url( $new_instance['linkurl'] );
 		$opt['blank']       = ( isset( $new_instance['blank'] ) && $new_instance['blank'] == 'true' );
 		$opt['size']        = in_array( $new_instance['size'], array( 'sm', 'lg' ) ) ? $new_instance['size'] : 'md';
-		$opt['color']       = in_array( $new_instance['color'], array_keys( self::button_otherlabels() ) ) ? $new_instance['color'] : static::$button_default;
+		// static::$button_default was never declared as a class property; fall back to the value defined in defaults() to avoid a potential fatal error.
+		$opt['color'] = in_array( $new_instance['color'], array_keys( self::button_otherlabels() ) ) ? $new_instance['color'] : self::defaults()['color'];
 		return $opt;
 	}
 

--- a/inc/other-widget/widget-button.php
+++ b/inc/other-widget/widget-button.php
@@ -228,9 +228,12 @@ class WP_Widget_Button extends WP_Widget {
 		$opt['subtext']     = wp_kses_post( stripslashes( $new_instance['subtext'] ) );
 		$opt['linkurl']     = esc_url( $new_instance['linkurl'] );
 		$opt['blank']       = ( isset( $new_instance['blank'] ) && $new_instance['blank'] == 'true' );
-		$opt['size']        = in_array( $new_instance['size'], array( 'sm', 'lg' ) ) ? $new_instance['size'] : 'md';
-		// static::$button_default was never declared as a class property; fall back to the value defined in defaults() to avoid a potential fatal error.
-		$opt['color'] = in_array( $new_instance['color'], array_keys( self::button_otherlabels() ) ) ? $new_instance['color'] : self::defaults()['color'];
+		// Guard against missing key: select elements are absent from $_POST when the widget block is saved without interacting with the field.
+		$size        = isset( $new_instance['size'] ) ? $new_instance['size'] : '';
+		$opt['size'] = in_array( $size, array( 'sm', 'lg' ) ) ? $size : 'md';
+		// Guard against missing key and fall back via defaults() to avoid PHP 8.x "Undefined array key" warning.
+		$color        = isset( $new_instance['color'] ) ? $new_instance['color'] : '';
+		$opt['color'] = in_array( $color, array_keys( self::button_otherlabels() ) ) ? $color : self::defaults()['color'];
 		return $opt;
 	}
 

--- a/inc/other-widget/widget-page.php
+++ b/inc/other-widget/widget-page.php
@@ -188,12 +188,13 @@ class WP_Widget_vkExUnit_widget_page extends WP_Widget {
 
 	// 保存・更新する値
 	function update( $new_instance, $old_instance ) {
-		$instance                       = $old_instance;
-		$instance['title']              = wp_kses_post( stripslashes( $new_instance['title'] ) );
-		$instance['page_id']            = $new_instance['page_id'];
-		$instance['set_title']          = $new_instance['set_title'];
-		$instance['child_page_index']   = $new_instance['child_page_index'];
-		$instance['page_list_ancestor'] = $new_instance['page_list_ancestor'];
+		$instance              = $old_instance;
+		$instance['title']     = wp_kses_post( stripslashes( $new_instance['title'] ) );
+		$instance['page_id']   = $new_instance['page_id'];
+		$instance['set_title'] = $new_instance['set_title'];
+		// Checkboxes are omitted from POST data when unchecked, so guard with isset() to avoid PHP 8.x undefined array key warning.
+		$instance['child_page_index']   = isset( $new_instance['child_page_index'] ) ? $new_instance['child_page_index'] : '';
+		$instance['page_list_ancestor'] = isset( $new_instance['page_list_ancestor'] ) ? $new_instance['page_list_ancestor'] : '';
 		return $instance;
 	}
 

--- a/inc/sns/widget-fb-page-plugin.php
+++ b/inc/sns/widget-fb-page-plugin.php
@@ -54,10 +54,14 @@ class WP_Widget_vkExUnit_fbPagePlugin extends WP_Widget {
 		$instance['label']    = wp_kses_post( stripslashes( $new_instance['label'] ) );
 		$instance['page_url'] = esc_url( $new_instance['page_url'] );
 		$instance['height']   = esc_html( $new_instance['height'] );
-		// Checkboxes are omitted from POST data when unchecked, so guard with isset() to avoid PHP 8.x undefined array key warning.
-		$instance['showFaces'] = isset( $new_instance['showFaces'] ) ? $new_instance['showFaces'] : 'false';
-		$instance['hideCover'] = isset( $new_instance['hideCover'] ) ? $new_instance['hideCover'] : 'false';
-		$instance['showPosts'] = isset( $new_instance['showPosts'] ) ? $new_instance['showPosts'] : 'false';
+		// Checkboxes are omitted from POST data when unchecked, so guard with isset() to avoid the
+		// PHP 8.x undefined array key warning. Fall back to '' (an empty, falsy value) so that widget()
+		// reproduces the previous behavior: it treats this the same as the old unguarded null value and
+		// applies its own default (showPosts => 'true'). Using 'false' here would be truthy and would
+		// silently change the saved value for existing users.
+		$instance['showFaces'] = isset( $new_instance['showFaces'] ) ? $new_instance['showFaces'] : '';
+		$instance['hideCover'] = isset( $new_instance['hideCover'] ) ? $new_instance['hideCover'] : '';
+		$instance['showPosts'] = isset( $new_instance['showPosts'] ) ? $new_instance['showPosts'] : '';
 
 		return $instance;
 	}

--- a/inc/sns/widget-fb-page-plugin.php
+++ b/inc/sns/widget-fb-page-plugin.php
@@ -50,13 +50,14 @@ class WP_Widget_vkExUnit_fbPagePlugin extends WP_Widget {
 
 
 	function update( $new_instance, $old_instance ) {
-		$instance              = $old_instance;
-		$instance['label']     = wp_kses_post( stripslashes( $new_instance['label'] ) );
-		$instance['page_url']  = esc_url( $new_instance['page_url'] );
-		$instance['height']    = esc_html( $new_instance['height'] );
-		$instance['showFaces'] = $new_instance['showFaces'];
-		$instance['hideCover'] = $new_instance['hideCover'];
-		$instance['showPosts'] = $new_instance['showPosts'];
+		$instance             = $old_instance;
+		$instance['label']    = wp_kses_post( stripslashes( $new_instance['label'] ) );
+		$instance['page_url'] = esc_url( $new_instance['page_url'] );
+		$instance['height']   = esc_html( $new_instance['height'] );
+		// Checkboxes are omitted from POST data when unchecked, so guard with isset() to avoid PHP 8.x undefined array key warning.
+		$instance['showFaces'] = isset( $new_instance['showFaces'] ) ? $new_instance['showFaces'] : 'false';
+		$instance['hideCover'] = isset( $new_instance['hideCover'] ) ? $new_instance['hideCover'] : 'false';
+		$instance['showPosts'] = isset( $new_instance['showPosts'] ) ? $new_instance['showPosts'] : 'false';
 
 		return $instance;
 	}

--- a/inc/sns/widget-twitter.php
+++ b/inc/sns/widget-twitter.php
@@ -153,8 +153,9 @@ class VK_Twitter_Widget extends WP_Widget {
 		$instance['title']   = wp_kses_post( $new_instance['title'] );
 		$instance['account'] = wp_kses_post( $new_instance['account'] );
 		$instance['height']  = wp_kses_post( mb_convert_kana( $new_instance['height'], 'a' ) );
-		// static::$button_default was never declared as a class property; fall back to 'light' (the first key of time_line_color()) to avoid a potential fatal error.
-		$instance['bg_color']   = in_array( $new_instance['bg_color'], array_keys( self::time_line_color() ) ) ? $new_instance['bg_color'] : 'light';
+		// Guard against missing key and fall back to 'light' to avoid PHP 8.x "Undefined array key" warning.
+		$bg_color               = isset( $new_instance['bg_color'] ) ? $new_instance['bg_color'] : '';
+		$instance['bg_color']   = in_array( $bg_color, array_keys( self::time_line_color() ) ) ? $bg_color : 'light';
 		$instance['link_color'] = ( isset( $new_instance['link_color'] ) ) ? sanitize_hex_color( $new_instance['link_color'] ) : false;
 		return $instance;
 	}

--- a/inc/sns/widget-twitter.php
+++ b/inc/sns/widget-twitter.php
@@ -109,7 +109,8 @@ class VK_Twitter_Widget extends WP_Widget {
 	<select id="<?php echo $this->get_field_id( 'bg_color' ); ?>" name="<?php echo $this->get_field_name( 'bg_color' ); ?>" class="admin-custom-input">
 		<?php
 		if ( ! isset( $instance['bg_color'] ) || ! $instance['bg_color'] ) {
-			$instance['bg_color'] = $default['bg_color'];
+			// $default is undefined here; use the hard-coded default to avoid PHP 8.x undefined variable warning.
+			$instance['bg_color'] = 'light';
 		}
 		foreach ( static::time_line_color() as $key => $label ) :
 			?>
@@ -148,11 +149,12 @@ class VK_Twitter_Widget extends WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 		// ウィジェットオプションの保存処理
-		$instance               = $old_instance;
-		$instance['title']      = wp_kses_post( $new_instance['title'] );
-		$instance['account']    = wp_kses_post( $new_instance['account'] );
-		$instance['height']     = wp_kses_post( mb_convert_kana( $new_instance['height'], 'a' ) );
-		$instance['bg_color']   = in_array( $new_instance['bg_color'], array_keys( self::time_line_color() ) ) ? $new_instance['bg_color'] : static::$button_default;
+		$instance            = $old_instance;
+		$instance['title']   = wp_kses_post( $new_instance['title'] );
+		$instance['account'] = wp_kses_post( $new_instance['account'] );
+		$instance['height']  = wp_kses_post( mb_convert_kana( $new_instance['height'], 'a' ) );
+		// static::$button_default was never declared as a class property; fall back to 'light' (the first key of time_line_color()) to avoid a potential fatal error.
+		$instance['bg_color']   = in_array( $new_instance['bg_color'], array_keys( self::time_line_color() ) ) ? $new_instance['bg_color'] : 'light';
 		$instance['link_color'] = ( isset( $new_instance['link_color'] ) ) ? sanitize_hex_color( $new_instance['link_color'] ) : false;
 		return $instance;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,8 @@ e.g.
 
 [ Spec Change ][ Article Structured Data ] Changed the JSON-LD "image" to the ImageObject format (url/width/height) and switched the source to the original full-resolution image.
 
+[ Bug Fix ][ Widget ] Fixed PHP 8.x undefined array key and undefined variable warnings that were written to the error log when saving widgets with unchecked checkboxes (Contact Section, Page, FB Page Plugin) or an invalid colour selection (Button, Twitter).
+
 = 9.117.2 =
 [ Bug Fix ] Fixed a warning in the article structured data output when the author user could not be retrieved.
 


### PR DESCRIPTION
## 関連Issue
- 関連Issue: #1395

## 変更の目的・理由

PHP 8.x 環境で、いくつかのウィジェットを保存・表示する際に、サーバーのエラーログ（`debug.log`）へ PHP の警告（Undefined array key / Undefined variable）が記録されてしまう不具合がありました。サイトの表示自体は動作しますが、警告でログが埋まることで本当に重要なエラーが埋もれてしまいます。デバッグ表示が有効な環境では、画面に英語の警告文がそのまま表示される場合もあります。

PHP 8.x で「未定義の変数・配列キーの参照」が警告（一部は致命的エラー）になる仕様に対し、古い書き方（`isset()` ガードや変数初期化の欠落）が残っていたのが原因です。

## 実装内容

各ウィジェットの保存（`update()`）・表示（`form()`）処理で、未定義になり得るキー・変数を参照する前にガードを追加しました。**いずれも従来の挙動（保存値・表示）は変えていません。**

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

### 技術的な詳細

| ファイル | 内容 |
|---|---|
| `inc/contact-section/contact-section.php` | お問い合わせセクション。`vertical`（縦並びチェックボックス）が未チェックだと POST に含まれないため、`isset()` でガードして未定義キー警告を解消 |
| `inc/other-widget/widget-page.php` | 固定ページウィジェット。`child_page_index` / `page_list_ancestor`（チェックボックス）を `isset()` でガード |
| `inc/sns/widget-fb-page-plugin.php` | Facebook ページプラグインウィジェット。`showFaces` / `hideCover` / `showPosts`（チェックボックス）を `isset()` でガード |
| `inc/other-widget/widget-button.php` | ボタンウィジェット。未定義変数 `$default['color']` の参照と、クラスに未宣言のまま参照されていた `static::$button_default` を、本来の既定値（`self::defaults()['color']` = `'primary'`）に置き換え |
| `inc/sns/widget-twitter.php` | Twitter タイムラインウィジェット。未定義変数 `$default['bg_color']` の参照と、未宣言の `static::$button_default` を、本来の既定値（`'light'`）に置き換え |

`static::$button_default` はクラスに宣言されていないプロパティで、想定外の保存値が来たときに PHP 8.x では致命的エラー（保存失敗）になり得る潜在的な不具合でした。本来意図されていた既定値リテラルに置き換えることで解消しています。

#### スコープ外（別issue想定）
- `vk_sanitize_array()` の同種警告（`Undefined variable $return`）は、複数の vektor プラグインで共有しているライブラリ（template-tags）由来のため本PRには含めていません。
- レビュー中に見つかった既存コードの軽微な改善余地（Twitter ウィジェットの `data-height` 属性のエスケープ強化など）も、本PRのスコープ（PHP 8.x 警告対応）とは別のため含めていません。

## スクリーンショット

本PRは内部処理（防御的コーディング）の修正で、画面の表示・UI に変化はないため、見た目のスクリーンショットは省略します。検証の証跡は下記「テスト手順」の `debug.log` の Before / After を確認してください。

### Before（変更前）
保存時に `debug.log` へ警告が記録される（下記テスト手順参照）。

### After（変更後）
同じ操作で警告が記録されない（下記テスト手順参照）。

## 実装者チェックリスト

### コード品質
- [ ] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [ ] 不要なコード整形やフォーマット変更を含んでいない
- [ ] ワークフローファイルの変更を含んでいない（別PRで対応）
- [ ] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [ ] `readme.txt`に変更内容を記載
- [ ] エンドユーザーが理解できる内容で記載

### テスト
- [ ] 書けるテストは実装済み
- [ ] 既存のテストが通ることを確認
- [ ] 手動テストを実施済み

### 最終確認
- [ ] このテンプレートの全項目を確認済み
- [ ] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順

#### 前提条件
- PHP 8.0 以上の環境
- `wp-config.php` で `define( 'WP_DEBUG', true );` と `define( 'WP_DEBUG_LOG', true );` を有効化（`wp-content/debug.log` に出力される）

#### Before（修正前の再現）
1. 管理画面 > 外観 > ウィジェット を開く（ブロックベースのウィジェット画面の場合は「レガシーウィジェット」として追加）
2. 「[VK] お問い合わせセクション」ウィジェットをウィジェットエリアに追加する
3. 「縦に並べる」系のチェックボックスを **OFF のまま** 保存する
   → ✗ `wp-content/debug.log` に `PHP Warning: Undefined array key "vertical" in .../inc/contact-section/contact-section.php on line 538` が記録される
4. 同様に、固定ページウィジェット / Facebook ページプラグインウィジェットのチェックボックスを OFF で保存、ボタン / Twitter ウィジェットを色の既定状態で保存すると、それぞれ同種の「Undefined array key / Undefined variable」警告が記録される

#### After（修正後）
1. Before と同じ手順でそれぞれのウィジェットを保存する
   → ✓ `debug.log` に上記の警告が記録されない
2. 各ウィジェットの設定値・公開側の表示が修正前と変わらないことを確認する
   → ✓ 既存の動作に影響がない（デグレしていない）

### レビューポイント（任意）
- 追加した `isset()` ガード・既定値のフォールバックが、修正前の挙動（チェックボックス未選択時の保存値・表示）と同一であること
- `static::$button_default` の置き換え先（`'primary'` / `'light'`）が、各ウィジェットの既定値と一致していること

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- ウィジェット設定の保存時に、未チェックのチェックボックスや色などの未指定項目によって PHP 8.x の「未定義の配列キー」警告が発生する不具合を修正しました。未入力時は適切な既定値へフォールバックします。

## Documentation
- Changelog に、PHP 8.x での警告回避の対応内容を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->