### PR TITLE
[ 不具合修正 ][ ウィジェット ] PHP 8.x 環境でプロフィール／PR Blocks ウィジェット保存時にエラーログへ PHP 警告が記録される不具合を修正

### DIFF
--- a/inc/other-widget/widget-pr-blocks.php
+++ b/inc/other-widget/widget-pr-blocks.php
@@ -209,15 +209,23 @@ class WP_Widget_vkExUnit_PR_Blocks extends WP_Widget {
 			$instance['block_count'] = $new_instance['block_count'];
 		}
 
+		// The loop always covers blocks 1-4, but when block_count is less than 4 the keys for the extra
+		// blocks are not present in $new_instance. Guard with `?? ''` so a missing key falls back to an
+		// empty string instead of passing null to string functions (PHP 8.x warnings). The output is bound
+		// to block_count, so the upper bound stays at 4 to keep the existing data-retention behavior.
+		// ループは常にブロック1〜4を処理するが、block_count が4未満のとき余分なブロックのキーは
+		// $new_instance に存在しない。`?? ''` でガードし、欠落キーは null ではなく空文字へフォールバックさせる
+		// （null を文字列関数へ渡すことによる PHP 8.x の警告を防ぐ）。出力は block_count に束縛されるため、
+		// 既存のデータ保持挙動を維持する目的で上限は4のままにしている。
 		for ( $i = 1; $i <= 4; ) {
-			$instance[ 'label_' . $i ]            = wp_kses_post( stripslashes( $new_instance[ 'label_' . $i ] ) );
-			$instance[ 'media_image_' . $i ]      = esc_url( $new_instance[ 'media_image_' . $i ] );
-			$instance[ 'media_alt_' . $i ]        = esc_html( stripslashes( $new_instance[ 'media_alt_' . $i ] ) );
-			$instance[ 'iconFont_class_' . $i ]   = wp_kses_post( stripslashes( $new_instance[ 'iconFont_class_' . $i ] ) );
-			$instance[ 'iconFont_bgColor_' . $i ] = esc_html( $new_instance[ 'iconFont_bgColor_' . $i ] );
-			$instance[ 'iconFont_bgType_' . $i ]  = $new_instance[ 'iconFont_bgType_' . $i ];
-			$instance[ 'summary_' . $i ]          = wp_kses_post( stripslashes( $new_instance[ 'summary_' . $i ] ) );
-			$instance[ 'linkurl_' . $i ]          = esc_url( $new_instance[ 'linkurl_' . $i ] );
+			$instance[ 'label_' . $i ]            = wp_kses_post( stripslashes( $new_instance[ 'label_' . $i ] ?? '' ) );
+			$instance[ 'media_image_' . $i ]      = esc_url( $new_instance[ 'media_image_' . $i ] ?? '' );
+			$instance[ 'media_alt_' . $i ]        = esc_html( stripslashes( $new_instance[ 'media_alt_' . $i ] ?? '' ) );
+			$instance[ 'iconFont_class_' . $i ]   = wp_kses_post( stripslashes( $new_instance[ 'iconFont_class_' . $i ] ?? '' ) );
+			$instance[ 'iconFont_bgColor_' . $i ] = esc_html( $new_instance[ 'iconFont_bgColor_' . $i ] ?? '' );
+			$instance[ 'iconFont_bgType_' . $i ]  = $new_instance[ 'iconFont_bgType_' . $i ] ?? '';
+			$instance[ 'summary_' . $i ]          = wp_kses_post( stripslashes( $new_instance[ 'summary_' . $i ] ?? '' ) );
+			$instance[ 'linkurl_' . $i ]          = esc_url( $new_instance[ 'linkurl_' . $i ] ?? '' );
 			$instance[ 'blank_' . $i ]            = ( isset( $new_instance[ 'blank_' . $i ] ) && $new_instance[ 'blank_' . $i ] == 'true' );
 			++$i;
 		}

