### PR TITLE
[ 不具合修正 ][ 投稿タイプマネージャー ] PHP 8 で旧データの再登録時に array_keys() が TypeError となり Fatal Error を引き起こす不具合を修正

### DIFF
--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -856,11 +856,13 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 					);
 
 					$post_type_items = get_post_meta( $post->ID, 'veu_post_type_items', true );
-					if ( ! $post_type_items ) {
-						// メタ未保存（旧データ）時は title サポートを既定にする。
-						// 直後の array_keys() でキーを supports に用いるため、リストではなく連想配列で初期化する（array( 'title' ) だとキーが 0 になり title が付与されない）。
-						// Default to title support when the meta is unsaved (legacy data).
-						// Initialize as an associative array (not a list) because the following array_keys() maps keys to supports; array( 'title' ) would yield key 0 and drop title support.
+					if ( ! is_array( $post_type_items ) || empty( $post_type_items ) ) {
+						// メタ未保存（旧データ）や、配列以外の値が保存されていた場合は title サポートを既定にする。
+						// 直後の array_keys() に配列以外を渡すと PHP 8 系で TypeError になるため、ここで正規化しておく。
+						// キーを supports に用いるため、リストではなく連想配列で初期化する（array( 'title' ) だとキーが 0 になり title が付与されない）。
+						// Default to title support when the meta is unsaved (legacy data) or is not an array.
+						// Normalize here because passing a non-array to the following array_keys() throws a TypeError on PHP 8.
+						// Initialize as an associative array (not a list) because array_keys() maps keys to supports; array( 'title' ) would yield key 0 and drop title support.
 						$post_type_items = array( 'title' => 'true' );
 					}
 					// $supports を明示初期化（PHP 8 系の Warning 対策） / Initialize $supports explicitly to avoid PHP 8 warnings.

--- a/inc/post-type-manager/package/class.post-type-manager.php
+++ b/inc/post-type-manager/package/class.post-type-manager.php
@@ -865,11 +865,9 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 						// Initialize as an associative array (not a list) because array_keys() maps keys to supports; array( 'title' ) would yield key 0 and drop title support.
 						$post_type_items = array( 'title' => 'true' );
 					}
-					// $supports を明示初期化（PHP 8 系の Warning 対策） / Initialize $supports explicitly to avoid PHP 8 warnings.
-					$supports = array();
-					foreach ( array_keys( $post_type_items ) as $key ) {
-						$supports[] = $key;
-					}
+					// $post_type_items は上のガードで必ず配列になっているため、そのキー一覧をそのまま supports に用いる。
+					// $post_type_items is guaranteed to be an array by the guard above, so use its keys directly as supports.
+					$supports = array_keys( $post_type_items );
 
 					// 強制サポートする項目（issue #1322）。配列にしておくことで将来の追加要件にも対応しやすくする.
 					// Forced supports (issue #1322). Kept as an array for future extensibility.

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ e.g.
 [ Bug Fix ] Fixed PHP warnings, notices and deprecations ( and a potential fatal error ) logged in debug mode on recent PHP versions, while keeping PHP 7.4 support.
 [ Bug Fix ][ CTA ] Fixed the CTA image not being saved and the button text / message losing their allowed HTML when saved from the classic edit screen.
 [ Bug Fix ][ Custom Post Type Manager ] Fixed custom post types saved by older versions losing "title" support when re-registered.
