### PR TITLE
[ 不具合修正 ][ ウィジェット ] クラシックウィジェットがブロックウィジェット編集画面で参照解決に失敗し非表示になる不具合に対し show_instance_in_rest を付与して堅牢化

### DIFF
--- a/inc/call-to-action/package/view-adminsetting.php
+++ b/inc/call-to-action/package/view-adminsetting.php
@@ -1,12 +1,6 @@
 <?php
 
 /*
-このファイルの元ファイルは
-https://github.com/vektor-inc/vektor-wp-libraries
-にあります。修正の際は上記リポジトリのデータを修正してください。
-*/
-
-/*
 Main setting Page
 */
 global $vk_call_to_action_textdomain;

--- a/inc/call-to-action/package/widget-call-to-action.php
+++ b/inc/call-to-action/package/widget-call-to-action.php
@@ -1,11 +1,5 @@
 <?php
 
-/*
-このファイルの元ファイルは
-https://github.com/vektor-inc/vektor-wp-libraries
-にあります。修正の際は上記リポジトリのデータを修正してください。
-*/
-
 // namespace Vektor\ExUnit\Package\Cta;
 
 
@@ -23,7 +17,10 @@ class Widget_CTA extends \WP_Widget {
 			'vkExUnit_cta',
 			$widget_name,
 			array(
-				'description' => __( 'Select CTA and display it.', $vk_call_to_action_textdomain ),
+				'description'           => __( 'Select CTA and display it.', $vk_call_to_action_textdomain ),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
 			)
 		);
 	}

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -468,7 +468,10 @@ class WP_Widget_VkExUnit_Contact_Button extends WP_Widget {
 			'vkExUnit_contact',
 			$widget_name,
 			array(
-				'description' => $widget_description,
+				'description'           => $widget_description,
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
 			)
 		);
 	}
@@ -518,7 +521,10 @@ class WP_Widget_VkExUnit_Contact_Section extends WP_Widget {
 			'vkExUnit_contact_section',
 			$widget_name,
 			array(
-				'description' => $widget_description,
+				'description'           => $widget_description,
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
 			)
 		);
 	}