--- a/inc/other-widget/widget-profile.php
+++ b/inc/other-widget/widget-profile.php
@@ -184,16 +184,21 @@ class WP_Widget_vkExUnit_profile extends WP_Widget {
 		update
 	/*-------------------------------------------*/
 	function update( $new_instance, $old_instance ) {
+		// Notes on $new_instance keys that may be missing on PHP 8.x (avoids undefined array key warnings):
+		// - mediaAlign_left: deprecated key with no form field, so it is never present and is intentionally not read here; its value is carried over from $old_instance.
+		// - mediaRound / mediaFloat: checkbox fields that are not sent when unchecked, so they are guarded and fall back to an empty string (stays falsy, behavior unchanged).
+		// $new_instance のキーに関する補足（PHP 8.x の未定義キー警告対策）:
+		// - mediaAlign_left: 対応するフォーム項目が無い廃止済みキーのため常に存在せず、ここでは意図的に読み込まない。値は $old_instance から引き継がれる。
+		// - mediaRound / mediaFloat: 未チェック時に送信されないチェックボックスのため、未定義キーをガードして空文字へフォールバックさせる（falsy のままで挙動は不変）。
 		$instance                    = $old_instance;
 		$instance['label']           = wp_kses_post( stripslashes( $new_instance['label'] ) );
 		$instance['mediaFile']       = esc_url( $new_instance['mediaFile'] );
 		$instance['mediaAlt']        = esc_html( stripslashes( $new_instance['mediaAlt'] ) );
 		$instance['profile']         = wp_kses_post( stripslashes( $new_instance['profile'] ) );
-		$instance['mediaAlign_left'] = $new_instance['mediaAlign_left'];
 		$instance['mediaAlign']      = $new_instance['mediaAlign'];
-		$instance['mediaRound']      = $new_instance['mediaRound'];
+		$instance['mediaRound']      = isset( $new_instance['mediaRound'] ) ? $new_instance['mediaRound'] : '';
 		$instance['mediaSize']       = esc_html( $new_instance['mediaSize'] );
-		$instance['mediaFloat']      = $new_instance['mediaFloat'];
+		$instance['mediaFloat']      = isset( $new_instance['mediaFloat'] ) ? $new_instance['mediaFloat'] : '';
 		$instance['facebook']        = esc_url( $new_instance['facebook'] );
 		$instance['twitter']         = esc_url( $new_instance['twitter'] );
 		$instance['mail']            = esc_url( $new_instance['mail'] );

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Widget ] Fixed PHP 8.x warnings that were written to the error log when saving the Profile widget or the PR Blocks widget with certain settings.
+
 = 9.117.3 =
 [ Bug Fix ][ Setting Page ] Updated the shared admin component so that the setting screen styles and scripts are reloaded reliably after an update instead of being served from the cache, and so that the left side navigation is no longer cut off while a notice is displayed.
 

--- a/tests/test-widget-pr-blocks.php
+++ b/tests/test-widget-pr-blocks.php
@@ -23,38 +23,57 @@ class WidgetPrBlocksTest extends WP_UnitTestCase {
 	function test_update_guards_missing_block_keys() {
 		$widget = new WP_Widget_vkExUnit_PR_Blocks();
 
-		// block_count = 3 で、ブロック1〜3のキーのみを送信する（ブロック4は未送信）。
-		$new_instance = array(
-			'block_count' => '3',
+		// ブロックごとの文字列フィールド（未送信時に空文字へフォールバックすべきキー）。
+		$string_fields = array(
+			'label_',
+			'media_image_',
+			'media_alt_',
+			'iconFont_class_',
+			'iconFont_bgColor_',
+			'iconFont_bgType_',
+			'summary_',
+			'linkurl_',
 		);
-		for ( $i = 1; $i <= 3; $i++ ) {
-			$new_instance[ 'label_' . $i ]            = 'Label ' . $i;
-			$new_instance[ 'media_image_' . $i ]      = '';
-			$new_instance[ 'media_alt_' . $i ]        = '';
-			$new_instance[ 'iconFont_class_' . $i ]   = 'far fa-file-alt';
-			$new_instance[ 'iconFont_bgColor_' . $i ] = '#337ab7';
-			$new_instance[ 'iconFont_bgType_' . $i ]  = '';
-			$new_instance[ 'summary_' . $i ]          = '';
-			$new_instance[ 'linkurl_' . $i ]          = '';
-			// blank_$i（チェックボックス）は未チェック想定で未送信。
+
+		// テスト条件と期待する結果の組み合わせ。block_count を変えた検証を追加しやすいよう配列で持つ。
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'block_count=3 のとき未送信のブロック4がガードされる',
+				'block_count'         => 3, // フォームに入力欄がある（＝送信される）ブロック数。
+				'missing_block'       => 4, // 入力欄が無く $new_instance にキーが存在しないブロック番号。
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			// 送信されるブロック（1〜block_count）のキーのみを詰める（それ以外は未送信）。
+			$new_instance = array(
+				'block_count' => (string) $case['block_count'],
+			);
+			for ( $i = 1; $i <= $case['block_count']; $i++ ) {
+				$new_instance[ 'label_' . $i ]            = 'Label ' . $i;
+				$new_instance[ 'media_image_' . $i ]      = '';
+				$new_instance[ 'media_alt_' . $i ]        = '';
+				$new_instance[ 'iconFont_class_' . $i ]   = 'far fa-file-alt';
+				$new_instance[ 'iconFont_bgColor_' . $i ] = '#337ab7';
+				$new_instance[ 'iconFont_bgType_' . $i ]  = '';
+				$new_instance[ 'summary_' . $i ]          = '';
+				$new_instance[ 'linkurl_' . $i ]          = '';
+				// blank_$i（チェックボックス）は未チェック想定で未送信。
+			}
+
+			$result = $widget->update( $new_instance, array() );
+
+			// 送信されたブロック1の値はそのまま保持されること（挙動が変わっていないことの確認）。
+			$this->assertSame( 'Label 1', $result['label_1'], $case['test_condition_name'] );
+
+			// 未送信ブロックの文字列フィールドは null ではなく空文字へフォールバックしていること。
+			$missing = $case['missing_block'];
+			foreach ( $string_fields as $field ) {
+				$this->assertSame( '', $result[ $field . $missing ], $case['test_condition_name'] . ' / ' . $field . $missing );
+			}
+
+			// 未送信のチェックボックスは空文字ではなく false へフォールバックすること。
+			$this->assertFalse( $result[ 'blank_' . $missing ], $case['test_condition_name'] . ' / blank_' . $missing );
 		}
-
-		$result = $widget->update( $new_instance, array() );
-
-		// 送信されたブロック1の値はそのまま保持されること（挙動が変わっていないことの確認）。
-		$this->assertSame( 'Label 1', $result['label_1'] );
-
-		// 未送信のブロック4は null ではなく空文字へフォールバックしていること。
-		$this->assertSame( '', $result['label_4'] );
-		$this->assertSame( '', $result['media_image_4'] );
-		$this->assertSame( '', $result['media_alt_4'] );
-		$this->assertSame( '', $result['iconFont_class_4'] );
-		$this->assertSame( '', $result['iconFont_bgColor_4'] );
-		$this->assertSame( '', $result['iconFont_bgType_4'] );
-		$this->assertSame( '', $result['summary_4'] );
-		$this->assertSame( '', $result['linkurl_4'] );
-
-		// 未送信のチェックボックスは false になっていること。
-		$this->assertFalse( $result['blank_4'] );
 	}
 }

--- a/tests/test-widget-pr-blocks.php
+++ b/tests/test-widget-pr-blocks.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class WidgetPrBlocksTest
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * PR Blocks ウィジェットの update() のテスト。
+ */
+class WidgetPrBlocksTest extends WP_UnitTestCase {
+
+	/**
+	 * block_count が4未満のとき、存在しないブロックのキーを update() がガードすることのテスト。
+	 *
+	 * update() のループは常にブロック1〜4を処理するが、block_count が3以下のとき
+	 * フォームにブロック4の入力欄が無く、$new_instance にブロック4のキーは存在しない。
+	 * その状態でも PHP 8.x の警告（未定義キー / null を文字列関数へ渡す）が出ず、
+	 * 値が空文字へフォールバックすることを検証する。
+	 *
+	 * @return void
+	 */
+	function test_update_guards_missing_block_keys() {
+		$widget = new WP_Widget_vkExUnit_PR_Blocks();
+
+		// block_count = 3 で、ブロック1〜3のキーのみを送信する（ブロック4は未送信）。
+		$new_instance = array(
+			'block_count' => '3',
+		);
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$new_instance[ 'label_' . $i ]            = 'Label ' . $i;
+			$new_instance[ 'media_image_' . $i ]      = '';
+			$new_instance[ 'media_alt_' . $i ]        = '';
+			$new_instance[ 'iconFont_class_' . $i ]   = 'far fa-file-alt';
+			$new_instance[ 'iconFont_bgColor_' . $i ] = '#337ab7';
+			$new_instance[ 'iconFont_bgType_' . $i ]  = '';
+			$new_instance[ 'summary_' . $i ]          = '';
+			$new_instance[ 'linkurl_' . $i ]          = '';
+			// blank_$i（チェックボックス）は未チェック想定で未送信。
+		}
+
+		$result = $widget->update( $new_instance, array() );
+
+		// 送信されたブロック1の値はそのまま保持されること（挙動が変わっていないことの確認）。
+		$this->assertSame( 'Label 1', $result['label_1'] );
+
+		// 未送信のブロック4は null ではなく空文字へフォールバックしていること。
+		$this->assertSame( '', $result['label_4'] );
+		$this->assertSame( '', $result['media_image_4'] );
+		$this->assertSame( '', $result['media_alt_4'] );
+		$this->assertSame( '', $result['iconFont_class_4'] );
+		$this->assertSame( '', $result['iconFont_bgColor_4'] );
+		$this->assertSame( '', $result['iconFont_bgType_4'] );
+		$this->assertSame( '', $result['summary_4'] );
+		$this->assertSame( '', $result['linkurl_4'] );
+
+		// 未送信のチェックボックスは false になっていること。
+		$this->assertFalse( $result['blank_4'] );
+	}
+}

--- a/tests/test-widget-profile.php
+++ b/tests/test-widget-profile.php
@@ -177,4 +177,94 @@ class WidgetProfileTest extends WP_UnitTestCase {
 
 		} // foreach ( $test_array as $key => $test_value) {
 	} // function test_icon_color() {