+[ Bug Fix ][ Custom Post Type Manager ] Fixed a fatal TypeError on PHP 8 when re-registering a custom post type whose legacy support data was not stored as an array.
 
 = 9.118.0 =
 [ New Feature ][ SNS Share Button ] Added a Threads share button, with a show / hide toggle under ExUnit > Main Setting.

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -161,6 +161,19 @@ class CTATest extends WP_UnitTestCase {
 		$raw_url         = 'https://example.com/?q=<script>';
 		$raw_img_id      = '123<script>';
 
+		// アイコン系フィールドは wp_kses_post のみ（stripslashes なし）で保存される。
+		// ただし WordPress コアは post meta 保存時（add_post_meta / update_post_meta）に wp_unslash を1回かけるため、
+		// 単一バックスラッシュでは stripslashes 有無を区別できない。二重バックスラッシュ（ \\ ）を用いると、
+		// アイコン系（コアの unslash 1回のみ）は \ が1つ残るのに対し、テキスト系（プラグインの stripslashes ＋ コアの unslash ＝ 2回）は \ が消える。
+		// これによりアイコン系に stripslashes が適用されていない事を検証できる。
+		// Icon fields are stored via wp_kses_post only ( no stripslashes ). WordPress core, however, runs wp_unslash once
+		// when saving post meta, so a single backslash cannot distinguish the icon path from the text path.
+		// A doubled backslash ( \\ ) can: the icon path ( only core's single unslash ) keeps one backslash,
+		// whereas the text path ( plugin stripslashes + core unslash = two levels ) would drop it.
+		$raw_button_icon        = "<i class=\"fa fa-star\"></i>a\\\\b<script>alert(3)</script>";
+		$raw_button_icon_before = "<span class=\"dashicons dashicons-arrow-left\"></span>a\\\\b<script>alert(4)</script>";
+		$raw_button_icon_after  = "<em>after a\\\\b</em><script>alert(5)</script>";
+
 		// 各フィールドの入力値と save_custom_field() 適用後に期待されるサニタイズ結果を1つの配列で表現し、
 		// $_POST の組み立てと保存結果の検証を同じ配列でループして行う。
 		// Express each field's input and its expected sanitized output in a single array, and drive both the $_POST setup and the assertions from it in a loop.
@@ -204,24 +217,26 @@ class CTATest extends WP_UnitTestCase {
 				'expected' => wp_kses_post( stripslashes( $raw_cta_text ) ),
 			),
 			array(
-				// アイコン系は限定HTML（許可タグ）を保持しつつ <script> 等が除去される（stripslashes なし）。
-				// Icon fields keep allowed HTML while stripping disallowed tags such as <script> ( no stripslashes ).
-				'name'     => 'button_icon は wp_kses_post のみでサニタイズされる（許可タグ保持）',
+				// アイコン系は限定HTML（許可タグ）を保持しつつ <script> 等が除去される。plugin では stripslashes を通さないため、
+				// コアの unslash 1回のみが効き、二重バックスラッシュが1つ残る（期待値は wp_unslash( wp_kses_post( 入力 ) )）。
+				// Icon fields keep allowed HTML while stripping <script>. The plugin does not apply stripslashes,
+				// so only core's single unslash applies and one backslash survives ( expected = wp_unslash( wp_kses_post( input ) ) ).
+				'name'     => 'button_icon は wp_kses_post のみで保存され stripslashes されない（許可タグ保持・二重\\は1つ残存）',
 				'field'    => 'vkExUnit_cta_button_icon',
-				'input'    => '<i class="fa fa-star"></i><script>alert(3)</script>',
-				'expected' => wp_kses_post( '<i class="fa fa-star"></i><script>alert(3)</script>' ),
+				'input'    => $raw_button_icon,
+				'expected' => wp_unslash( wp_kses_post( $raw_button_icon ) ),
 			),
 			array(
-				'name'     => 'button_icon_before は wp_kses_post のみでサニタイズされる（許可タグ保持）',
+				'name'     => 'button_icon_before は wp_kses_post のみで保存され stripslashes されない（許可タグ保持・二重\\は1つ残存）',
 				'field'    => 'vkExUnit_cta_button_icon_before',
-				'input'    => '<span class="dashicons dashicons-arrow-left"></span><script>alert(4)</script>',
-				'expected' => wp_kses_post( '<span class="dashicons dashicons-arrow-left"></span><script>alert(4)</script>' ),
+				'input'    => $raw_button_icon_before,
+				'expected' => wp_unslash( wp_kses_post( $raw_button_icon_before ) ),
 			),
 			array(
-				'name'     => 'button_icon_after は wp_kses_post のみでサニタイズされる（<script> 除去・異常系）',
+				'name'     => 'button_icon_after は wp_kses_post のみで保存され stripslashes されない（<script> 除去・二重\\は1つ残存）',
 				'field'    => 'vkExUnit_cta_button_icon_after',
-				'input'    => '<em>after</em><script>alert(5)</script>',
-				'expected' => wp_kses_post( '<em>after</em><script>alert(5)</script>' ),
+				'input'    => $raw_button_icon_after,
+				'expected' => wp_unslash( wp_kses_post( $raw_button_icon_after ) ),
 			),
 		);
 

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -159,54 +159,91 @@ class CTATest extends WP_UnitTestCase {
 		$raw_button_text = "Click <script>alert(1)</script> O\\'Clock";
 		$raw_cta_text    = "Line 1\\nLine 2<script>alert(2)</script>";
 		$raw_url         = 'https://example.com/?q=<script>';
-		// vkExUnit_cta_img はアタッチメントIDを保持するフィールドなので、
-		// 数値以外が混入しても absint で整数（IDのみ）に正規化される事を検証する。
-		// vkExUnit_cta_img stores an attachment ID, so verify that non-numeric junk is normalized to the integer ID via absint.
-		$raw_img_id = '123<script>';
+		$raw_img_id      = '123<script>';
 
-		// アイコン系フィールドは限定HTML（許可タグ）を保持しつつ <script> 等が除去される事を検証する。
-		// Icon fields keep allowed HTML while stripping disallowed tags such as <script>.
-		$raw_icon_fields = array(
-			'vkExUnit_cta_button_icon'        => '<i class="fa fa-star"></i><script>alert(3)</script>',
-			'vkExUnit_cta_button_icon_before' => '<span class="dashicons dashicons-arrow-left"></span><script>alert(4)</script>',
-			'vkExUnit_cta_button_icon_after'  => '<em>after</em><script>alert(5)</script>',
+		// 各フィールドの入力値と save_custom_field() 適用後に期待されるサニタイズ結果を1つの配列で表現し、
+		// $_POST の組み立てと保存結果の検証を同じ配列でループして行う。
+		// Express each field's input and its expected sanitized output in a single array, and drive both the $_POST setup and the assertions from it in a loop.
+		$field_cases = array(
+			array(
+				'name'     => 'use_type はそのまま保持される（正常系）',
+				'field'    => 'vkExUnit_cta_use_type',
+				'input'    => 'veu_cta_normal',
+				'expected' => 'veu_cta_normal',
+			),
+			array(
+				// vkExUnit_cta_img はアタッチメントIDを保持するため、数値以外が混入しても absint で整数（IDのみ）に正規化される。
+				// vkExUnit_cta_img stores an attachment ID, so non-numeric junk is normalized to the integer ID via absint.
+				'name'     => 'img はアタッチメントID（整数文字列）へ正規化される（境界値）',
+				'field'    => 'vkExUnit_cta_img',
+				'input'    => $raw_img_id,
+				'expected' => (string) absint( $raw_img_id ),
+			),
+			array(
+				'name'     => 'button_text は stripslashes + wp_kses_post でサニタイズされる（正常系）',
+				'field'    => 'vkExUnit_cta_button_text',
+				'input'    => $raw_button_text,
+				'expected' => wp_kses_post( stripslashes( $raw_button_text ) ),
+			),
+			array(
+				'name'     => 'url は esc_url でサニタイズされる（正常系）',
+				'field'    => 'vkExUnit_cta_url',
+				'input'    => $raw_url,
+				'expected' => esc_url( $raw_url ),
+			),
+			array(
+				'name'     => 'url_blank はそのまま保持される（正常系）',
+				'field'    => 'vkExUnit_cta_url_blank',
+				'input'    => 'window_self',
+				'expected' => 'window_self',
+			),
+			array(
+				'name'     => 'text は stripslashes + wp_kses_post でサニタイズされる（正常系）',
+				'field'    => 'vkExUnit_cta_text',
+				'input'    => $raw_cta_text,
+				'expected' => wp_kses_post( stripslashes( $raw_cta_text ) ),
+			),
+			array(
+				// アイコン系は限定HTML（許可タグ）を保持しつつ <script> 等が除去される（stripslashes なし）。
+				// Icon fields keep allowed HTML while stripping disallowed tags such as <script> ( no stripslashes ).
+				'name'     => 'button_icon は wp_kses_post のみでサニタイズされる（許可タグ保持）',
+				'field'    => 'vkExUnit_cta_button_icon',
+				'input'    => '<i class="fa fa-star"></i><script>alert(3)</script>',
+				'expected' => wp_kses_post( '<i class="fa fa-star"></i><script>alert(3)</script>' ),
+			),
+			array(
+				'name'     => 'button_icon_before は wp_kses_post のみでサニタイズされる（許可タグ保持）',
+				'field'    => 'vkExUnit_cta_button_icon_before',
+				'input'    => '<span class="dashicons dashicons-arrow-left"></span><script>alert(4)</script>',
+				'expected' => wp_kses_post( '<span class="dashicons dashicons-arrow-left"></span><script>alert(4)</script>' ),
+			),
+			array(
+				'name'     => 'button_icon_after は wp_kses_post のみでサニタイズされる（<script> 除去・異常系）',
+				'field'    => 'vkExUnit_cta_button_icon_after',
+				'input'    => '<em>after</em><script>alert(5)</script>',
+				'expected' => wp_kses_post( '<em>after</em><script>alert(5)</script>' ),
+			),
 		);
 
+		// テストケースから $_POST を組み立てる。
+		// Build $_POST from the test cases.
 		$_POST = array(
 			'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
 			'_vkExUnit_cta_switch'       => 'cta_content',
-			'vkExUnit_cta_use_type'      => 'veu_cta_normal',
-			'vkExUnit_cta_img'           => $raw_img_id,
-			'vkExUnit_cta_button_text'   => $raw_button_text,
-			'vkExUnit_cta_url'           => $raw_url,
-			'vkExUnit_cta_url_blank'     => 'window_self',
-			'vkExUnit_cta_text'          => $raw_cta_text,
 		);
-		// アイコン系フィールドを $_POST に合流する。
-		// Merge the icon fields into $_POST.
-		$_POST = array_merge( $_POST, $raw_icon_fields );
+		foreach ( $field_cases as $case ) {
+			$_POST[ $case['field'] ] = $case['input'];
+		}
 
 		Vk_Call_To_Action::save_custom_field( $post_id );
 
-		$this->assertSame( 'veu_cta_normal', get_post_meta( $post_id, 'vkExUnit_cta_use_type', true ) );
-		$this->assertSame( (string) absint( $raw_img_id ), get_post_meta( $post_id, 'vkExUnit_cta_img', true ) );
-		$this->assertSame(
-			wp_kses_post( stripslashes( $raw_button_text ) ),
-			get_post_meta( $post_id, 'vkExUnit_cta_button_text', true )
-		);
-		$this->assertSame( esc_url( $raw_url ), get_post_meta( $post_id, 'vkExUnit_cta_url', true ) );
-		$this->assertSame( 'window_self', get_post_meta( $post_id, 'vkExUnit_cta_url_blank', true ) );
-		$this->assertSame(
-			wp_kses_post( stripslashes( $raw_cta_text ) ),
-			get_post_meta( $post_id, 'vkExUnit_cta_text', true )
-		);
-		// アイコン系フィールドは wp_kses_post のみ（stripslashes なし）でサニタイズされる事を検証する。
-		// Verify the icon fields are sanitized with wp_kses_post only ( no stripslashes ).
-		foreach ( $raw_icon_fields as $icon_field => $icon_raw ) {
+		// 各フィールドが期待どおりサニタイズされて保存されている事を検証する。
+		// Assert each field is saved with the expected sanitized value.
+		foreach ( $field_cases as $case ) {
 			$this->assertSame(
-				wp_kses_post( $icon_raw ),
-				get_post_meta( $post_id, $icon_field, true ),
-				$icon_field
+				$case['expected'],
+				get_post_meta( $post_id, $case['field'], true ),
+				$case['name']
 			);
 		}
 	}

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -164,6 +164,14 @@ class CTATest extends WP_UnitTestCase {
 		// vkExUnit_cta_img stores an attachment ID, so verify that non-numeric junk is normalized to the integer ID via absint.
 		$raw_img_id = '123<script>';
 
+		// アイコン系フィールドは限定HTML（許可タグ）を保持しつつ <script> 等が除去される事を検証する。
+		// Icon fields keep allowed HTML while stripping disallowed tags such as <script>.
+		$raw_icon_fields = array(
+			'vkExUnit_cta_button_icon'        => '<i class="fa fa-star"></i><script>alert(3)</script>',
+			'vkExUnit_cta_button_icon_before' => '<span class="dashicons dashicons-arrow-left"></span><script>alert(4)</script>',
+			'vkExUnit_cta_button_icon_after'  => '<em>after</em><script>alert(5)</script>',
+		);
+
 		$_POST = array(
 			'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
 			'_vkExUnit_cta_switch'       => 'cta_content',
@@ -174,6 +182,9 @@ class CTATest extends WP_UnitTestCase {
 			'vkExUnit_cta_url_blank'     => 'window_self',
 			'vkExUnit_cta_text'          => $raw_cta_text,
 		);
+		// アイコン系フィールドを $_POST に合流する。
+		// Merge the icon fields into $_POST.
+		$_POST = array_merge( $_POST, $raw_icon_fields );
 
 		Vk_Call_To_Action::save_custom_field( $post_id );
 
@@ -189,6 +200,15 @@ class CTATest extends WP_UnitTestCase {
 			wp_kses_post( stripslashes( $raw_cta_text ) ),
 			get_post_meta( $post_id, 'vkExUnit_cta_text', true )
 		);
+		// アイコン系フィールドは wp_kses_post のみ（stripslashes なし）でサニタイズされる事を検証する。
+		// Verify the icon fields are sanitized with wp_kses_post only ( no stripslashes ).
+		foreach ( $raw_icon_fields as $icon_field => $icon_raw ) {
+			$this->assertSame(
+				wp_kses_post( $icon_raw ),
+				get_post_meta( $post_id, $icon_field, true ),
+				$icon_field
+			);
+		}
 	}
 
 	/**

--- a/tests/test-isert-ads.php
+++ b/tests/test-isert-ads.php
@@ -56,6 +56,15 @@ class InsertAdsTest extends WP_UnitTestCase {
 					'after'  => array( '' ),
 				),
 			),
+			array(
+				'test_condition_name' => 'input が null（当該オプション群が $_POST に無い一括保存時）=> offset-on-null / stripslashes(null) を出さず既定値を返す（異常系）',
+				'input'               => null,
+				'expected'            => array(
+					'before' => array( '' ),
+					'more'   => array( '' ),
+					'after'  => array( '' ),
+				),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {


### PR DESCRIPTION
## 概要

PR #1412（PHP 8系の Warning / Notice / Deprecation / Fatal Error 修正）のマージ後に届いた CodeRabbit の追加レビュー指摘への対応を、独立した PR として切り出したものです。#1412 は当該対応の push 前にマージされたため、本 PR で追補します。

対象は **投稿タイプマネージャーの潜在的な Fatal Error（TypeError）の修正**（製品コード）と、それに関連する **テストの拡充・整理**（開発環境）です。

## 主な変更

### 1. 投稿タイプマネージャーの TypeError 修正（製品コード）
`inc/post-type-manager/package/class.post-type-manager.php`

- `veu_post_type_items` メタが**配列以外の値（旧データ・破損データ）**で保存されていた場合、従来の `if ( ! $post_type_items )` では非空文字列を弾けず、直後の `array_keys()` に配列以外が渡って **PHP 8 系で Fatal な TypeError**（`array_keys(): Argument #1 ($array) must be of type array`）となる恐れがありました。
- ガードを `if ( ! is_array( $post_type_items ) || empty( $post_type_items ) )` に変更し、配列以外・空値を `title` サポート既定（連想配列）へ正規化するようにしました。

### 2. テストの拡充・整理（開発環境）
- `tests/test-isert-ads.php` — `vExUnit_Ads::sanitize_config()` に **`input => null`**（当該オプション群が `$_POST` に無い一括保存時）のケースを追加し、offset-on-null / `stripslashes(null)` を出さず既定値を返す事を検証。
- `tests/test-cta.php` — `test_save_custom_field_cta_content_sanitizes_fields()` を **全9フィールドの入力値／期待サニタイズ結果を単一のケース配列で表現し、`$_POST` 組み立てと検証を同じ配列でループ**する形式へ統一（PHPUnit 方針準拠）。あわせて未検証だったアイコン系フィールド（`vkExUnit_cta_button_icon` / `_before` / `_after`）の `wp_kses_post` カバレッジを追加。

## 確認手順

### A. 自動テスト（回帰確認）
1. `composer install` 後に `npm run phpunit` を実行する
   → **全テストが pass** すること。特に以下が緑になること:
   - `test_sanitize_config`（null 入力ケースを含む）
   - `test_save_custom_field_cta_content_sanitizes_fields`（全9フィールド・アイコン含む / 9 assertions）
   - 投稿タイプマネージャーのテスト一式（`test_save_cf_value_missing_supports_still_saves_with_forced_custom_fields` 等）

### B. TypeError 修正の手動確認（Before / After）
前提: PHP 8.x・`WP_DEBUG` 有効。

1. 任意の投稿タイプマネージャーの CPT 投稿に対し、旧データ相当として `veu_post_type_items` メタを**配列でない文字列**で保存する（例: `update_post_meta( $cpt_post_id, 'veu_post_type_items', 'title' );`）。
2. 管理画面を再読み込みするなどして投稿タイプ登録処理（`register_custom_post_types` 相当）を走らせる。
   - **Before（修正前）**: `array_keys()` に文字列が渡り、PHP 8 で **TypeError（Fatal Error）** が発生し得る。
   - **After（修正後）**: → `title` サポート既定に正規化され、TypeError が発生せず正常に登録される。

## 補足
- 表示（UI）の見た目を変える変更は含みません（Fatal 回避とテストのみ）。スクリーンショットは省略します。
- 本 PR の TypeError 修正は #1412 の広域エントリ（"a potential fatal error"）とは別に、投稿タイプマネージャー固有の Fatal として `readme.txt` の Changelog に個別エントリを追記しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PHP 8 環境で、カスタム投稿タイプの再登録時に発生する致命的エラーを修正しました。
  * サポート設定が配列でない／空の場合でも、既定値へ安全に正規化するようになりました。
  * 一括保存時に未入力があっても、広告設定の保存処理が警告なく動作します。
* **Documentation**
  * Changelog に PHP 8 環境での不具合修正内容を追記しました。
* **Tests**
  * CTA 入力のサニタイズをテーブル駆動で検証する形に強化しました。
  * 広告設定の sanitize 時に `input=null` の既定値動作を追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->