### PR TITLE
[ 開発環境 ] npm run dist で配布 ZIP が生成されず GitHub Release に添付されない問題を修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,6 @@ var cleanCss = require('gulp-clean-css');
 // 同期的に処理してくれる（ distで使用している ）
 var runSequence = require('run-sequence');
 var replace = require('gulp-replace');
-const ps = require('child_process').exec
 
 
 let error_stop = true
@@ -170,12 +169,6 @@ gulp.task('watch', function() {
 
 gulp.task('default', gulp.series('text-domain','watch'))
 gulp.task('compile', gulp.series('scripts', 'sass'))
-gulp.task('dist', (done)=>{
-  ps('bin/dist', (err, stdout, stderr)=>{
-    console.log(stdout)
-    done()
-  })
-})
 
 gulp.task('build', gulp.series('scripts', 'sass', 'scripts_smooth'))
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"lint:sitemap-page": "wp-scripts format inc/sitemap-page/block/ && wp-scripts lint-js inc/sitemap-page/block/ --fix",
 		"lint:sns": "wp-scripts format inc/sns/block/ && wp-scripts lint-js inc/sns/block/ --fix",
 		"lint:panel": "wp-scripts format src/editor-panel/ && wp-scripts lint-js src/editor-panel/ --fix",
-		"dist": "rm -rf dist/vk-all-in-one-expansion-unit && composer install --optimize-autoloader --prefer-dist --no-dev && npm run build && npx gulp dist",
+		"dist": "rm -rf dist/vk-all-in-one-expansion-unit dist/vk-all-in-one-expansion-unit.zip && composer install --optimize-autoloader --prefer-dist --no-dev && npm run build && npx gulp dist && cd dist && zip -rq vk-all-in-one-expansion-unit.zip vk-all-in-one-expansion-unit/",
 		"dist:github": "composer install --optimize-autoloader --prefer-dist --no-dev && npx gulp dist",
 		"dist:org": "composer install --optimize-autoloader --prefer-dist --no-dev",
 		"gulp": "gulp",


### PR DESCRIPTION
## 概要

`npm run dist` が配布用 ZIP（`dist/vk-all-in-one-expansion-unit.zip`）を生成しておらず、リリースワークフロー（`.github/workflows/release.yml`）の「Create Release」ステップで `files: dist/vk-all-in-one-expansion-unit.zip` がパターン不一致となり、**GitHub Release に ZIP が添付されていなかった**問題を修正します。

実害として 9.117.0〜9.117.4 の GitHub Release はすべて添付アセットが 0 件でした（wordpress.org への SVN 配信は正常なため、エンドユーザーの更新には影響なし。GitHub Release から ZIP を取得する用途のみ影響）。

## 原因

- `gulpfile.js` に `dist` タスクが2回定義されており（旧 `bin/dist` 呼び出し版と、ファイルコピー版）、gulp 4 では後勝ちで**コピー版のみ有効**。コピー版は `dist/vk-all-in-one-expansion-unit/` へ複製するだけで **ZIP 化していなかった**。
- そのため `npm run dist` 実行後も `dist/vk-all-in-one-expansion-unit.zip` が生成されず、ワークフローの `files:` 指定にマッチしなかった（`fail_on_unmatched_files` 既定 false のためジョブ自体は成功扱いとなり、添付漏れが見逃されていた）。

## 変更内容

- `package.json` の `dist` スクリプト末尾に ZIP 化処理を追加（`cd dist && zip -rq vk-all-in-one-expansion-unit.zip vk-all-in-one-expansion-unit/`）。先頭の削除処理にも古い ZIP の削除を追加し、再生成時に確実に最新化。
- `gulpfile.js` の重複・無効化されていた旧 `dist` タスク定義（`bin/dist` 呼び出し版）と、それに伴い未使用となった `child_process.exec` の require を削除。

> changelog 追記なし: ビルド／リリースのパッケージング設定のみの変更で、配布されるプラグインの実行時挙動は変わらず、エンドユーザーに影響しないため（changelog ルールの「更新不要なケース」に該当）。

## 確認手順

### Before（修正前）
1. `git stash` 等で本変更を外した状態で `npm run dist` を実行する
2. `ls dist/` を確認する
   → `dist/vk-all-in-one-expansion-unit/` のみで `vk-all-in-one-expansion-unit.zip` が**生成されない**

### After（修正後）
1. `npm run dist` を実行する
2. `ls dist/` を確認する
   → `dist/vk-all-in-one-expansion-unit.zip` が**生成される**
3. ZIP の中身を確認する: `unzip -l dist/vk-all-in-one-expansion-unit.zip`
   → ルートに `vk-all-in-one-expansion-unit/` ディレクトリがあり、`vkExUnit.php` / `readme.txt` / `vendor/` / `build/` を含む
   → `node_modules` / `tests/` / `package.json` / `composer.*` / `phpunit.xml` などの開発用ファイルが**含まれない**

### リリースフロー全体（次回タグ push 時）
- タグ push 後の `Release` ジョブで「`Pattern 'dist/vk-all-in-one-expansion-unit.zip' does not match any files.`」が出ず、GitHub Release に ZIP が添付されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルドプロセスを簡素化し、配布ファイルの生成フローを改善しました。既存の出力ファイルを自動削除した後、統一されたビルド手順を実行するようになり、より確実で再現可能なビルドが可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->