+
+	/**
+	 * update() がチェックボックス未送信のキーをガードすることのテスト。
+	 *
+	 * チェックボックス（mediaRound / mediaFloat）は未チェックだと送信されず
+	 * $new_instance にキーが存在しない。その状態でも PHP 8.x の警告が出ず、
+	 * 値が空文字（falsy）へフォールバックすることを検証する。
+	 *
+	 * @return void
+	 */
+	function test_update_guards_missing_checkbox_keys() {
+		$widget = new WP_Widget_vkExUnit_profile();
+
+		// チェックボックス系（mediaRound / mediaFloat）と廃止済みの mediaAlign_left を
+		// あえて含めない $new_instance を用意する（未チェック保存を再現）。
+		$new_instance = array(
+			'label'           => 'My Profile',
+			'mediaFile'       => '',
+			'mediaAlt'        => '',
+			'profile'         => 'profile text',
+			'mediaAlign'      => 'left',
+			'mediaSize'       => '',
+			'facebook'        => '',
+			'twitter'         => '',
+			'mail'            => '',
+			'youtube'         => '',
+			'rss'             => '',
+			'instagram'       => '',
+			'linkedin'        => '',
+			'iconFont_bgType' => '',
+			'icon_color'      => '',
+		);
+
+		$result = $widget->update( $new_instance, array() );
+
+		// 未送信のチェックボックスは空文字（falsy）になっていること。
+		$this->assertSame( '', $result['mediaRound'] );
+		$this->assertSame( '', $result['mediaFloat'] );
+
+		// 廃止済みの mediaAlign_left は保存対象から外れ、キー自体が存在しないこと。
+		$this->assertArrayNotHasKey( 'mediaAlign_left', $result );
+
+		// 送信された他の値はそのまま保持されること（挙動が変わっていないことの確認）。
+		$this->assertSame( 'left', $result['mediaAlign'] );
+		$this->assertSame( 'My Profile', $result['label'] );
+	}
+
+	/**
+	 * 既存ユーザーの mediaAlign_left 保存値が update() 後も保持されることのテスト。
+	 *
+	 * update() で mediaAlign_left を保存対象から外したが、$old_instance に保存済みの
+	 * レガシー値はそのまま引き継がれ、image_align() の移行フォールバックが
+	 * これまでどおり機能することを検証する。
+	 *
+	 * @return void
+	 */
+	function test_update_keeps_legacy_media_align_left() {
+		$widget = new WP_Widget_vkExUnit_profile();
+
+		// 旧フィールドのみ保存されている既存ユーザーを再現する。
+		$old_instance = array(
+			'mediaAlign_left' => true,
+		);
+
+		// mediaAlign は既定でチェック済みのラジオボタンのため常に送信される。
+		// ここでは mediaAlign_left の引き継ぎ確認が目的なので、現実に即して mediaAlign は含める。
+		$new_instance = array(
+			'label'           => '',
+			'mediaFile'       => '',
+			'mediaAlt'        => '',
+			'profile'         => '',
+			'mediaAlign'      => 'left',
+			'mediaSize'       => '',
+			'facebook'        => '',
+			'twitter'         => '',
+			'mail'            => '',
+			'youtube'         => '',
+			'rss'             => '',
+			'instagram'       => '',
+			'linkedin'        => '',
+			'iconFont_bgType' => '',
+			'icon_color'      => '',
+		);
+
+		$result = $widget->update( $new_instance, $old_instance );
+
+		// $old_instance のレガシー値が維持されていること。
+		$this->assertArrayHasKey( 'mediaAlign_left', $result );
+		$this->assertTrue( $result['mediaAlign_left'] );
+	}
 }

