### PR TITLE
[ 仕様変更 ] vektor-inc/font-awesome-versions を 0.7.2 から 0.7.4 にアップデート

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"vektor-inc/vk-admin": "^0.8.0",
 		"vektor-inc/vk-breadcrumb": "^0.2.9",
 		"vektor-inc/vk-helpers": "^0.3.0",
-		"vektor-inc/font-awesome-versions": "^0.7.2",
+		"vektor-inc/font-awesome-versions": "^0.7.4",
 		"vektor-inc/vk-term-color": "^0.7.1",
 		"vektor-inc/vk-css-optimize": "^0.2.5"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0088113d042fdb3bae6902230fbf3205",
+    "content-hash": "b016d375a4d88b9060bd14366ee5422e",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
-            "version": "0.7.2",
+            "version": "0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/font-awesome-versions.git",
-                "reference": "ec8458a56165dc309befe88c982a54bda4bcb2e4"
+                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/ec8458a56165dc309befe88c982a54bda4bcb2e4",
-                "reference": "ec8458a56165dc309befe88c982a54bda4bcb2e4",
+                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
+                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
@@ -54,9 +54,9 @@
             "description": "Font Awesome",
             "support": {
                 "issues": "https://github.com/vektor-inc/font-awesome-versions/issues",
-                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.2"
+                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.4"
             },
-            "time": "2026-03-19T04:34:56+00:00"
+            "time": "2026-06-26T02:51:54+00:00"
         },
         {
             "name": "vektor-inc/vk-admin",
@@ -2919,5 +2919,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ e.g.
 
 == Changelog ==
 
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.4
 [ Design Bug Fix ][ Sitemap ] Changed the sitemap link color from a hardcoded value to `color: inherit` so it inherits the theme's color scheme correctly.
 
 = 9.117.5 =


### PR DESCRIPTION
誤ってrevertされた font-awesome-versions 0.7.4 アップデートを復元します。

関連Issue: なし

## 変更内容

- revertコミット `bb114f5` を取り消し、0.7.4 アップデートを再適用

## 確認手順

1. `composer install` を実行する → エラーなく完了する
2. `composer show vektor-inc/font-awesome-versions` → `versions : * 0.7.4` と表示される