### PR TITLE
[ 不具合修正 ][ ウィジェット ] PHP 8 でタクソノミーリストウィジェット設定フォームを開くと Undefined array key 警告が発生する不具合を修正

### DIFF
--- a/inc/other-widget/widget-taxonomies.php
+++ b/inc/other-widget/widget-taxonomies.php
@@ -203,7 +203,10 @@ class WP_Widget_VK_taxonomy_list extends WP_Widget {
 
 		$instance['form_design'] = $new_instance['form_design'];
 
-		$instance['form_sort'] = $new_instance['form_sort'];
+		$allowed_sort          = array( 'asc', 'desc' );
+		$instance['form_sort'] = in_array( $new_instance['form_sort'], $allowed_sort, true )
+			? $new_instance['form_sort']
+			: 'asc';
 		return $instance;
 	}
 }

--- a/inc/other-widget/widget-taxonomies.php
+++ b/inc/other-widget/widget-taxonomies.php
@@ -204,8 +204,9 @@ class WP_Widget_VK_taxonomy_list extends WP_Widget {
 		$instance['form_design'] = $new_instance['form_design'];
 
 		$allowed_sort          = array( 'asc', 'desc' );
-		$instance['form_sort'] = in_array( $new_instance['form_sort'], $allowed_sort, true )
-			? $new_instance['form_sort']
+		$form_sort             = $new_instance['form_sort'] ?? '';
+		$instance['form_sort'] = in_array( $form_sort, $allowed_sort, true )
+			? $form_sort
 			: 'asc';
 		return $instance;
 	}

--- a/inc/other-widget/widget-taxonomies.php
+++ b/inc/other-widget/widget-taxonomies.php
@@ -105,6 +105,7 @@ class WP_Widget_VK_taxonomy_list extends WP_Widget {
 			'form_design' => 'list',
 			'hide_empty'  => false,
 			'_builtin'    => false,
+			'form_sort'   => 'asc',
 		);
 		return wp_parse_args( (array) $instance, $defaults );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Widget ] Fixed a PHP 8 undefined array key warning for `form_sort` in the categories/taxonomies list widget by adding the key to `get_defaults()`.
+
 [ Design Bug Fix ][ Sitemap ] Changed the sitemap link color from a hardcoded value to `color: inherit` so it inherits the theme's color scheme correctly.
 
 = 9.117.5 =

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,8 @@ e.g.
 
 == Changelog ==
 
-[ Bug Fix ][ Widget ] Fixed a PHP 8 undefined array key warning for `form_sort` in the categories/taxonomies list widget by adding the key to `get_defaults()`.
+[ Bug Fix ][ Widget ] Fixed undefined array key `form_sort` warning in PHP 8 on the categories/taxonomies list widget form
+[ Security Fix ][ Widget ] Added allowlist validation for `form_sort` value in the widget save process
 
 [ Design Bug Fix ][ Sitemap ] Changed the sitemap link color from a hardcoded value to `color: inherit` so it inherits the theme's color scheme correctly.
 


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #1406

## 変更の目的・理由

PHP 8 環境でタクソノミーリストウィジェット（分類リスト）の設定フォームを開くと、エラーログに以下の警告が記録されていました。

```
PHP Warning: Undefined array key "form_sort"
```

PHP 7 では未定義キーアクセスが黙って `null` を返すだけでしたが、PHP 8 から `E_WARNING` として記録されるようになったため顕在化した問題です。

## 実装内容

### 主な変更点
- [x] バグ修正

### 技術的な詳細

`get_defaults()` 静的メソッドに `form_sort` キーが含まれておらず、`form()` メソッド内で `wp_parse_args` 後も `$instance['form_sort']` が存在しない状態で参照されていました。

- `widget()` メソッドは個別の `isset` ガードを持つため影響なし
- `form()` メソッドはガードなしで直接参照するため警告が発生

**修正 1:** `get_defaults()` に `'form_sort' => 'asc'` を追加し、`widget()` / `form()` 両方を一元カバー

**修正 2:** セキュリティレビュー（安藤）の指摘を受け、`update()` メソッドで `form_sort` の保存値をホワイトリスト（`asc` / `desc`）で検証するよう対処

## スクリーンショット

UIの表示変更なし（管理画面ウィジェットフォームの動作は変わらず、警告が出なくなるのみ）

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み（ウィジェット admin フォームの単体テストは WP 環境依存のため省略）
- [x] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順

**注意:** WP 5.8 以降のブロックウィジェットエディター（外観 → ウィジェット）は PHP の `form()` を呼ばないため再現しません。**カスタマイザー経由**で確認してください。

**前提条件:**
- テーマ: Lightning（ウィジェットエリアが登録されているテーマであれば可）
- PHP 8.x 環境

**Before（再現手順）:**

1. PHP 8 環境でウィジェットが一度も保存されていない状態にする
2. 管理画面 > 外観 > **カスタマイズ** を開く
3. 「ウィジェット」→ いずれかのウィジェットエリアに「**VK カテゴリー/カスタム分類リスト**」を追加して設定フォームを開く
4. → `wp-content/debug.log` に `Undefined array key "form_sort"` 警告が記録される

**After（修正後の確認手順）:**

1. 修正後のコードで同じ操作を行う
2. 管理画面 > 外観 > **カスタマイズ** → ウィジェットエリアに「**VK カテゴリー/カスタム分類リスト**」を追加して設定フォームを開く
3. → `wp-content/debug.log` に警告が記録されないことを確認

**既存動作の確認:**

1. 「VK カテゴリー/カスタム分類リスト」ウィジェットで「表示順」を「昇順」または「降順」に設定して保存
2. フロントエンドでウィジェットが正常に表示されることを確認
3. → 保存前後でウィジェットの表示が変わらないこと

### レビューポイント

- `get_defaults()` への `form_sort` 追加による `widget()` / `form()` 両メソッドへの影響
- `update()` のホワイトリスト検証が `asc` / `desc` を正しく許可し、不正値をデフォルト `asc` にフォールバックすること

### 動作確認時の注意事項

- [ ] 最新のコードをプルしている
- [ ] PHP 8.x 環境で確認する（PHP 7.x では警告が出ないため再現しない）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * カテゴリ/タクソノミー一覧ウィジェットで、並び順が未設定でも既定値が適用されるようになりました。
  * 保存時に不正な並び順が入力されても自動的に既定の並び順へ戻るよう改善しました。
  * PHP 8 環境で表示されていた未定義キー関連の警告が解消されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->