--- a/tests/test-widget-profile.php
+++ b/tests/test-widget-profile.php
@@ -190,38 +190,51 @@ class WidgetProfileTest extends WP_UnitTestCase {
 	function test_update_guards_missing_checkbox_keys() {
 		$widget = new WP_Widget_vkExUnit_profile();
 
-		// チェックボックス系（mediaRound / mediaFloat）と廃止済みの mediaAlign_left を
-		// あえて含めない $new_instance を用意する（未チェック保存を再現）。
-		$new_instance = array(
-			'label'           => 'My Profile',
-			'mediaFile'       => '',
-			'mediaAlt'        => '',
-			'profile'         => 'profile text',
-			'mediaAlign'      => 'left',
-			'mediaSize'       => '',
-			'facebook'        => '',
-			'twitter'         => '',
-			'mail'            => '',
-			'youtube'         => '',
-			'rss'             => '',
-			'instagram'       => '',
-			'linkedin'        => '',
-			'iconFont_bgType' => '',
-			'icon_color'      => '',
+		// テスト条件（送信内容）と期待する結果を配列で持ち、ループで検証する。
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'チェックボックス（mediaRound / mediaFloat）と廃止済み mediaAlign_left を未送信',
+				// チェックボックス系（mediaRound / mediaFloat）と廃止済みの mediaAlign_left を
+				// あえて含めない $new_instance（未チェック保存を再現）。
+				'new_instance'        => array(
+					'label'           => 'My Profile',
+					'mediaFile'       => '',
+					'mediaAlt'        => '',
+					'profile'         => 'profile text',
+					'mediaAlign'      => 'left',
+					'mediaSize'       => '',
+					'facebook'        => '',
+					'twitter'         => '',
+					'mail'            => '',
+					'youtube'         => '',
+					'rss'             => '',
+					'instagram'       => '',
+					'linkedin'        => '',
+					'iconFont_bgType' => '',
+					'icon_color'      => '',
+				),
+				// 未送信のチェックボックスは空文字（falsy）へ、送信値はそのまま保持されること。
+				'expected_same'       => array(
+					'mediaRound' => '',
+					'mediaFloat' => '',
+					'mediaAlign' => 'left',
+					'label'      => 'My Profile',
+				),
+				// 廃止済みの mediaAlign_left は保存対象から外れ、キー自体が存在しないこと。
+				'expected_absent'     => array( 'mediaAlign_left' ),
+			),
 		);
 
-		$result = $widget->update( $new_instance, array() );
+		foreach ( $test_cases as $case ) {
+			$result = $widget->update( $case['new_instance'], array() );
 
-		// 未送信のチェックボックスは空文字（falsy）になっていること。
-		$this->assertSame( '', $result['mediaRound'] );
-		$this->assertSame( '', $result['mediaFloat'] );
-
-		// 廃止済みの mediaAlign_left は保存対象から外れ、キー自体が存在しないこと。
-		$this->assertArrayNotHasKey( 'mediaAlign_left', $result );
-
-		// 送信された他の値はそのまま保持されること（挙動が変わっていないことの確認）。
-		$this->assertSame( 'left', $result['mediaAlign'] );
-		$this->assertSame( 'My Profile', $result['label'] );
+			foreach ( $case['expected_same'] as $key => $value ) {
+				$this->assertSame( $value, $result[ $key ], $case['test_condition_name'] . ' / ' . $key );
+			}
+			foreach ( $case['expected_absent'] as $key ) {
+				$this->assertArrayNotHasKey( $key, $result, $case['test_condition_name'] . ' / ' . $key );
+			}
+		}
 	}
 
 	/**
@@ -235,11 +248,6 @@ class WidgetProfileTest extends WP_UnitTestCase {
 	 */
 	function test_update_keeps_legacy_media_align_left() {
 		$widget = new WP_Widget_vkExUnit_profile();
-
-		// 旧フィールドのみ保存されている既存ユーザーを再現する。
-		$old_instance = array(
-			'mediaAlign_left' => true,
-		);
 
 		// mediaAlign は既定でチェック済みのラジオボタンのため常に送信される。
 		// ここでは mediaAlign_left の引き継ぎ確認が目的なので、現実に即して mediaAlign は含める。
@@ -261,10 +269,27 @@ class WidgetProfileTest extends WP_UnitTestCase {
 			'icon_color'      => '',
 		);
 
-		$result = $widget->update( $new_instance, $old_instance );
+		// 旧フィールド（mediaAlign_left）のみ保存されている既存ユーザーの保存値ごとに、
+		// update() 後もその値が引き継がれることを検証する。
+		$test_cases = array(
+			array(
+				'test_condition_name'       => 'mediaAlign_left=true が引き継がれる',
+				'old_instance'              => array( 'mediaAlign_left' => true ),
+				'expected_media_align_left' => true,
+			),
+			array(
+				'test_condition_name'       => 'mediaAlign_left=false が引き継がれる',
+				'old_instance'              => array( 'mediaAlign_left' => false ),
+				'expected_media_align_left' => false,
+			),
+		);
 
-		// $old_instance のレガシー値が維持されていること。
-		$this->assertArrayHasKey( 'mediaAlign_left', $result );
-		$this->assertTrue( $result['mediaAlign_left'] );
+		foreach ( $test_cases as $case ) {
+			$result = $widget->update( $new_instance, $case['old_instance'] );
+
+			// $old_instance のレガシー値が維持されていること。
+			$this->assertArrayHasKey( 'mediaAlign_left', $result, $case['test_condition_name'] );
+			$this->assertSame( $case['expected_media_align_left'], $result['mediaAlign_left'], $case['test_condition_name'] );
+		}
 	}
 }


