### PR TITLE
[ 仕様変更 ] font-awesome-versions を 0.7.4 から 0.7.5 に更新

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"vektor-inc/vk-admin": "^0.8.0",
 		"vektor-inc/vk-breadcrumb": "^0.2.9",
 		"vektor-inc/vk-helpers": "^0.3.0",
-		"vektor-inc/font-awesome-versions": "^0.7.4",
+		"vektor-inc/font-awesome-versions": "^0.7.5",
 		"vektor-inc/vk-term-color": "^0.7.1",
 		"vektor-inc/vk-css-optimize": "^0.2.5"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b016d375a4d88b9060bd14366ee5422e",
+    "content-hash": "37bff8eec41fcf1a90c2efdb8584d419",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ e.g.
 
 == Changelog ==
 
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5
 [ Bug Fix ][ Widget ] Fixed a PHP warning that occurred on the admin widget form of the Recent Posts widget when its title was empty.
 [ Bug Fix ] Fixed PHP warnings, notices and deprecations ( and a potential fatal error ) logged in debug mode on recent PHP versions, while keeping PHP 7.4 support.
 [ Bug Fix ][ CTA ] Fixed the CTA image not being saved and the button text / message losing their allowed HTML when saved from the classic edit screen.


### PR DESCRIPTION
## 概要

`vektor-inc/font-awesome-versions` を 0.7.4 から 0.7.5 に更新します。

`composer.lock` は先行して 0.7.5 に更新済みでしたが、`composer.json` の制約が `^0.7.4` のままで不整合（lock ハッシュも古い状態）だったため、`composer.json` の制約を `^0.7.5` に揃え、`composer.lock` のハッシュを再生成し、changelog に更新エントリを追記しました。

font-awesome-versions 0.7.5 には、旧 Font Awesome バージョン設定が残存すると Fatal Error で画面全体が表示不能になる不具合の修正が含まれます。

### 変更ファイル

- `composer.json` — `vektor-inc/font-awesome-versions` の制約を `^0.7.4` → `^0.7.5`
- `composer.lock` — content-hash を再生成（パッケージバージョンは既に 0.7.5）
- `readme.txt` — changelog に `[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5` を追記

## 確認手順

1. このブランチをチェックアウトする
   → `git checkout update/font-awesome-versions-0.7.5`
2. 依存関係をインストールする
   → `composer install`
3. lock と composer.json の整合性を確認する
   → `composer validate --no-check-publish --no-check-all` を実行
   → `./composer.json is valid` と表示され、`Lock file errors` が出ないこと
4. インストールされた font-awesome-versions のバージョンを確認する
   → `composer show vektor-inc/font-awesome-versions | grep versions`
   → `versions : * 0.7.5` と表示されること
5. オートロードが機能することを確認する
   → `php -r 'require "vendor/autoload.php"; var_dump(class_exists("VektorInc\\VK_Font_Awesome_Versions\\VkFontAwesomeVersions"));'`
   → `bool(true)` が返ること

## デグレ確認

- 純粋な依存バージョン更新のため表示・UI 変更なし（スクリーンショット省略）
- PHPCS lint（pre-commit フック）が通過することを確認済み


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存パッケージのバージョン要件を更新し、最新の修正版を利用できるようになりました。
* **Documentation**
  * 変更履歴に、今回のバージョン更新に関する記載を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->