--- a/inc/other-widget/widget-3pr-area.php
+++ b/inc/other-widget/widget-3pr-area.php
@@ -8,7 +8,12 @@ class WP_Widget_vkExUnit_3PR_area extends WP_Widget {
 		parent::__construct(
 			'WP_Widget_vkExUnit_3PR_area',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-archives.php
+++ b/inc/other-widget/widget-archives.php
@@ -11,7 +11,12 @@ class WP_Widget_VK_archive_list extends WP_Widget {
 		parent::__construct(
 			'WP_Widget_VK_archive_list',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-banner.php
+++ b/inc/other-widget/widget-banner.php
@@ -5,7 +5,12 @@ class WidgetBanner extends WP_Widget {
 		parent::__construct(
 			'vkExUnit_banner',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-button.php
+++ b/inc/other-widget/widget-button.php
@@ -32,7 +32,12 @@ class WP_Widget_Button extends WP_Widget {
 		parent::__construct(
 			'vkExUnit_button',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-new-posts.php
+++ b/inc/other-widget/widget-new-posts.php
@@ -11,7 +11,12 @@ class WP_Widget_vkExUnit_post_list extends WP_Widget {
 		parent::__construct(
 			'vkExUnit_post_list',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-page.php
+++ b/inc/other-widget/widget-page.php
@@ -9,7 +9,12 @@ class WP_Widget_vkExUnit_widget_page extends WP_Widget {
 		parent::__construct(
 			'pudge',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-pr-blocks.php
+++ b/inc/other-widget/widget-pr-blocks.php
@@ -19,7 +19,12 @@ class WP_Widget_vkExUnit_PR_Blocks extends WP_Widget {
 		parent::__construct(
 			'WP_Widget_vkExUnit_PR_Blocks',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-profile.php
+++ b/inc/other-widget/widget-profile.php
@@ -8,7 +8,12 @@ class WP_Widget_vkExUnit_profile extends WP_Widget {
 		parent::__construct(
 			'WP_Widget_vkExUnit_profile',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-side-child-page-list.php
+++ b/inc/other-widget/widget-side-child-page-list.php
@@ -5,7 +5,12 @@ class WP_Widget_vkExUnit_ChildPageList extends WP_Widget {
 		parent::__construct(
 			'vkExUnit_childPageList',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/other-widget/widget-taxonomies.php
+++ b/inc/other-widget/widget-taxonomies.php
@@ -8,7 +8,12 @@ class WP_Widget_VK_taxonomy_list extends WP_Widget {
 		parent::__construct(
 			'WP_Widget_VK_taxonomy_list',
 			self::veu_widget_name(),
-			array( 'description' => self::veu_widget_description() )
+			array(
+				'description'           => self::veu_widget_description(),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/sns/widget-fb-page-plugin.php
+++ b/inc/sns/widget-fb-page-plugin.php
@@ -10,7 +10,12 @@ class WP_Widget_vkExUnit_fbPagePlugin extends WP_Widget {
 		parent::__construct(
 			'vkExUnit_fbPagePlugin',
 			$widget_name,
-			array( 'description' => __( 'Displays a Facebook Page Plugin', 'vk-all-in-one-expansion-unit' ) )
+			array(
+				'description'           => __( 'Displays a Facebook Page Plugin', 'vk-all-in-one-expansion-unit' ),
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 	}
 

--- a/inc/sns/widget-twitter.php
+++ b/inc/sns/widget-twitter.php
@@ -9,7 +9,12 @@ class VK_Twitter_Widget extends WP_Widget {
 		parent::__construct(
 			'vk_twitter_widget', // Base ID
 			self::widget_name(), // Name
-			array( 'description' => self::widget_description() ) // Args
+			array(
+				'description'           => self::widget_description(), // Args
+				// インスタンス設定を REST API に出力し、ブロックウィジェット編集画面でブロック内に自己完結で保持・編集できるようにする（参照ウィジェット扱いによる非表示を防ぐ）。
+				// Expose the instance settings to the REST API so the block-based widgets editor can keep and edit them inline (prevents the widget from being hidden as a reference widget).
+				'show_instance_in_rest' => true,
+			)
 		);
 		// widget actual processes
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Widget ] Added show_instance_in_rest to the ExUnit classic widgets so their settings are kept inline in the block-based widgets editor, preventing them from being hidden when reference widget resolution fails.
+
 = 9.117.4 =
 [ Bug Fix ][ Widget ] Fixed PHP 8.x warnings that were written to the error log when saving the Profile widget or the PR Blocks widget with certain settings.
 

--- a/tests/test-widget-show-instance-in-rest.php
+++ b/tests/test-widget-show-instance-in-rest.php
@@ -18,7 +18,7 @@ class WidgetShowInstanceInRestTest extends WP_UnitTestCase {
 	/**
 	 * 検証対象となる ExUnit ウィジェットクラス名の一覧。
 	 *
-	 * @return string[] ウィジェットクラス名の配列。
+	 * @return array<int, string[]> 各要素が「ウィジェットクラス名1件を持つ配列」となるデータセット。
 	 */
 	public function widget_class_provider() {
 		return array(

--- a/tests/test-widget-show-instance-in-rest.php
+++ b/tests/test-widget-show-instance-in-rest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Class WidgetShowInstanceInRestTest
+ *
+ * ExUnit のクラシックウィジェットに widget オプション show_instance_in_rest が
+ * true で付与されていることを検証するテスト。
+ * これによりブロックウィジェット編集画面でインスタンス設定をブロック内に
+ * 自己完結で保持・編集でき、参照ウィジェットの解決失敗による非表示を防ぐ。
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * WidgetShowInstanceInRest test case.
+ */
+class WidgetShowInstanceInRestTest extends WP_UnitTestCase {
+
+	/**
+	 * 検証対象となる ExUnit ウィジェットクラス名の一覧。
+	 *
+	 * @return string[] ウィジェットクラス名の配列。
+	 */
+	public function widget_class_provider() {
+		return array(
+			array( 'WP_Widget_vkExUnit_fbPagePlugin' ),
+			array( 'VK_Twitter_Widget' ),
+			array( 'WP_Widget_vkExUnit_post_list' ),
+			array( 'WP_Widget_VK_taxonomy_list' ),
+			array( 'WP_Widget_vkExUnit_profile' ),
+			array( 'WP_Widget_vkExUnit_PR_Blocks' ),
+			array( 'WP_Widget_vkExUnit_ChildPageList' ),
+			array( 'WidgetBanner' ),
+			array( 'WP_Widget_Button' ),
+			array( 'WP_Widget_VK_archive_list' ),
+			array( 'WP_Widget_vkExUnit_3PR_area' ),
+			array( 'WP_Widget_vkExUnit_widget_page' ),
+			array( 'WP_Widget_VkExUnit_Contact_Button' ),
+			array( 'WP_Widget_VkExUnit_Contact_Section' ),
+			array( 'Widget_CTA' ),
+		);
+	}
+
+	/**
+	 * 各ウィジェットの widget_options に show_instance_in_rest => true が
+	 * 含まれていることを確認する。
+	 *
+	 * @dataProvider widget_class_provider
+	 *
+	 * @param string $class_name 検証対象のウィジェットクラス名。
+	 */
+	public function test_show_instance_in_rest_is_enabled( $class_name ) {
+		// 対象クラスが読み込まれていることを前提とする。
+		$this->assertTrue( class_exists( $class_name ), $class_name . ' クラスが存在しません。' );
+
+		// ウィジェットをインスタンス化し、コンストラクタで設定された widget_options を取得する。
+		$widget = new $class_name();
+
+		// show_instance_in_rest が宣言されていることを確認する。
+		$this->assertArrayHasKey(
+			'show_instance_in_rest',
+			$widget->widget_options,
+			$class_name . ' に show_instance_in_rest が宣言されていません。'
+		);
+
+		// 値が true であることを確認する。
+		$this->assertTrue(
+			$widget->widget_options['show_instance_in_rest'],
+			$class_name . ' の show_instance_in_rest が true ではありません。'
+		);
+	}
+}


### PR DESCRIPTION
## 概要

[#1400](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1400) 対応。

ExUnit のクラシックウィジェットは `show_instance_in_rest` を宣言していないため、ブロックウィジェット編集画面では「参照ウィジェット（reference widget）」として扱われ、実データは `widget_*` オプション + `sidebars_widgets` 側に残り、ブロックは参照だけを持ちます。この対応では、ExUnit のクラシックウィジェット全15クラスに widget オプション `show_instance_in_rest => true` を付与し、ブロック内にインスタンスを自己完結で保持・編集できるようにしました（WordPress 公式の Legacy Widget block 推奨手法）。これにより、`sidebars_widgets` と `widget_*` の対応がズレた既存データで参照解決に失敗して編集画面に出ない、という事象に強くなります。

> ⚠️ 報告環境（WordPress 6.9.4 / Lightning G3）では現行最新で**再現できていない**ため、確実な解消の保証ではなく**堅牢化**の位置づけです（issue の改善案に沿った対応）。

## 変更内容

- クラシックウィジェット全15クラスの `parent::__construct()` の widget オプションに `show_instance_in_rest => true` を付与
  - 対象: FB Page Plugin / Twitter / Recent Posts / Categories・Taxonomies / Profile / PR Blocks / Child Pages / Banner / Button / Archive / 3PR area / Page / Contact Button / Contact Section / CTA
  - いずれもインスタンスは JSON 化可能なスカラー値のみで機微情報を保存しないため、付与条件を満たします
- CTA ウィジェット（`vkExUnit_cta`）は `extends \WP_Widget` 記法のため当初の検出から漏れていたが追加対応
- CTA パッケージ（`inc/call-to-action/package/`）の「元ファイルは vektor-wp-libraries にあります」という案内コメントを削除
  - 当該パッケージは 2019 年に上流（vektor-wp-libraries）から削除済み（`ExUnitでしか使っていないので一旦削除`）で、ExUnit が事実上のソースのため、記述が実態と矛盾し誤解を招くため
- PHPUnit テスト追加（`tests/test-widget-show-instance-in-rest.php`）: 全15クラスに `show_instance_in_rest => true` が設定されていることをデータプロバイダで検証

## 確認手順

### 前提条件

- クラシックテーマ（ウィジェットエリアを持つもの。例: Twenty Twenty-One や Lightning G3）を有効化
- 「Classic Widgets」プラグインは**無効**（＝ブロックウィジェット編集画面が有効な状態）
- ExUnit を有効化し、いずれかのウィジェットエリアに VK のクラシックウィジェット（VK ボタン等）を配置・保存しておく

### 手順

#### After（修正後 / 確認手順）

1. 管理画面 > 外観 > ウィジェット（ブロックウィジェット編集画面）を開く
   → ✓ 配置済みの VK ウィジェット（VK ボタン / VK プロフィール / VK CTA 等）がウィジェットブロックとして表示される（空欄・消失しない）
2. 各ウィジェットブロックをクリックして選択する
   → ✓ 保存済みの設定値がフォームに表示され、インラインで編集できる
3. 値を変更して「更新」し、画面を再読み込みする
   → ✓ 変更した値が保持されている
4. 公開側（フロント）の該当ウィジェットエリアを表示する
   → ✓ 従来どおり表示され、デグレがない

#### 補足: REST API での確認（任意）

- `GET /wp/v2/widgets/<widget_id>`（context=edit、要管理者認証）を実行する
  → ✓ レスポンスの `instance.raw` に設定値がインラインで含まれる（修正前は `instance.raw` が無く、参照ウィジェット扱い）

## 関連 issue

Refs #1400

## 残課題（このPRのスコープ外）

- issue 補足の「ウィジェットエリア説明文『ヘッダーサブウィジェット』表記の更新」は別途対応


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* クラシックウィジェットの各設定が、ブロックエディタでインライン保持・編集できるようになり、エディタの切り替え時に設定が失われないよう改善しました。

## Tests
* 対象ウィジェットで REST API 側のインスタンス設定が有効化されていることを検証するテストを追加しました。

## Documentation
* Changelog に今回の変更内容（ブロックエディタで設定が隠れないようにする旨）を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->