### PR DESCRIPTION
## 関連Issue

- 関連Issue: vektor-inc/multi-repo-tasks#23（PHP 8.x 実行時警告の横断対応のうち ExUnit 分）

## 変更の目的・理由

`vk-all-in-one-expansion-unit` #1395 / PR #1396 でウィジェットの PHP 8.x 警告を修正しましたが、その際に直し切れなかった残りのウィジェット 2 種で、特定の設定のまま保存するとエラーログに PHP 警告が記録され続けていました。エンドユーザーのサーバーログにノイズが蓄積するため修正します。

- **プロフィールウィジェット** … 保存のたびに、または「画像を角丸に」「テキストを画像に回り込ませる」のチェックを外して保存したときに警告が発生
- **PR Blocks ウィジェット** … カラム数を既定（3）で保存したときに、描画されていない 4 ブロック目のキーを参照して警告が発生

## 実装内容

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

### 技術的な詳細

いずれも `update()` が、フォームから送られてこないキーを未ガードで参照していたことが原因です。**フォールバック値は既存ユーザーの保存値・フロント出力が変わらないもの（空文字 / 旧データの引き継ぎ）を選び、挙動は完全に不変**としています。

**`inc/other-widget/widget-profile.php` の `update()`**
- `mediaAlign_left` … 対応するフォーム項目が無い廃止済みキー（`mediaAlign` へ移行済み）を `$new_instance` から読んでいたため毎回必発。読み取り行を削除（値は `$instance = $old_instance;` で引き継がれ、レガシー移行フォールバックは従来どおり機能）。
- `mediaRound` / `mediaFloat` … 未チェックだと送信されないチェックボックスを `isset( ... ) ? ... : ''` でガード（未チェック時は空文字＝従来と同じ falsy）。

