### PR TITLE
[ 不具合修正 ][ 新着記事ウィジェット ] タイトル空白時に管理画面フォームで PHP Warning が発生する不具合を修正

### DIFF
--- a/inc/other-widget/widget-new-posts.php
+++ b/inc/other-widget/widget-new-posts.php
@@ -317,11 +317,9 @@ class WP_Widget_vkExUnit_post_list extends WP_Widget {
 		<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:' ); ?></label>
 		</h3>
 		<?php
-		if ( isset( $instance['title'] ) && $instance['title'] ) {
-			$title = $instance['title'];
-		} else {
-			$title = $instance['label'];
-		}
+		// Use the shared guarded method (same as the front-end) to avoid an Undefined array key warning when title / label are unset.
+		// title / label 未設定時の Undefined array key 警告を避けるため、フロント表示と共通のガード済みメソッドを使用する。
+		$title = $this->get_widget_title( $instance );
 		?>
 		<input type="text" id="<?php echo $this->get_field_id( 'title' ); ?>-title" name="<?php echo $this->get_field_name( 'title' ); ?>" value="<?php echo esc_attr( $title ); ?>" class="admin_widget_input" />
 


### PR DESCRIPTION
## 概要

PHP 8.x 環境で「VK 最近の投稿（VK Recent Posts）」ウィジェットのタイトルを空にした状態で管理画面のウィジェット編集フォームを開くと、以下の PHP Warning が記録される不具合を修正します。

```
PHP Warning: Undefined array key "label" in .../inc/other-widget/widget-new-posts.php on line 323
```

## 原因

`form()` メソッドで `$instance['label']` を `isset()` ガードなしで参照していました。フロント表示側の `get_widget_title()` は既に `title` / `label` 双方をガード済みでしたが、管理画面フォーム側が未対応だったため、`title` も `label` も未設定の場合に警告が発生していました。

## 修正内容

`form()` 内のタイトル決定処理を、フロント表示と共通のガード済みメソッド `get_widget_title()` の呼び出しに統一しました。

## 確認手順

### 前提条件
- PHP 8.x 環境
- `WP_DEBUG` および `WP_DEBUG_LOG` を有効化（`debug.log` に Warning が記録される状態）
- 投稿を1件以上作成
- クラシックウィジェット編集画面を使用（管理画面 > 外観 > ウィジェット）

### 手順

#### Before（修正前の再現手順）
1. 「VK 最近の投稿」ウィジェットをサイドバー等に追加する
2. ウィジェットの「タイトル」欄を **空欄** のまま保存する
3. ウィジェット編集フォームを開き直す（フォームが再描画される）
4. `wp-content/debug.log` を確認する
   → ✗ `PHP Warning: Undefined array key "label" ... widget-new-posts.php` が記録される

#### After（修正後）
1. 「VK 最近の投稿」ウィジェットの「タイトル」欄を **空欄** のまま保存する
2. ウィジェット編集フォームを開き直す
3. `wp-content/debug.log` を確認する
   → ✓ `Undefined array key "label"` の Warning が記録されない
4. 「タイトル」欄に任意の文字列（例: `新着情報`）を入力して保存する
   → ✓ フォームおよび公開側にタイトルが正しく表示される（デグレしていない）

Refs #1410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 管理画面でウィジェットのタイトル表示をフロント側と同じ判定に統一し、未設定時に表示されていた警告を回避しました。
  * `title` や `label` が空の場合でも、安定してタイトルを扱えるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->