**`inc/other-widget/widget-pr-blocks.php` の `update()`**
- ループは固定で 1〜4 ブロックを処理する一方、`form()` / `widget()` は `block_count`（既定 3）までしか描画しないため、4 ブロック目のキーが欠落していました。ループ内 8 キーの参照を `?? ''` でガード。フロント出力は `block_count` に束縛されるため、データ保持挙動を変えないようループ上限 4 は据え置き。

## スクリーンショット

表示・UI に影響しない内部処理（ウィジェット保存時の値の取り扱い）の修正のため、スクリーンショットは省略します。フロント表示・保存済みウィジェットの挙動は変わりません。

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み（`tests/test-widget-profile.php` / `tests/test-widget-pr-blocks.php`）
- [ ] 既存のテストが通ることを確認（`run-ci` で CI 実行後に確認）
- [x] 手動テストを実施済み（wp-env PHP 8.3.31 + WP_DEBUG で Before/After を確認）

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [ ] レビュワーに回す準備が整っている（CodeRabbit / CI 確認後）

---
## レビュワー向け情報

### テスト手順

PHP 8.0 以上・`WP_DEBUG` / `WP_DEBUG_LOG` を有効にした環境で確認します。

**Before（修正前 = master）**
1. 管理画面 →「外観」→「ウィジェット」で「プロフィール」ウィジェットを追加し、「画像を角丸に」「テキストを画像に回り込ませる」のチェックを外したまま保存する。
2. `wp-content/debug.log` を確認する。
   → `Undefined array key "mediaAlign_left"` / `"mediaRound"` / `"mediaFloat"`（widget-profile.php）が記録される。
3. 「PR Blocks」ウィジェットをカラム数 3（既定）のまま保存する。
4. `wp-content/debug.log` を確認する。
   → `Undefined array key "label_4"` などブロック 4 のキー群、および `stripslashes()/ltrim(): Passing null to parameter ... is deprecated`（widget-pr-blocks.php）が記録される。

**After（修正後 = 本ブランチ）**
- 同じ操作を行い、上記の警告が `debug.log` に**記録されないこと**を確認する。
- フロント表示・保存済みウィジェットの挙動が変わらないことを確認する。

**実機確認の結果（参考）**
- wp-env（PHP 8.3.31 / WP_DEBUG=on）で各ウィジェットの `update()` を既定保存相当の入力で直接呼び出して計測しました。
  - 修正前: プロフィール **3 件**（`mediaAlign_left` / `mediaRound` / `mediaFloat`）、PR Blocks **14 件**（ブロック 4 の未定義キー 8 件＋ null 渡し由来の deprecation 6 件）
  - 修正後: 両ウィジェットとも **0 件**

**自動テスト**
- `npm run phpunit`（CI: PHP 7.4 / 8.0 / 8.1）。`update()` が欠落キーで警告を出さず、フォールバック値（空文字）になること、`mediaAlign_left` のレガシー保存値が `$old_instance` から温存されることを検証。

### レビューポイント（任意）

- フォールバック値が既存ユーザーの保存値・フロント出力を変えないか（消費側はいずれも `empty()` / 真偽判定で、空文字は従来の null と同じ falsy）。
- `mediaAlign_left` の読み取り削除がレガシーユーザーの表示に影響しないか（`mediaAlign` が常に保存されるため移行フォールバックは発火せず、旧値も `$old_instance` で温存）。

### 動作確認時の注意事項

- [ ] 最新のコードをプルしている
- [ ] 正しいディレクトリで作業している
- [ ] キャッシュをクリアしている（OPcache。ブランチ切り替え後は PHP 再起動推奨）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロフィールウィジェットと PR ブロックウィジェットの保存時に PHP 8.x で発生していた警告を修正しました。

* **テスト**
  * ウィジェット設定の保存処理に関する単体テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->