### PR TITLE
[ 仕様変更 ] 装飾アイコンを読み上げから除外・アイコンのみリンクに読み上げ名を付与

### DIFF
--- a/admin/admin-post-metabox.php
+++ b/admin/admin-post-metabox.php
@@ -71,8 +71,10 @@ function veu_parent_metabox_body() {
 	echo '<div class="veu_metabox_nav">';
 	// ▼ Toggle Button
 	echo '<p class="veu_metabox_all_section_toggle close">';
-	echo '<button class="button button-default veu_metabox_all_section_toggle_btn_open">' . __( 'Open all', 'vk-all-in-one-expansion-unit' ) . ' <i class="fas fa-caret-down"></i></button> ';
-	echo '<button class="button button-default veu_metabox_all_section_toggle_btn_close">' . __( 'Close all', 'vk-all-in-one-expansion-unit' ) . ' <i class="fas fa-caret-up"></i></button>';
+	// ボタン内の開閉状態を示す装飾キャレット。ボタンに可視テキスト（Open all / Close all）があるため読み上げから除外する。
+	// Decorative carets indicating the open/close state inside the buttons. The buttons have visible text (Open all / Close all), so hide them from screen readers.
+	echo '<button class="button button-default veu_metabox_all_section_toggle_btn_open">' . __( 'Open all', 'vk-all-in-one-expansion-unit' ) . ' <i class="fas fa-caret-down" aria-hidden="true"></i></button> ';
+	echo '<button class="button button-default veu_metabox_all_section_toggle_btn_close">' . __( 'Close all', 'vk-all-in-one-expansion-unit' ) . ' <i class="fas fa-caret-up" aria-hidden="true"></i></button>';
 	echo '</p>';
 	// ▲ Toggle Button
 	echo '</div>';

--- a/admin/class-veu-metabox.php
+++ b/admin/class-veu-metabox.php
@@ -106,8 +106,10 @@ class VEU_Metabox {
 			// Section title
 			if ( ! empty( $this->args['title'] ) ) {
 				echo '<h3 class="veu_metabox_section_title">' . wp_kses_post( $this->args['title'] ) . '';
-				echo '<span class="veu_metabox_section_title_status_btn close"><i class="fas fa-caret-down"></i></span>';
-				echo '<span class="veu_metabox_section_title_status_btn open"><i class="fas fa-caret-up"></i></span>';
+				// セクションの開閉状態を示す装飾キャレット。見出し（h3）にタイトル文字が見えているため読み上げから除外する。
+				// Decorative carets indicating the section's open/close state. The title text is visible in the heading (h3), so hide them from screen readers.
+				echo '<span class="veu_metabox_section_title_status_btn close"><i class="fas fa-caret-down" aria-hidden="true"></i></span>';
+				echo '<span class="veu_metabox_section_title_status_btn open"><i class="fas fa-caret-up" aria-hidden="true"></i></span>';
 				echo '</h3>';
 			}
 			echo '<div class="veu_metabox_section_body">';

--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -231,8 +231,12 @@ function veu_cta_block_callback( $attributes, $content ) {
 								$icon_class = $raw;
 							}
 
+							// ボタンラベルの前に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する。
+							// トグル非依存で属性を揃えるためインラインで付与する（render_block フィルタは付与済み aria-hidden をスキップするので二重付与にならない）。
+							// Decorative icon before the button label; the label text is in the same button, so hide it from screen readers.
+							// Added inline so the attribute is present regardless of the toggle ( the render_block filter skips <i> that already has aria-hidden, so it is not applied twice ).
 							$btn_before = $icon_class
-								? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon"></i> '
+								? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon" aria-hidden="true"></i> '
 								: '';
 						}
 
@@ -248,8 +252,10 @@ function veu_cta_block_callback( $attributes, $content ) {
 								// クラス名のみが入っているケース
 								$icon_class = $raw;
 							}
+							// ボタンラベルの後に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する（トグル非依存でインライン付与）。
+							// Decorative icon after the button label; the label text is in the same button, so hide it from screen readers ( added inline, toggle-independent ).
 							$btn_after = $icon_class
-								? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon"></i> '
+								? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon" aria-hidden="true"></i> '
 								: '';
 						}
 

--- a/inc/call-to-action/package/view-actionbox.php
+++ b/inc/call-to-action/package/view-actionbox.php
@@ -25,8 +25,10 @@ if ( $btn_before ) {
 		$icon_class = $raw;
 	}
 
+	// ボタンラベルの前に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する。
+	// Decorative icon before the button label. The label text is in the same button, so hide it from screen readers.
 	$btn_before = $icon_class
-		? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon"></i> '
+		? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon" aria-hidden="true"></i> '
 		: '';
 }
 $btn_after = get_post_meta( $id, 'vkExUnit_cta_button_icon_after', true );
@@ -41,8 +43,10 @@ if ( $btn_after ) {
 		$icon_class = $raw;
 	}
 
+	// ボタンラベルの後に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する。
+	// Decorative icon after the button label. The label text is in the same button, so hide it from screen readers.
 	$btn_after = $icon_class
-		? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon"></i> '
+		? '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon" aria-hidden="true"></i> '
 		: '';
 }
 $url   = get_post_meta( $id, 'vkExUnit_cta_url', true );

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -369,8 +369,11 @@ class VkExUnit_Contact {
 				// ここで組み立て直す出力に必ず aria-hidden="true" を付けて読み上げから除外する。
 				// Decorative icon next to the phone number text. Whether the saved value is a class string or a
 				// full <i> tag, the output rebuilt here always gets aria-hidden="true" to hide it from screen readers.
-				// $options['tel_icon'] の中が <i class="fas fa-mobile-alt"></i> など i タグの場合
-				if ( preg_match( '/<i class="(.+?)"><\/i>/', $options['tel_icon'], $matches ) ) {
+				// $options['tel_icon'] の中が <i class="fas fa-mobile-alt"></i> など i タグの場合、
+				// 属性の順序や他の属性の有無に依らず class 属性の値だけを取り出す。
+				// When $options['tel_icon'] holds an <i> tag ( e.g. <i class="fas fa-mobile-alt"></i> ),
+				// extract only the class attribute value regardless of attribute order or extra attributes.
+				if ( preg_match( '/<i[^>]*\bclass=["\']([^"\']*)["\']/', $options['tel_icon'], $matches ) ) {
 					$tel_icon = '<i class="contact_txt_tel_icon ' . esc_attr( $matches[1] ) . '" aria-hidden="true"></i>';
 				} else {
 					$tel_icon = '<i class="contact_txt_tel_icon ' . esc_attr( $options['tel_icon'] ) . '" aria-hidden="true"></i>';

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -365,11 +365,15 @@ class VkExUnit_Contact {
 
 			$tel_icon = '';
 			if ( ! empty( $options['tel_icon'] ) ) {
+				// 電話番号テキストの隣に置く装飾アイコン。保存値がクラス文字列でも <i> 丸ごとでも、
+				// ここで組み立て直す出力に必ず aria-hidden="true" を付けて読み上げから除外する。
+				// Decorative icon next to the phone number text. Whether the saved value is a class string or a
+				// full <i> tag, the output rebuilt here always gets aria-hidden="true" to hide it from screen readers.
 				// $options['tel_icon'] の中が <i class="fas fa-mobile-alt"></i> など i タグの場合
 				if ( preg_match( '/<i class="(.+?)"><\/i>/', $options['tel_icon'], $matches ) ) {
-					$tel_icon = '<i class="contact_txt_tel_icon ' . esc_attr( $matches[1] ) . '"></i>';
+					$tel_icon = '<i class="contact_txt_tel_icon ' . esc_attr( $matches[1] ) . '" aria-hidden="true"></i>';
 				} else {
-					$tel_icon = '<i class="contact_txt_tel_icon ' . esc_attr( $options['tel_icon'] ) . '"></i>';
+					$tel_icon = '<i class="contact_txt_tel_icon ' . esc_attr( $options['tel_icon'] ) . '" aria-hidden="true"></i>';
 				}
 			}
 
@@ -386,12 +390,14 @@ class VkExUnit_Contact {
 			if ( $options['contact_link'] && $options['button_text'] ) {
 				$cont .= '<a href="' . $options['contact_link'] . '"' . $link_target . ' class="btn btn-primary btn-lg contact_bt">';
 				$cont .= '<span class="contact_bt_txt">';
-				$cont .= '<i class="fa-regular fa-envelope"></i> ';
+				// ボタンラベルの前後に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する。
+				// Decorative icons before / after the button label. The label text is in the same button, so hide them from screen readers.
+				$cont .= '<i class="fa-regular fa-envelope" aria-hidden="true"></i> ';
 
 				$cont .= wp_kses_post( $options['button_text'] );
 
 				// Arrow Icon
-				$cont .= ' <i class="fa-regular fa-circle-right"></i>';
+				$cont .= ' <i class="fa-regular fa-circle-right" aria-hidden="true"></i>';
 
 				$cont .= '</span>';
 
@@ -432,12 +438,14 @@ class VkExUnit_Contact {
 		) {
 			$cont .= '<a href="' . esc_url( $options['contact_link'] ) . '"' . $link_target . ' class="btn btn-primary btn-lg btn-block contact_bt"><span class="contact_bt_txt">';
 
-			$cont .= '<i class="fa-regular fa-envelope"></i> ';
+			// ボタンラベルの前後に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する。
+			// Decorative icons before / after the button label. The label text is in the same button, so hide them from screen readers.
+			$cont .= '<i class="fa-regular fa-envelope" aria-hidden="true"></i> ';
 
 			$cont .= wp_kses_post( $options['short_text'] );
 
 			// Arrow Icon
-			$cont .= ' <i class="fa-regular fa-circle-right"></i>';
+			$cont .= ' <i class="fa-regular fa-circle-right" aria-hidden="true"></i>';
 
 			$cont .= '</span>';
 			if ( isset( $options['button_text_small'] ) && $options['button_text_small'] ) {

--- a/inc/other-widget/widget-button.php
+++ b/inc/other-widget/widget-button.php
@@ -93,7 +93,9 @@ class WP_Widget_Button extends WP_Widget {
 					// クラス名のみが入っているケース
 					$icon_class = $instance['icon_before'];
 				}
-				echo '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon"></i>';
+				// ボタンラベルの前に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する。
+				// Decorative icon before the button label. The label text is in the same button, so hide it from screen readers.
+				echo '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon" aria-hidden="true"></i>';
 			}
 
 			echo wp_kses_post( $options['title'] );
@@ -107,7 +109,9 @@ class WP_Widget_Button extends WP_Widget {
 					// クラス名のみが入っているケース
 					$icon_class = $instance['icon_after'];
 				}
-				echo '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon"></i>';
+				// ボタンラベルの後に置く装飾アイコン。同じボタン内にラベルテキストがあるため読み上げから除外する。
+				// Decorative icon after the button label. The label text is in the same button, so hide it from screen readers.
+				echo '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon" aria-hidden="true"></i>';
 			}
 			?>
 

--- a/inc/other-widget/widget-pr-blocks.php
+++ b/inc/other-widget/widget-pr-blocks.php
@@ -298,7 +298,9 @@ class WP_Widget_vkExUnit_PR_Blocks extends WP_Widget {
 						// クラス名のみが入っているケース
 						$icon_class = $instance[ 'iconFont_class_' . $i ];
 					}
-					echo '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon prBlock_icon"' . $icon_styles . '></i></div>' . PHP_EOL;
+					// PR ブロックのタイトル・本文が同じブロック内にあるため、アイコンは装飾として読み上げから除外する。
+					// The PR block's title and body are in the same block, so the icon is decorative and hidden from screen readers.
+					echo '<i class="' . $fa . esc_attr( $icon_class ) . ' font_icon prBlock_icon"' . $icon_styles . ' aria-hidden="true"></i></div>' . PHP_EOL;
 					// image display
 				} elseif ( ! empty( $instance[ 'media_image_' . $i ] ) ) {
 					echo '<div class="prBlock_image" style="background:url(' . esc_url( $instance[ 'media_image_' . $i ] ) . ') no-repeat 50% center;background-size: cover;">';

--- a/inc/other-widget/widget-profile.php
+++ b/inc/other-widget/widget-profile.php
@@ -438,34 +438,50 @@ class WP_Widget_vkExUnit_profile extends WP_Widget {
 			?>
 <ul class="sns_btns">
 			<?php
+			// 各 SNS リンクはアイコンのみで可視テキストが無いため、リンク自体に読み上げ名（aria-label）を付ける。
+			// ブランド名は %s プレースホルダにして文型のみ翻訳する（Follow us on %s など）。
+			// Each SNS link is icon-only with no visible text, so give the link an accessible name ( aria-label ).
+			// Keep the brand name as a %s placeholder and translate only the sentence pattern ( e.g. "Follow us on %s" ).
 			$sns_names = array(
 				array(
-					'name' => 'facebook',
-					'icon' => 'fa-brands fa-facebook-f',
+					'name'       => 'facebook',
+					'icon'       => 'fa-brands fa-facebook-f',
+					/* translators: %s: social media service name */
+					'aria_label' => sprintf( __( 'Follow us on %s', 'vk-all-in-one-expansion-unit' ), 'Facebook' ),
 				),
 				array(
-					'name' => 'twitter',
-					'icon' => 'fa-brands fa-x-twitter',
+					'name'       => 'twitter',
+					'icon'       => 'fa-brands fa-x-twitter',
+					/* translators: %s: social media service name */
+					'aria_label' => sprintf( __( 'Follow us on %s', 'vk-all-in-one-expansion-unit' ), 'X (Twitter)' ),
 				),
 				array(
-					'name' => 'mail',
-					'icon' => 'fa-solid fa-envelope',
+					'name'       => 'mail',
+					'icon'       => 'fa-solid fa-envelope',
+					'aria_label' => __( 'Email', 'vk-all-in-one-expansion-unit' ),
 				),
 				array(
-					'name' => 'youtube',
-					'icon' => 'fa-brands fa-youtube',
+					'name'       => 'youtube',
+					'icon'       => 'fa-brands fa-youtube',
+					/* translators: %s: social media service name */
+					'aria_label' => sprintf( __( 'Follow us on %s', 'vk-all-in-one-expansion-unit' ), 'YouTube' ),
 				),
 				array(
-					'name' => 'rss',
-					'icon' => 'fa-solid fa-rss',
+					'name'       => 'rss',
+					'icon'       => 'fa-solid fa-rss',
+					'aria_label' => __( 'Subscribe via RSS', 'vk-all-in-one-expansion-unit' ),
 				),
 				array(
-					'name' => 'instagram',
-					'icon' => 'fa-brands fa-instagram',
+					'name'       => 'instagram',
+					'icon'       => 'fa-brands fa-instagram',
+					/* translators: %s: social media service name */
+					'aria_label' => sprintf( __( 'Follow us on %s', 'vk-all-in-one-expansion-unit' ), 'Instagram' ),
 				),
 				array(
-					'name' => 'linkedin',
-					'icon' => 'fa-brands fa-linkedin',
+					'name'       => 'linkedin',
+					'icon'       => 'fa-brands fa-linkedin',
+					/* translators: %s: social media service name */
+					'aria_label' => sprintf( __( 'Follow us on %s', 'vk-all-in-one-expansion-unit' ), 'LinkedIn' ),
 				),
 
 			);
@@ -480,7 +496,9 @@ class WP_Widget_vkExUnit_profile extends WP_Widget {
 
 					$sns_name_class = $sns_name['icon'];
 
-					echo '<li class="' . $sns_name['name'] . '_btn"><a href="' . esc_url( $instance[ $sns_name['name'] ] ) . '" target="_blank"' . $outer_css . '><i class="' . $sns_name_class . ' icon"' . $icon_css . '></i></a></li>';
+					// アイコンのみリンク：リンクに aria-label（読み上げ名）を付け、中の <i> は装飾として読み上げから除外する。
+					// Icon-only link: give the link an aria-label ( accessible name ) and hide the inner <i> from screen readers as decoration.
+					echo '<li class="' . $sns_name['name'] . '_btn"><a href="' . esc_url( $instance[ $sns_name['name'] ] ) . '" target="_blank" aria-label="' . esc_attr( $sns_name['aria_label'] ) . '"' . $outer_css . '><i class="' . $sns_name_class . ' icon"' . $icon_css . ' aria-hidden="true"></i></a></li>';
 				} // if ( ! empty( $instance[$sns_name] ) ) :
 			} // foreach ( $sns_names as $key => $sns_name ) {
 			?>

--- a/inc/promotion-alert/package/class-veu-promotion-alert.php
+++ b/inc/promotion-alert/package/class-veu-promotion-alert.php
@@ -437,8 +437,10 @@ class VEU_Promotion_Alert {
 			$alert_content .= wp_kses( $options['alert-content'], $allowed_html );
 			$alert_content .= '</div>';
 		} elseif ( ! empty( $options['alert-text'] ) ) {
-			$alert_content  = '<div class="veu_promotion-alert__content--text">';
-			$alert_content .= '<span class="veu_promotion-alert__icon"><i class="fa-solid fa-circle-info"></i></span>';
+			$alert_content = '<div class="veu_promotion-alert__content--text">';
+			// 隣に注意文のテキストがあるためアイコンは装飾。読み上げから除外する（kses 許可リストに aria-hidden 登録済み）。
+			// The alert text sits next to it, so the icon is decorative and hidden from screen readers ( aria-hidden is in the kses allowlist ).
+			$alert_content .= '<span class="veu_promotion-alert__icon"><i class="fa-solid fa-circle-info" aria-hidden="true"></i></span>';
 			$alert_content .= '<span class="veu_promotion-alert__text">' . esc_html( $options['alert-text'] ) . '</span>';
 			$alert_content .= '</div>';
 		}

--- a/inc/related_posts/related_posts.php
+++ b/inc/related_posts/related_posts.php
@@ -150,7 +150,9 @@ function veu_add_related_posts_item_html( $post ) {
 	endif;
 	$post_item_html .= '<div class="media-body">';
 	$post_item_html .= '<div class="media-heading"><a href="' . get_the_permalink( $post->ID ) . '">' . $post->post_title . '</a></div>';
-	$post_item_html .= '<div class="media-date published"><i class="fa fa-calendar"></i>&nbsp;' . get_the_date( '', $post->ID ) . '</div>';
+	// 日付の前の装飾アイコン。同じ要素内に日付テキストが見えているため読み上げから除外する。
+	// Decorative icon before the date. The date text is visible in the same element, so hide it from screen readers.
+	$post_item_html .= '<div class="media-date published"><i class="fa fa-calendar" aria-hidden="true"></i>&nbsp;' . get_the_date( '', $post->ID ) . '</div>';
 	$post_item_html .= '</div>';
 	$post_item_html .= '</div>';
 	$post_item_html .= '</div>' . "\n";

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -270,7 +270,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( ! empty( $options['useThreads'] ) ) {
 			$social_btns .= '<li class="sb_threads sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_attr( 'https://www.threads.net/intent/post?text=' . $page_title . '%0A' . $link_url ) . '" target="_blank" ' . $outer_css . '>';
-			$social_btns .= '<span class="icon_sns"' . $icon_css . '><i class="fa-brands fa-threads"></i></span>';
+			// 隣に可視ラベル（.sns_txt "Threads"）があるためアイコンは装飾。読み上げから除外する。
+			// The visible label ( .sns_txt "Threads" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			$social_btns .= '<span class="icon_sns"' . $icon_css . '><i class="fa-brands fa-threads" aria-hidden="true"></i></span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Threads</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';
@@ -303,7 +305,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( ! empty( $options['useCopy'] ) ) {
 			$social_btns .= '<li class="sb_copy sb_icon">';
 			$social_btns .= '<button class="copy-button sb_icon_inner"' . $outer_css . 'data-clipboard-text="' . esc_attr( urldecode( $page_title ) ) . ' ' . esc_attr( urldecode( $link_url ) ) . '">';
-			$social_btns .= '<span class="vk_icon_w_r_sns_copy icon_sns"' . $icon_css . '><i class="fas fa-copy"></i></span>';
+			// 隣に可視ラベル（.sns_txt "Copy"）があるためアイコンは装飾。読み上げから除外する。
+			// The visible label ( .sns_txt "Copy" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			$social_btns .= '<span class="vk_icon_w_r_sns_copy icon_sns"' . $icon_css . '><i class="fas fa-copy" aria-hidden="true"></i></span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Copy</span>';
 			$social_btns .= '</button>';
 			$social_btns .= '</li>';

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -231,7 +231,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( ! empty( $options['useFacebook'] ) ) {
 			$social_btns .= '<li class="sb_facebook sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_url( '//www.facebook.com/sharer.php?src=bm&u=' . $link_url . '&t=' . $page_title ) . '" target="_blank" ' . $outer_css . 'onclick="window.open(this.href,\'FBwindow\',\'width=650,height=450,menubar=no,toolbar=no,scrollbars=yes\');return false;">';
-			$social_btns .= '<span class="vk_icon_w_r_sns_fb icon_sns"' . $icon_css . '></span>';
+			// 字形を CSS 疑似要素で描く自前 web フォント（vk_sns）アイコン。隣に可視ラベル（.sns_txt "Facebook"）があるため装飾扱いで読み上げから除外する。
+			// In-house web font ( vk_sns ) icon whose glyph is drawn via a CSS pseudo-element. The visible label ( .sns_txt "Facebook" ) sits next to it, so it is decorative and hidden from screen readers.
+			$social_btns .= '<span class="vk_icon_w_r_sns_fb icon_sns" aria-hidden="true"' . $icon_css . '></span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Facebook</span>';
 			$social_btns .= '<span class="veu_count_sns_fb"' . $icon_css . '></span>';
 			$social_btns .= '</a>';
@@ -242,7 +244,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( ! empty( $options['useTwitter'] ) ) {
 			$social_btns .= '<li class="sb_x_twitter sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_url( '//twitter.com/intent/tweet?url=' . $link_url . '&text=' . $page_title ) . '" target="_blank" ' . $outer_css . '>';
-			$social_btns .= '<span class="vk_icon_w_r_sns_x_twitter icon_sns"' . $icon_css . '></span>';
+			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "X"）があるため装飾扱いで読み上げから除外する。
+			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "X" ) sits next to it, so it is decorative and hidden from screen readers.
+			$social_btns .= '<span class="vk_icon_w_r_sns_x_twitter icon_sns" aria-hidden="true"' . $icon_css . '></span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>X</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';
@@ -256,7 +260,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( ! empty( $options['useBluesky'] ) ) {
 			$social_btns .= '<li class="sb_bluesky sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_attr( 'https://bsky.app/intent/compose?text=' . $page_title . '%0A' . $link_url ) . '" target="_blank" ' . $outer_css . '>';
-			$social_btns .= '<span class="vk_icon_w_r_sns_bluesky icon_sns"' . $icon_css . '></span>';
+			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "Bluesky"）があるため装飾扱いで読み上げから除外する。
+			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "Bluesky" ) sits next to it, so it is decorative and hidden from screen readers.
+			$social_btns .= '<span class="vk_icon_w_r_sns_bluesky icon_sns" aria-hidden="true"' . $icon_css . '></span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Bluesky</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';
@@ -282,7 +288,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( ! empty( $options['useHatena'] ) ) {
 			$social_btns .= '<li class="sb_hatena sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_url( '//b.hatena.ne.jp/add?mode=confirm&url=' . $link_url . '&title=' . $page_title ) . '" target="_blank" ' . $outer_css . ' onclick="window.open(this.href,\'Hatenawindow\',\'width=650,height=450,menubar=no,toolbar=no,scrollbars=yes\');return false;">';
-			$social_btns .= '<span class="vk_icon_w_r_sns_hatena icon_sns"' . $icon_css . '></span>';
+			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "Hatena"）があるため装飾扱いで読み上げから除外する。
+			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "Hatena" ) sits next to it, so it is decorative and hidden from screen readers.
+			$social_btns .= '<span class="vk_icon_w_r_sns_hatena icon_sns" aria-hidden="true"' . $icon_css . '></span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Hatena</span>';
 			$social_btns .= '<span class="veu_count_sns_hb"' . $icon_css . '></span>';
 			$social_btns .= '</a>';
@@ -296,7 +304,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( wp_is_mobile() && ! empty( $options['useLine'] ) ) :
 			$social_btns .= '<li class="sb_line sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner"  href="' . esc_url( 'line://msg/text/' . $page_title . ' ' . $link_url, array( 'line' ) ) . '" ' . $outer_css . '>';
-			$social_btns .= '<span class="vk_icon_w_r_sns_line icon_sns"' . $icon_css . '></span>';
+			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "LINE"）があるため装飾扱いで読み上げから除外する。
+			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "LINE" ) sits next to it, so it is decorative and hidden from screen readers.
+			$social_btns .= '<span class="vk_icon_w_r_sns_line icon_sns" aria-hidden="true"' . $icon_css . '></span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>LINE</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Spec Change ] Hid decorative icons from screen readers so they are no longer read aloud together with the visible label.
+[ Spec Change ] Added accessible names to the Profile widget's icon-only social media links.
 [ Bug Fix ][ Widget ] Fixed a PHP warning that occurred on the admin widget form of the Recent Posts widget when its title was empty.
 [ Bug Fix ] Fixed PHP warnings, notices and deprecations ( and a potential fatal error ) logged in debug mode on recent PHP versions, while keeping PHP 7.4 support.
 [ Bug Fix ][ CTA ] Fixed the CTA image not being saved and the button text / message losing their allowed HTML when saved from the classic edit screen.

--- a/tests/test-contact-section.php
+++ b/tests/test-contact-section.php
@@ -12,6 +12,18 @@
 class ContactSectionTest extends WP_UnitTestCase {
 
 	/**
+	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
+	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
+		parent::tearDown();
+	}
+
+	/**
 	 * render_contact_section_html の装飾アイコン（電話 / 封筒 / 矢印）に aria-hidden="true" が付く事のテスト。
 	 * Test that the decorative icons ( phone / envelope / arrow ) in render_contact_section_html get aria-hidden="true".
 	 *
@@ -79,25 +91,49 @@ class ContactSectionTest extends WP_UnitTestCase {
 		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
 		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
 
-		// お問い合わせボタンウィジェットの描画に必要なオプションを設定。
-		// Set the option required to render the contact button widget.
-		update_option(
-			'vkExUnit_contact',
+		// 保存オプションの組み合わせごとに、封筒・矢印の装飾アイコンへ aria-hidden が付く事を検証する。
+		// For each combination of saved options, verify the decorative envelope / arrow icons get aria-hidden.
+		$test_cases = array(
 			array(
-				'contact_link' => 'https://example.com',
-				'short_text'   => 'Contact us',
-			)
+				'test_condition_name' => 'リンクと短いテキストのみ設定した場合 => 封筒・矢印アイコンに aria-hidden が付く',
+				'options'             => array(
+					'contact_link' => 'https://example.com',
+					'short_text'   => 'Contact us',
+				),
+				'expected'            => array(
+					'<i class="fa-regular fa-envelope" aria-hidden="true"></i>',
+					'<i class="fa-regular fa-circle-right" aria-hidden="true"></i>',
+				),
+			),
+			array(
+				'test_condition_name' => 'ボタン補足テキストも設定した場合 => 封筒・矢印アイコンに aria-hidden が付く',
+				'options'             => array(
+					'contact_link'      => 'https://example.com',
+					'short_text'        => 'Contact us',
+					'button_text_small' => 'お気軽にどうぞ',
+				),
+				'expected'            => array(
+					'<i class="fa-regular fa-envelope" aria-hidden="true"></i>',
+					'<i class="fa-regular fa-circle-right" aria-hidden="true"></i>',
+				),
+			),
 		);
 
-		// お問い合わせボタンウィジェットの HTML を取得 / Get the contact button widget HTML.
-		$html = VkExUnit_Contact::render_widget_contact_btn_html();
+		foreach ( $test_cases as $case ) {
+			// お問い合わせボタンウィジェットの描画に必要なオプションを設定。
+			// Set the option required to render the contact button widget.
+			update_option( 'vkExUnit_contact', $case['options'] );
 
-		// 封筒アイコンに aria-hidden が付く事を確認 / Check the envelope icon has aria-hidden.
-		$this->assertStringContainsString( '<i class="fa-regular fa-envelope" aria-hidden="true"></i>', $html );
-		// 矢印アイコンに aria-hidden が付く事を確認 / Check the arrow icon has aria-hidden.
-		$this->assertStringContainsString( '<i class="fa-regular fa-circle-right" aria-hidden="true"></i>', $html );
+			// お問い合わせボタンウィジェットの HTML を取得 / Get the contact button widget HTML.
+			$html = VkExUnit_Contact::render_widget_contact_btn_html();
 
-		// オプションをクリーンアップ / Clean up the option.
-		delete_option( 'vkExUnit_contact' );
+			// 封筒・矢印の装飾アイコンに aria-hidden が付く事を確認 / Check the decorative envelope / arrow icons have aria-hidden.
+			foreach ( $case['expected'] as $expected ) {
+				$this->assertStringContainsString( $expected, $html, $case['test_condition_name'] );
+			}
+
+			// オプションをクリーンアップ / Clean up the option.
+			delete_option( 'vkExUnit_contact' );
+		}
 	}
 }

--- a/tests/test-contact-section.php
+++ b/tests/test-contact-section.php
@@ -12,18 +12,6 @@
 class ContactSectionTest extends WP_UnitTestCase {
 
 	/**
-	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
-	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
-	 *
-	 * @return void
-	 */
-	public function tearDown(): void {
-		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
-		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
-		parent::tearDown();
-	}
-
-	/**
 	 * render_contact_section_html の装飾アイコン（電話 / 封筒 / 矢印）に aria-hidden="true" が付く事のテスト。
 	 * Test that the decorative icons ( phone / envelope / arrow ) in render_contact_section_html get aria-hidden="true".
 	 *

--- a/tests/test-contact-section.php
+++ b/tests/test-contact-section.php
@@ -48,6 +48,13 @@ class ContactSectionTest extends WP_UnitTestCase {
 				'tel_icon'            => 'fa-solid fa-phone',
 				'expected'            => '<i class="contact_txt_tel_icon fa-solid fa-phone" aria-hidden="true"></i>',
 			),
+			array(
+				// class より前に別属性（aria-hidden）を持つ <i>。属性順・追加属性に依存せず class を抽出できる事の回帰テスト。
+				// An <i> tag with another attribute ( aria-hidden ) before class. Regression test that class is extracted regardless of attribute order / extra attributes.
+				'test_condition_name' => 'tel_icon が aria-hidden を class より前に持つ <i> の場合 => class を正しく抽出し電話アイコンに aria-hidden が付く',
+				'tel_icon'            => '<i aria-hidden="true" class="fa-solid fa-phone"></i>',
+				'expected'            => '<i class="contact_txt_tel_icon fa-solid fa-phone" aria-hidden="true"></i>',
+			),
 		);
 
 		// アサーション失敗時も元の設定値を確実に戻すため、ループ実行前に元の値を保持し try/finally で復元する。

--- a/tests/test-contact-section.php
+++ b/tests/test-contact-section.php
@@ -50,32 +50,45 @@ class ContactSectionTest extends WP_UnitTestCase {
 			),
 		);
 
-		foreach ( $tel_icon_cases as $case ) {
-			// お問い合わせ情報のオプションを設定 / Set the contact information option.
-			update_option(
-				'vkExUnit_contact',
-				array(
-					'tel_icon'     => $case['tel_icon'],
-					'tel_number'   => '000-000-0000',
-					'contact_link' => 'https://example.com',
-					'button_text'  => 'Contact us',
-					'short_text'   => 'Contact us',
-				)
-			);
+		// アサーション失敗時も元の設定値を確実に戻すため、ループ実行前に元の値を保持し try/finally で復元する。
+		// Preserve the original option before the loop and restore it in finally so the value is restored even if an assertion fails.
+		$original_option = get_option( 'vkExUnit_contact', false );
 
-			// お問い合わせセクションの HTML を取得 / Get the contact section HTML.
-			$html = VkExUnit_Contact::render_contact_section_html();
+		try {
+			foreach ( $tel_icon_cases as $case ) {
+				// お問い合わせ情報のオプションを設定 / Set the contact information option.
+				update_option(
+					'vkExUnit_contact',
+					array(
+						'tel_icon'     => $case['tel_icon'],
+						'tel_number'   => '000-000-0000',
+						'contact_link' => 'https://example.com',
+						'button_text'  => 'Contact us',
+						'short_text'   => 'Contact us',
+					)
+				);
 
-			// 電話アイコン（保存値によらず組み立て直した <i>）に aria-hidden が付く事を確認。
-			// Check the phone icon ( the <i> rebuilt regardless of the saved value ) has aria-hidden.
-			$this->assertStringContainsString( $case['expected'], $html, $case['test_condition_name'] );
-			// ボタン前の封筒アイコンに aria-hidden が付く事を確認 / Check the envelope icon before the button has aria-hidden.
-			$this->assertStringContainsString( '<i class="fa-regular fa-envelope" aria-hidden="true"></i>', $html, $case['test_condition_name'] );
-			// ボタン後の矢印アイコンに aria-hidden が付く事を確認 / Check the arrow icon after the button has aria-hidden.
-			$this->assertStringContainsString( '<i class="fa-regular fa-circle-right" aria-hidden="true"></i>', $html, $case['test_condition_name'] );
+				// お問い合わせセクションの HTML を取得 / Get the contact section HTML.
+				$html = VkExUnit_Contact::render_contact_section_html();
 
-			// オプションをクリーンアップ / Clean up the option.
-			delete_option( 'vkExUnit_contact' );
+				// 電話アイコン（保存値によらず組み立て直した <i>）に aria-hidden が付く事を確認。
+				// Check the phone icon ( the <i> rebuilt regardless of the saved value ) has aria-hidden.
+				$this->assertStringContainsString( $case['expected'], $html, $case['test_condition_name'] );
+				// ボタン前の封筒アイコンに aria-hidden が付く事を確認 / Check the envelope icon before the button has aria-hidden.
+				$this->assertStringContainsString( '<i class="fa-regular fa-envelope" aria-hidden="true"></i>', $html, $case['test_condition_name'] );
+				// ボタン後の矢印アイコンに aria-hidden が付く事を確認 / Check the arrow icon after the button has aria-hidden.
+				$this->assertStringContainsString( '<i class="fa-regular fa-circle-right" aria-hidden="true"></i>', $html, $case['test_condition_name'] );
+
+				// オプションをクリーンアップ / Clean up the option.
+				delete_option( 'vkExUnit_contact' );
+			}
+		} finally {
+			// 元の設定値を復元（元々未設定だったら削除）/ Restore the original option value ( delete if it was originally unset ).
+			if ( false === $original_option ) {
+				delete_option( 'vkExUnit_contact' );
+			} else {
+				update_option( 'vkExUnit_contact', $original_option );
+			}
 		}
 	}
 
@@ -119,21 +132,34 @@ class ContactSectionTest extends WP_UnitTestCase {
 			),
 		);
 
-		foreach ( $test_cases as $case ) {
-			// お問い合わせボタンウィジェットの描画に必要なオプションを設定。
-			// Set the option required to render the contact button widget.
-			update_option( 'vkExUnit_contact', $case['options'] );
+		// アサーション失敗時も元の設定値を確実に戻すため、ループ実行前に元の値を保持し try/finally で復元する。
+		// Preserve the original option before the loop and restore it in finally so the value is restored even if an assertion fails.
+		$original_option = get_option( 'vkExUnit_contact', false );
 
-			// お問い合わせボタンウィジェットの HTML を取得 / Get the contact button widget HTML.
-			$html = VkExUnit_Contact::render_widget_contact_btn_html();
+		try {
+			foreach ( $test_cases as $case ) {
+				// お問い合わせボタンウィジェットの描画に必要なオプションを設定。
+				// Set the option required to render the contact button widget.
+				update_option( 'vkExUnit_contact', $case['options'] );
 
-			// 封筒・矢印の装飾アイコンに aria-hidden が付く事を確認 / Check the decorative envelope / arrow icons have aria-hidden.
-			foreach ( $case['expected'] as $expected ) {
-				$this->assertStringContainsString( $expected, $html, $case['test_condition_name'] );
+				// お問い合わせボタンウィジェットの HTML を取得 / Get the contact button widget HTML.
+				$html = VkExUnit_Contact::render_widget_contact_btn_html();
+
+				// 封筒・矢印の装飾アイコンに aria-hidden が付く事を確認 / Check the decorative envelope / arrow icons have aria-hidden.
+				foreach ( $case['expected'] as $expected ) {
+					$this->assertStringContainsString( $expected, $html, $case['test_condition_name'] );
+				}
+
+				// オプションをクリーンアップ / Clean up the option.
+				delete_option( 'vkExUnit_contact' );
 			}
-
-			// オプションをクリーンアップ / Clean up the option.
-			delete_option( 'vkExUnit_contact' );
+		} finally {
+			// 元の設定値を復元（元々未設定だったら削除）/ Restore the original option value ( delete if it was originally unset ).
+			if ( false === $original_option ) {
+				delete_option( 'vkExUnit_contact' );
+			} else {
+				update_option( 'vkExUnit_contact', $original_option );
+			}
 		}
 	}
 }

--- a/tests/test-contact-section.php
+++ b/tests/test-contact-section.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Class ContactSectionTest
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * お問い合わせセクション（VkExUnit_Contact）の描画テスト。
+ * Test for the contact section ( VkExUnit_Contact ) rendering.
+ */
+class ContactSectionTest extends WP_UnitTestCase {
+
+	/**
+	 * render_contact_section_html の装飾アイコン（電話 / 封筒 / 矢印）に aria-hidden="true" が付く事のテスト。
+	 * Test that the decorative icons ( phone / envelope / arrow ) in render_contact_section_html get aria-hidden="true".
+	 *
+	 * @return void
+	 */
+	function test_render_contact_section_html() {
+		// アイコンアクセシビリティのフィルター有無に依存しない事を確かめるため、フィルターを外した状態で検証する。
+		// Verify with the filter removed to confirm the attributes do not depend on the icon accessibility filter.
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
+		// tel_icon の保存値（<i> 丸ごと / クラス文字列）ごとに、組み立て直した電話アイコンへ aria-hidden が付く事を検証する。
+		// For each saved tel_icon value ( full <i> tag / class string ), verify the rebuilt phone icon gets aria-hidden.
+		$tel_icon_cases = array(
+			array(
+				'test_condition_name' => 'tel_icon が <i> 丸ごとの場合 => 電話アイコンに aria-hidden が付く',
+				'tel_icon'            => '<i class="fa-solid fa-phone"></i>',
+				'expected'            => '<i class="contact_txt_tel_icon fa-solid fa-phone" aria-hidden="true"></i>',
+			),
+			array(
+				'test_condition_name' => 'tel_icon がクラス文字列の場合 => 電話アイコンに aria-hidden が付く',
+				'tel_icon'            => 'fa-solid fa-phone',
+				'expected'            => '<i class="contact_txt_tel_icon fa-solid fa-phone" aria-hidden="true"></i>',
+			),
+		);
+
+		foreach ( $tel_icon_cases as $case ) {
+			// お問い合わせ情報のオプションを設定 / Set the contact information option.
+			update_option(
+				'vkExUnit_contact',
+				array(
+					'tel_icon'     => $case['tel_icon'],
+					'tel_number'   => '000-000-0000',
+					'contact_link' => 'https://example.com',
+					'button_text'  => 'Contact us',
+					'short_text'   => 'Contact us',
+				)
+			);
+
+			// お問い合わせセクションの HTML を取得 / Get the contact section HTML.
+			$html = VkExUnit_Contact::render_contact_section_html();
+
+			// 電話アイコン（保存値によらず組み立て直した <i>）に aria-hidden が付く事を確認。
+			// Check the phone icon ( the <i> rebuilt regardless of the saved value ) has aria-hidden.
+			$this->assertStringContainsString( $case['expected'], $html, $case['test_condition_name'] );
+			// ボタン前の封筒アイコンに aria-hidden が付く事を確認 / Check the envelope icon before the button has aria-hidden.
+			$this->assertStringContainsString( '<i class="fa-regular fa-envelope" aria-hidden="true"></i>', $html, $case['test_condition_name'] );
+			// ボタン後の矢印アイコンに aria-hidden が付く事を確認 / Check the arrow icon after the button has aria-hidden.
+			$this->assertStringContainsString( '<i class="fa-regular fa-circle-right" aria-hidden="true"></i>', $html, $case['test_condition_name'] );
+
+			// オプションをクリーンアップ / Clean up the option.
+			delete_option( 'vkExUnit_contact' );
+		}
+	}
+
+	/**
+	 * render_widget_contact_btn_html の装飾アイコン（封筒 / 矢印）に aria-hidden="true" が付く事のテスト。
+	 * Test that the decorative icons ( envelope / arrow ) in render_widget_contact_btn_html get aria-hidden="true".
+	 *
+	 * @return void
+	 */
+	function test_render_widget_contact_btn_html() {
+		// アイコンアクセシビリティのフィルター有無に依存しない事を確かめるため、フィルターを外した状態で検証する。
+		// Verify with the filter removed to confirm the attributes do not depend on the icon accessibility filter.
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
+		// お問い合わせボタンウィジェットの描画に必要なオプションを設定。
+		// Set the option required to render the contact button widget.
+		update_option(
+			'vkExUnit_contact',
+			array(
+				'contact_link' => 'https://example.com',
+				'short_text'   => 'Contact us',
+			)
+		);
+
+		// お問い合わせボタンウィジェットの HTML を取得 / Get the contact button widget HTML.
+		$html = VkExUnit_Contact::render_widget_contact_btn_html();
+
+		// 封筒アイコンに aria-hidden が付く事を確認 / Check the envelope icon has aria-hidden.
+		$this->assertStringContainsString( '<i class="fa-regular fa-envelope" aria-hidden="true"></i>', $html );
+		// 矢印アイコンに aria-hidden が付く事を確認 / Check the arrow icon has aria-hidden.
+		$this->assertStringContainsString( '<i class="fa-regular fa-circle-right" aria-hidden="true"></i>', $html );
+
+		// オプションをクリーンアップ / Clean up the option.
+		delete_option( 'vkExUnit_contact' );
+	}
+}

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -14,10 +14,6 @@ class CTATest extends WP_UnitTestCase {
 	 * Reset globals after each test.
 	 */
 	protected function tearDown(): void {
-		// アイコンアクセシビリティのフィルターを元の登録内容で復元する。
-		// Restore the icon accessibility filters ( with the original arguments / priority ).
-		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
-		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
 		parent::tearDown();
 		$_POST = array();
 	}

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -14,6 +14,10 @@ class CTATest extends WP_UnitTestCase {
 	 * Reset globals after each test.
 	 */
 	protected function tearDown(): void {
+		// アイコンアクセシビリティのフィルターを元の登録内容で復元する。
+		// Restore the icon accessibility filters ( with the original arguments / priority ).
+		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
 		parent::tearDown();
 		$_POST = array();
 	}

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -340,6 +340,25 @@ class CTATest extends WP_UnitTestCase {
 				),
 				'expected'   => '<div class="veu-cta-block &quot; onmouseover=&quot;alert(/XSS/)&quot; style=&quot;background:red;&quot;">CTA content</div>',
 			),
+			// 本文を空にして古典スタイルのボタン（メタのアイコン）を描画させ、装飾アイコンに aria-hidden="true" が付く事を検証する。
+			// Empty the content so the classic-style button ( icons from meta ) is rendered, and verify the decorative icons get aria-hidden="true".
+			'classic button icons'        => array(
+				'target_url'        => get_permalink( $test_posts['page'] ),
+				'attributes'        => array(
+					'postId' => $test_posts['cta_post_id'],
+				),
+				'cta_content'       => '',
+				'post_meta'         => array(
+					'vkExUnit_cta_button_text'        => 'Read more',
+					'vkExUnit_cta_url'                => 'https://example.com',
+					'vkExUnit_cta_button_icon_before' => 'fa-solid fa-star',
+					'vkExUnit_cta_button_icon_after'  => 'fa-solid fa-arrow-right',
+				),
+				'expected_contains' => array(
+					'<i class="fa-solid fa-star font_icon" aria-hidden="true"></i>',
+					'<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i>',
+				),
+			),
 			'No CTA specified'            => array(
 				'attributes' => array(
 					'postId' => null,
@@ -390,11 +409,36 @@ class CTATest extends WP_UnitTestCase {
 					}
 				}
 			}
+			// 対象 CTA の本文・メタをケースごとに設定（古典スタイルのボタン描画を再現するため）。
+			// Set the target CTA's content / meta per case ( to reproduce the classic-style button rendering ).
+			if ( array_key_exists( 'cta_content', $test_value ) ) {
+				wp_update_post(
+					array(
+						'ID'           => $test_posts['cta_post_id'],
+						'post_content' => $test_value['cta_content'],
+					)
+				);
+			}
+			if ( ! empty( $test_value['post_meta'] ) ) {
+				foreach ( $test_value['post_meta'] as $meta_key => $meta_value ) {
+					update_post_meta( $test_posts['cta_post_id'], $meta_key, $meta_value );
+				}
+			}
+
 			$actual = '';
 			$actual = veu_cta_block_callback( $test_value['attributes'], $content );
 			// print 'expected ::' . $test_value['expected'] . PHP_EOL;
 			// print 'actual ::::' . $actual . PHP_EOL;
-			$this->assertEquals( $test_value['expected'], $actual );
+
+			// expected_contains があれば部分一致で、無ければ完全一致で検証する。
+			// If expected_contains is set, assert substrings; otherwise assert full equality.
+			if ( isset( $test_value['expected_contains'] ) ) {
+				foreach ( (array) $test_value['expected_contains'] as $needle ) {
+					$this->assertStringContainsString( $needle, $actual, $key );
+				}
+			} else {
+				$this->assertEquals( $test_value['expected'], $actual );
+			}
 		}
 	}
 
@@ -612,6 +656,13 @@ class CTATest extends WP_UnitTestCase {
 	function test_render_cta_content() {
 		$test_posts = array();
 
+		// 装飾アイコンの aria-hidden がインライン付与（トグル非依存）である事を確かめるため、
+		// アイコンアクセシビリティのフィルターを外した状態で検証する。
+		// Verify with the icon accessibility filter removed to confirm the decorative icon's
+		// aria-hidden is added inline ( toggle-independent ).
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
 		// テスト用のCTAを作成
 		$cta_post                  = array(
 			'post_title'   => 'cta_published',
@@ -658,6 +709,20 @@ class CTATest extends WP_UnitTestCase {
 					'vkExUnit_cta_url'         => 'https://example.com',
 				),
 				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">"&gt;alert(0)</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">"&gt;alert(0)</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+			),
+			// 前後アイコン付きの古典CTA：装飾アイコンの <i> に aria-hidden="true" が付く事を検証する。
+			// Classic CTA with before / after icons: verify the decorative icons' <i> get aria-hidden="true".
+			'classic CTA icon test'    => array(
+				'cta_title'   => 'Classic Title',
+				'cta_content' => '',
+				'post_meta'   => array(
+					'vkExUnit_cta_text'               => 'cta',
+					'vkExUnit_cta_button_text'        => 'Read more',
+					'vkExUnit_cta_url'                => 'https://example.com',
+					'vkExUnit_cta_button_icon_before' => 'fa-solid fa-star',
+					'vkExUnit_cta_button_icon_after'  => 'fa-solid fa-arrow-right',
+				),
+				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank"><i class="fa-solid fa-star font_icon" aria-hidden="true"></i> Read more<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i> </a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 		);
 

--- a/tests/test-promotion-alert.php
+++ b/tests/test-promotion-alert.php
@@ -398,7 +398,7 @@ class PromotionAlertTest extends WP_UnitTestCase {
 						'post' => 'display',
 					),
 				),
-				'correct' => '<div class="veu_promotion-alert" data-nosnippet><div class="veu_promotion-alert__content--text"><span class="veu_promotion-alert__icon"><i class="fa-solid fa-circle-info"></i></span><span class="veu_promotion-alert__text">aaaa</span></div></div>',
+				'correct' => '<div class="veu_promotion-alert" data-nosnippet><div class="veu_promotion-alert__content--text"><span class="veu_promotion-alert__icon"><i class="fa-solid fa-circle-info" aria-hidden="true"></i></span><span class="veu_promotion-alert__text">aaaa</span></div></div>',
 			),
 			array(
 				'name'    => 'No alert text',

--- a/tests/test-related-posts.php
+++ b/tests/test-related-posts.php
@@ -12,6 +12,18 @@
 class RelatedPostsTest extends WP_UnitTestCase {
 
 	/**
+	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
+	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
+		parent::tearDown();
+	}
+
+	/**
 	 * 関連記事の日付前アイコン（fa-calendar）に aria-hidden="true" が付く事のテスト。
 	 * Test that the calendar icon before the related-post date gets aria-hidden="true".
 	 *

--- a/tests/test-related-posts.php
+++ b/tests/test-related-posts.php
@@ -12,18 +12,6 @@
 class RelatedPostsTest extends WP_UnitTestCase {
 
 	/**
-	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
-	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
-	 *
-	 * @return void
-	 */
-	public function tearDown(): void {
-		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
-		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
-		parent::tearDown();
-	}
-
-	/**
 	 * 関連記事の日付前アイコン（fa-calendar）に aria-hidden="true" が付く事のテスト。
 	 * Test that the calendar icon before the related-post date gets aria-hidden="true".
 	 *

--- a/tests/test-related-posts.php
+++ b/tests/test-related-posts.php
@@ -23,20 +23,49 @@ class RelatedPostsTest extends WP_UnitTestCase {
 		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
 		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
 
-		// テスト用の投稿を作成 / Create a test post.
-		$post_id = wp_insert_post(
+		// テスト条件（投稿データ）と期待する結果の組み合わせ。
+		// カレンダーアイコンは投稿内容に依らず不変なので、投稿データを変えつつ全ケースで検証する。
+		// Combinations of the post data and expected result.
+		// The calendar icon is invariant regardless of post content, so we verify it across cases with varying post data.
+		$test_cases = array(
 			array(
-				'post_title'  => 'Related Post Test',
-				'post_type'   => 'post',
-				'post_status' => 'publish',
-			)
+				'test_condition_name' => '通常の投稿 => 日付前のカレンダーアイコンに aria-hidden が付く',
+				'post'                => array(
+					'post_title'  => 'Related Post Test A',
+					'post_type'   => 'post',
+					'post_status' => 'publish',
+				),
+				'expected_title'      => 'Related Post Test A',
+			),
+			array(
+				'test_condition_name' => '別タイトル・別日付の投稿 => 日付前のカレンダーアイコンに aria-hidden が付く',
+				'post'                => array(
+					'post_title'  => 'Related Post Test B',
+					'post_type'   => 'post',
+					'post_status' => 'publish',
+					'post_date'   => '2020-01-02 10:00:00',
+				),
+				'expected_title'      => 'Related Post Test B',
+			),
 		);
 
-		// 関連記事1件分の HTML を取得 / Get the single related-post item HTML.
-		$html = veu_add_related_posts_item_html( get_post( $post_id ) );
+		foreach ( $test_cases as $case ) {
+			// テスト用の投稿を作成 / Create a test post.
+			$post_id = wp_insert_post( $case['post'] );
 
-		// 日付前のカレンダーアイコンに aria-hidden="true" が付いている事を確認。
-		// Check the calendar icon before the date has aria-hidden="true".
-		$this->assertStringContainsString( '<i class="fa fa-calendar" aria-hidden="true"></i>', $html );
+			// 関連記事1件分の HTML を取得 / Get the single related-post item HTML.
+			$html = veu_add_related_posts_item_html( get_post( $post_id ) );
+
+			// 日付前のカレンダーアイコンに aria-hidden="true" が付いている事を確認。
+			// Check the calendar icon before the date has aria-hidden="true".
+			$this->assertStringContainsString( '<i class="fa fa-calendar" aria-hidden="true"></i>', $html, $case['test_condition_name'] );
+
+			// 投稿タイトルが出力に含まれる事を確認（ケースごとの差分）。
+			// Check the post title is present in the output ( the per-case difference ).
+			$this->assertStringContainsString( $case['expected_title'], $html, $case['test_condition_name'] );
+
+			// 後片付け / Clean up.
+			wp_delete_post( $post_id, true );
+		}
 	}
 }

--- a/tests/test-related-posts.php
+++ b/tests/test-related-posts.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Class RelatedPostsTest
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * 関連記事の1件分HTML（veu_add_related_posts_item_html）のテスト。
+ * Test for the single related-post item HTML ( veu_add_related_posts_item_html ).
+ */
+class RelatedPostsTest extends WP_UnitTestCase {
+
+	/**
+	 * 関連記事の日付前アイコン（fa-calendar）に aria-hidden="true" が付く事のテスト。
+	 * Test that the calendar icon before the related-post date gets aria-hidden="true".
+	 *
+	 * @return void
+	 */
+	function test_veu_add_related_posts_item_html() {
+		// アイコンアクセシビリティのフィルター有無に依存しない事を確かめるため、フィルターを外した状態で検証する。
+		// Verify with the filter removed to confirm the attribute does not depend on the icon accessibility filter.
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
+		// テスト用の投稿を作成 / Create a test post.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Related Post Test',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// 関連記事1件分の HTML を取得 / Get the single related-post item HTML.
+		$html = veu_add_related_posts_item_html( get_post( $post_id ) );
+
+		// 日付前のカレンダーアイコンに aria-hidden="true" が付いている事を確認。
+		// Check the calendar icon before the date has aria-hidden="true".
+		$this->assertStringContainsString( '<i class="fa fa-calendar" aria-hidden="true"></i>', $html );
+	}
+}

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -11,6 +11,18 @@
 class SnsBtnsTest extends WP_UnitTestCase {
 
 	/**
+	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
+	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
+		parent::tearDown();
+	}
+
+	/**
 	 * SNSボタンを本文欄やフックで自動挿入するかしないかのテスト
 	 */
 	function test_veu_is_sns_btns_auto_insert() {

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -395,5 +395,39 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			// オプション値をクリーンアップ / Clean up the option value.
 			delete_option( 'vkExUnit_sns_options' );
 		}
+
+		// 装飾アイコン（Threads / Copy）の <i> に aria-hidden="true" が付き読み上げから除外される事のテスト
+		// Test that the decorative icons ( Threads / Copy ) get aria-hidden="true" on their <i> and are hidden from screen readers.
+		// アイコンアクセシビリティのフィルター有無に依存しない事を確かめるため、フィルターを外した状態で検証する。
+		// Verify with the filter removed to confirm the attribute does not depend on the icon accessibility filter.
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
+		$aria_cases = array(
+			array(
+				'test_condition_name' => 'useThreads が true の場合 => Threads の <i> に aria-hidden="true" が付く',
+				'options'             => array( 'useThreads' => true ),
+				'expected'            => '<i class="fa-brands fa-threads" aria-hidden="true"></i>',
+			),
+			array(
+				'test_condition_name' => 'useCopy が true の場合 => Copy の <i> に aria-hidden="true" が付く',
+				'options'             => array( 'useCopy' => true ),
+				'expected'            => '<i class="fas fa-copy" aria-hidden="true"></i>',
+			),
+		);
+
+		foreach ( $aria_cases as $case ) {
+			// オプション値を設定 / Set option value.
+			update_option( 'vkExUnit_sns_options', $case['options'] );
+
+			// シェアボタンの HTML を取得 / Get the share button HTML.
+			$actual = veu_get_sns_btns();
+
+			// 装飾アイコンに aria-hidden が付いている事を確認 / Check the decorative icon has aria-hidden.
+			$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
+
+			// オプション値をクリーンアップ / Clean up the option value.
+			delete_option( 'vkExUnit_sns_options' );
+		}
 	}
 }

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -446,71 +446,75 @@ class SnsBtnsTest extends WP_UnitTestCase {
 		// Test that the empty in-house web font ( vk_sns ) span icons ( fb / x / bluesky / hatena / line ) also get aria-hidden="true" and are hidden from screen readers.
 		// class 直後・$icon_css の前に aria-hidden が入る実出力に合わせてリテラルで検証する。
 		// Verify against the literal output where aria-hidden comes right after class and before $icon_css.
+		// LINE はモバイル環境（wp_is_mobile() が true）かつ useLine が有効な時のみ出力されるため、ケースごとに user_agent を設定して分岐を通す。
+		// LINE is only output on mobile ( wp_is_mobile() returns true ) with useLine enabled, so set user_agent per case to go through the branch.
+		// iPhone の UA。文字列に "Mobile" を含むため wp_is_mobile() が true を返す。
+		// iPhone UA. It contains "Mobile", so wp_is_mobile() returns true.
+		$mobile_ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
 		$webfont_cases = array(
 			array(
 				'test_condition_name' => 'useFacebook が true の場合 => Facebook の web フォント span に aria-hidden="true" が付く',
 				'options'             => array( 'useFacebook' => true ),
-				'expected'            => '<span class="vk_icon_w_r_sns_fb icon_sns" aria-hidden="true"',
+				'user_agent'          => null,
+				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_fb icon_sns" aria-hidden="true"' ),
 			),
 			array(
 				'test_condition_name' => 'useTwitter が true の場合 => X の web フォント span に aria-hidden="true" が付く',
 				'options'             => array( 'useTwitter' => true ),
-				'expected'            => '<span class="vk_icon_w_r_sns_x_twitter icon_sns" aria-hidden="true"',
+				'user_agent'          => null,
+				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_x_twitter icon_sns" aria-hidden="true"' ),
 			),
 			array(
 				'test_condition_name' => 'useBluesky が true の場合 => Bluesky の web フォント span に aria-hidden="true" が付く',
 				'options'             => array( 'useBluesky' => true ),
-				'expected'            => '<span class="vk_icon_w_r_sns_bluesky icon_sns" aria-hidden="true"',
+				'user_agent'          => null,
+				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_bluesky icon_sns" aria-hidden="true"' ),
 			),
 			array(
 				'test_condition_name' => 'useHatena が true の場合 => Hatena の web フォント span に aria-hidden="true" が付く',
 				'options'             => array( 'useHatena' => true ),
-				'expected'            => '<span class="vk_icon_w_r_sns_hatena icon_sns" aria-hidden="true"',
+				'user_agent'          => null,
+				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_hatena icon_sns" aria-hidden="true"' ),
+			),
+			array(
+				// LINE はモバイル UA で wp_is_mobile() を true にした時のみ出力される。sb_line が含まれる事＝モバイル分岐を実際に通った裏取り（他に出力経路が無い）。
+				// LINE is only output when wp_is_mobile() is true via the mobile UA. Containing sb_line proves the mobile branch was actually taken ( no other output path ).
+				'test_condition_name' => 'useLine が true かつモバイルの場合 => LINE ボタンが出力され LINE の web フォント span に aria-hidden="true" が付く',
+				'options'             => array( 'useLine' => true ),
+				'user_agent'          => $mobile_ua,
+				'expected_contains'   => array( 'sb_line', '<span class="vk_icon_w_r_sns_line icon_sns" aria-hidden="true"' ),
 			),
 		);
 
-		foreach ( $webfont_cases as $case ) {
-			// オプション値を設定 / Set option value.
-			update_option( 'vkExUnit_sns_options', $case['options'] );
-
-			// シェアボタンの HTML を取得 / Get the share button HTML.
-			$actual = veu_get_sns_btns();
-
-			// 装飾アイコン（web フォント）の span に aria-hidden が付いている事を確認 / Check the decorative web font span icon has aria-hidden.
-			$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
-
-			// オプション値をクリーンアップ / Clean up the option value.
-			delete_option( 'vkExUnit_sns_options' );
-		}
-
-		// LINE の web フォント span アイコンにも aria-hidden="true" が付く事のテスト。
-		// LINE はモバイル環境（wp_is_mobile() が true）かつ useLine が有効な時のみ出力されるため、
-		// 一時的にモバイル UA をセットして分岐を有効化して検証する。
-		// Test that the LINE web font span icon also gets aria-hidden="true".
-		// LINE is only output on mobile ( wp_is_mobile() returns true ) with useLine enabled,
-		// so temporarily set a mobile UA to enable the branch for verification.
-		$line_expected = '<span class="vk_icon_w_r_sns_line icon_sns" aria-hidden="true"';
-		$original_ua   = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
-		// iPhone の UA。文字列に "Mobile" を含むため wp_is_mobile() が true を返す。
-		// iPhone UA. It contains "Mobile", so wp_is_mobile() returns true.
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+		// アサーション失敗時も元の UA を確実に戻すため、ループ実行前に元の値を保持し try/finally で復元する。
+		// Preserve the original UA before the loop and restore it in finally so it is restored even if an assertion fails.
+		$original_ua = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
 
 		try {
-			// モバイル UA が効いて wp_is_mobile() が true になっている事を前提として確認（false なら UA 設定が効いていないサイン）。
-			// Confirm the mobile UA is in effect and wp_is_mobile() returns true ( false means the UA is not applied ).
-			$this->assertTrue( wp_is_mobile(), 'モバイル UA をセットしたので wp_is_mobile() は true になる' );
+			foreach ( $webfont_cases as $case ) {
+				// ケースごとに UA を設定（null なら未設定にする）。LINE はモバイル UA で分岐を通す。
+				// Set the UA per case ( unset if null ). LINE goes through the branch with the mobile UA.
+				if ( null === $case['user_agent'] ) {
+					unset( $_SERVER['HTTP_USER_AGENT'] );
+				} else {
+					$_SERVER['HTTP_USER_AGENT'] = $case['user_agent'];
+				}
 
-			// useLine を有効化してシェアボタンの HTML を取得 / Enable useLine and get the share button HTML.
-			update_option( 'vkExUnit_sns_options', array( 'useLine' => true ) );
-			$actual = veu_get_sns_btns();
+				// オプション値を設定 / Set option value.
+				update_option( 'vkExUnit_sns_options', $case['options'] );
 
-			// LINE 分岐が実際に出力されている事（li.sb_line）を確認 / Confirm the LINE branch is actually output.
-			$this->assertStringContainsString( 'sb_line', $actual, 'useLine が true かつモバイルの場合 => LINE ボタンが出力される' );
-			// LINE の web フォント span に aria-hidden が付いている事を確認 / Check the LINE web font span icon has aria-hidden.
-			$this->assertStringContainsString( $line_expected, $actual, 'useLine が true かつモバイルの場合 => LINE の web フォント span に aria-hidden="true" が付く' );
+				// シェアボタンの HTML を取得 / Get the share button HTML.
+				$actual = veu_get_sns_btns();
 
-			// オプション値をクリーンアップ / Clean up the option value.
-			delete_option( 'vkExUnit_sns_options' );
+				// 期待する文字列が全て含まれる事を確認（装飾アイコン span の aria-hidden 等）/ Check that all expected strings are included ( aria-hidden on the decorative span icon, etc. ).
+				foreach ( $case['expected_contains'] as $expected ) {
+					$this->assertStringContainsString( $expected, $actual, $case['test_condition_name'] );
+				}
+
+				// オプション値をクリーンアップ / Clean up the option value.
+				delete_option( 'vkExUnit_sns_options' );
+			}
 		} finally {
 			// テスト後は $_SERVER['HTTP_USER_AGENT'] を必ず元に戻す（未設定だったら unset）。
 			// Always restore $_SERVER['HTTP_USER_AGENT'] after the test ( unset if it was not set ).

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -441,5 +441,46 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			// オプション値をクリーンアップ / Clean up the option value.
 			delete_option( 'vkExUnit_sns_options' );
 		}
+
+		// 自前 web フォント（vk_sns）の空 span アイコン（fb / x / bluesky / hatena / line）にも aria-hidden="true" が付き読み上げから除外される事のテスト
+		// Test that the empty in-house web font ( vk_sns ) span icons ( fb / x / bluesky / hatena / line ) also get aria-hidden="true" and are hidden from screen readers.
+		// class 直後・$icon_css の前に aria-hidden が入る実出力に合わせてリテラルで検証する。
+		// Verify against the literal output where aria-hidden comes right after class and before $icon_css.
+		$webfont_cases = array(
+			array(
+				'test_condition_name' => 'useFacebook が true の場合 => Facebook の web フォント span に aria-hidden="true" が付く',
+				'options'             => array( 'useFacebook' => true ),
+				'expected'            => '<span class="vk_icon_w_r_sns_fb icon_sns" aria-hidden="true"',
+			),
+			array(
+				'test_condition_name' => 'useTwitter が true の場合 => X の web フォント span に aria-hidden="true" が付く',
+				'options'             => array( 'useTwitter' => true ),
+				'expected'            => '<span class="vk_icon_w_r_sns_x_twitter icon_sns" aria-hidden="true"',
+			),
+			array(
+				'test_condition_name' => 'useBluesky が true の場合 => Bluesky の web フォント span に aria-hidden="true" が付く',
+				'options'             => array( 'useBluesky' => true ),
+				'expected'            => '<span class="vk_icon_w_r_sns_bluesky icon_sns" aria-hidden="true"',
+			),
+			array(
+				'test_condition_name' => 'useHatena が true の場合 => Hatena の web フォント span に aria-hidden="true" が付く',
+				'options'             => array( 'useHatena' => true ),
+				'expected'            => '<span class="vk_icon_w_r_sns_hatena icon_sns" aria-hidden="true"',
+			),
+		);
+
+		foreach ( $webfont_cases as $case ) {
+			// オプション値を設定 / Set option value.
+			update_option( 'vkExUnit_sns_options', $case['options'] );
+
+			// シェアボタンの HTML を取得 / Get the share button HTML.
+			$actual = veu_get_sns_btns();
+
+			// 装飾アイコン（web フォント）の span に aria-hidden が付いている事を確認 / Check the decorative web font span icon has aria-hidden.
+			$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
+
+			// オプション値をクリーンアップ / Clean up the option value.
+			delete_option( 'vkExUnit_sns_options' );
+		}
 	}
 }

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -11,18 +11,6 @@
 class SnsBtnsTest extends WP_UnitTestCase {
 
 	/**
-	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
-	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
-	 *
-	 * @return void
-	 */
-	public function tearDown(): void {
-		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
-		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
-		parent::tearDown();
-	}
-
-	/**
 	 * SNSボタンを本文欄やフックで自動挿入するかしないかのテスト
 	 */
 	function test_veu_is_sns_btns_auto_insert() {

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -482,5 +482,43 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			// オプション値をクリーンアップ / Clean up the option value.
 			delete_option( 'vkExUnit_sns_options' );
 		}
+
+		// LINE の web フォント span アイコンにも aria-hidden="true" が付く事のテスト。
+		// LINE はモバイル環境（wp_is_mobile() が true）かつ useLine が有効な時のみ出力されるため、
+		// 一時的にモバイル UA をセットして分岐を有効化して検証する。
+		// Test that the LINE web font span icon also gets aria-hidden="true".
+		// LINE is only output on mobile ( wp_is_mobile() returns true ) with useLine enabled,
+		// so temporarily set a mobile UA to enable the branch for verification.
+		$line_expected = '<span class="vk_icon_w_r_sns_line icon_sns" aria-hidden="true"';
+		$original_ua   = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
+		// iPhone の UA。文字列に "Mobile" を含むため wp_is_mobile() が true を返す。
+		// iPhone UA. It contains "Mobile", so wp_is_mobile() returns true.
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+		try {
+			// モバイル UA が効いて wp_is_mobile() が true になっている事を前提として確認（false なら UA 設定が効いていないサイン）。
+			// Confirm the mobile UA is in effect and wp_is_mobile() returns true ( false means the UA is not applied ).
+			$this->assertTrue( wp_is_mobile(), 'モバイル UA をセットしたので wp_is_mobile() は true になる' );
+
+			// useLine を有効化してシェアボタンの HTML を取得 / Enable useLine and get the share button HTML.
+			update_option( 'vkExUnit_sns_options', array( 'useLine' => true ) );
+			$actual = veu_get_sns_btns();
+
+			// LINE 分岐が実際に出力されている事（li.sb_line）を確認 / Confirm the LINE branch is actually output.
+			$this->assertStringContainsString( 'sb_line', $actual, 'useLine が true かつモバイルの場合 => LINE ボタンが出力される' );
+			// LINE の web フォント span に aria-hidden が付いている事を確認 / Check the LINE web font span icon has aria-hidden.
+			$this->assertStringContainsString( $line_expected, $actual, 'useLine が true かつモバイルの場合 => LINE の web フォント span に aria-hidden="true" が付く' );
+
+			// オプション値をクリーンアップ / Clean up the option value.
+			delete_option( 'vkExUnit_sns_options' );
+		} finally {
+			// テスト後は $_SERVER['HTTP_USER_AGENT'] を必ず元に戻す（未設定だったら unset）。
+			// Always restore $_SERVER['HTTP_USER_AGENT'] after the test ( unset if it was not set ).
+			if ( null === $original_ua ) {
+				unset( $_SERVER['HTTP_USER_AGENT'] );
+			} else {
+				$_SERVER['HTTP_USER_AGENT'] = $original_ua;
+			}
+		}
 	}
 }

--- a/tests/test-widget-btn.php
+++ b/tests/test-widget-btn.php
@@ -10,18 +10,6 @@
  */
 class WidgetBtnTest extends WP_UnitTestCase {
 
-	/**
-	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
-	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
-	 *
-	 * @return void
-	 */
-	public function tearDown(): void {
-		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
-		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
-		parent::tearDown();
-	}
-
 	function test_get_btn_options() {
 		$tests = array(
 			array(

--- a/tests/test-widget-btn.php
+++ b/tests/test-widget-btn.php
@@ -52,4 +52,44 @@ class WidgetBtnTest extends WP_UnitTestCase {
 			// print 'correct   :' . $test_value['correct'] . PHP_EOL;
 		}
 	}
+
+	/**
+	 * ボタン前後の装飾アイコンの <i> に aria-hidden="true" が付く事のテスト。
+	 * Test that the decorative icons before / after the button label get aria-hidden="true" on their <i>.
+	 *
+	 * @return void
+	 */
+	function test_widget() {
+		// アイコンアクセシビリティのフィルター有無に依存しない事を確かめるため、フィルターを外した状態で検証する。
+		// Verify with the filter removed to confirm the attribute does not depend on the icon accessibility filter.
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
+		$widget = new WP_Widget_Button();
+
+		// ウィジェット出力に必要な最小限の $args / Minimal $args required to render the widget.
+		$args = array(
+			'before_widget' => '',
+			'after_widget'  => '',
+			'before_title'  => '',
+			'after_title'   => '',
+		);
+
+		// 前後アイコンとラベル・リンクをセットしたインスタンス / Instance with before / after icons, a label and a link.
+		$instance = array(
+			'title'       => 'Read more',
+			'linkurl'     => 'https://example.com',
+			'icon_before' => 'fa-solid fa-star',
+			'icon_after'  => 'fa-solid fa-arrow-right',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		// 前後どちらの装飾アイコンにも aria-hidden="true" が付いている事を確認。
+		// Check both the before and after decorative icons have aria-hidden="true".
+		$this->assertStringContainsString( '<i class="fa-solid fa-star font_icon" aria-hidden="true"></i>', $output, 'ボタン前アイコンに aria-hidden が付く' );
+		$this->assertStringContainsString( '<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i>', $output, 'ボタン後アイコンに aria-hidden が付く' );
+	}
 }

--- a/tests/test-widget-btn.php
+++ b/tests/test-widget-btn.php
@@ -75,21 +75,67 @@ class WidgetBtnTest extends WP_UnitTestCase {
 			'after_title'   => '',
 		);
 
-		// 前後アイコンとラベル・リンクをセットしたインスタンス / Instance with before / after icons, a label and a link.
-		$instance = array(
-			'title'       => 'Read more',
-			'linkurl'     => 'https://example.com',
-			'icon_before' => 'fa-solid fa-star',
-			'icon_after'  => 'fa-solid fa-arrow-right',
+		// テスト条件（インスタンス）と、出力に含まれる／含まれない事を期待する文字列の組み合わせ。
+		// アイコン指定のパターンを後から増やしやすいよう配列で持つ。
+		// Combinations of the test instance and the strings expected to be present / absent in the output.
+		// Kept as an array so icon patterns can be added later.
+		$test_cases = array(
+			array(
+				'test_condition_name' => '前後両方のアイコン指定 => 前後どちらの <i> にも aria-hidden が付く',
+				'instance'            => array(
+					'title'       => 'Read more',
+					'linkurl'     => 'https://example.com',
+					'icon_before' => 'fa-solid fa-star',
+					'icon_after'  => 'fa-solid fa-arrow-right',
+				),
+				'contains'            => array(
+					'<i class="fa-solid fa-star font_icon" aria-hidden="true"></i>',
+					'<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i>',
+				),
+				'not_contains'        => array(),
+			),
+			array(
+				'test_condition_name' => '前アイコンのみ指定 => 前の <i> に aria-hidden が付き、後アイコンは出力されない',
+				'instance'            => array(
+					'title'       => 'Read more',
+					'linkurl'     => 'https://example.com',
+					'icon_before' => 'fa-solid fa-star',
+				),
+				'contains'            => array(
+					'<i class="fa-solid fa-star font_icon" aria-hidden="true"></i>',
+				),
+				'not_contains'        => array(
+					'fa-arrow-right',
+				),
+			),
+			array(
+				'test_condition_name' => 'アイコン未指定 => 装飾アイコンの <i>（font_icon）が出力されない',
+				'instance'            => array(
+					'title'   => 'Read more',
+					'linkurl' => 'https://example.com',
+				),
+				'contains'            => array(),
+				'not_contains'        => array(
+					'font_icon',
+				),
+			),
 		);
 
-		ob_start();
-		$widget->widget( $args, $instance );
-		$output = ob_get_clean();
+		foreach ( $test_cases as $case ) {
+			ob_start();
+			$widget->widget( $args, $case['instance'] );
+			$output = ob_get_clean();
 
-		// 前後どちらの装飾アイコンにも aria-hidden="true" が付いている事を確認。
-		// Check both the before and after decorative icons have aria-hidden="true".
-		$this->assertStringContainsString( '<i class="fa-solid fa-star font_icon" aria-hidden="true"></i>', $output, 'ボタン前アイコンに aria-hidden が付く' );
-		$this->assertStringContainsString( '<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i>', $output, 'ボタン後アイコンに aria-hidden が付く' );
+			// 出力に含まれるべき装飾アイコンの <i>（aria-hidden 付き）を確認。
+			// Check the decorative icon <i> ( with aria-hidden ) that must be present in the output.
+			foreach ( $case['contains'] as $needle ) {
+				$this->assertStringContainsString( $needle, $output, $case['test_condition_name'] );
+			}
+			// 出力に含まれてはいけない文字列（未指定アイコン等）を確認。
+			// Check strings that must be absent ( e.g. an icon that was not specified ).
+			foreach ( $case['not_contains'] as $needle ) {
+				$this->assertStringNotContainsString( $needle, $output, $case['test_condition_name'] );
+			}
+		}
 	}
 }

--- a/tests/test-widget-btn.php
+++ b/tests/test-widget-btn.php
@@ -10,6 +10,18 @@
  */
 class WidgetBtnTest extends WP_UnitTestCase {
 
+	/**
+	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
+	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
+		parent::tearDown();
+	}
+
 	function test_get_btn_options() {
 		$tests = array(
 			array(

--- a/tests/test-widget-pr-blocks.php
+++ b/tests/test-widget-pr-blocks.php
@@ -11,18 +11,6 @@
 class WidgetPrBlocksTest extends WP_UnitTestCase {
 
 	/**
-	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
-	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
-	 *
-	 * @return void
-	 */
-	public function tearDown(): void {
-		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
-		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
-		parent::tearDown();
-	}
-
-	/**
 	 * block_count が4未満のとき、存在しないブロックのキーを update() がガードすることのテスト。
 	 *
 	 * update() のループは常にブロック1〜4を処理するが、block_count が3以下のとき

--- a/tests/test-widget-pr-blocks.php
+++ b/tests/test-widget-pr-blocks.php
@@ -11,6 +11,18 @@
 class WidgetPrBlocksTest extends WP_UnitTestCase {
 
 	/**
+	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
+	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
+		parent::tearDown();
+	}
+
+	/**
 	 * block_count が4未満のとき、存在しないブロックのキーを update() がガードすることのテスト。
 	 *
 	 * update() のループは常にブロック1〜4を処理するが、block_count が3以下のとき

--- a/tests/test-widget-pr-blocks.php
+++ b/tests/test-widget-pr-blocks.php
@@ -99,29 +99,77 @@ class WidgetPrBlocksTest extends WP_UnitTestCase {
 			'after_title'   => '',
 		);
 
-		// アイコン（画像未登録・FA クラスあり）を持つブロック1件のインスタンス。
-		// Instance with a single block that has an icon ( no image, FA class present ).
-		$instance = array(
-			'block_count'        => 1,
-			'label_1'            => 'PR Block 1',
-			'media_image_1'      => '',
-			'iconFont_class_1'   => 'fa-solid fa-star',
-			'iconFont_bgColor_1' => '#337ab7',
-			'iconFont_bgType_1'  => '',
-			'summary_1'          => '',
-			'linkurl_1'          => '',
+		// テスト条件（インスタンス）と期待する結果の組み合わせ。
+		// アイコン／画像のパターンを後から増やしやすいよう配列で持つ。
+		// Combinations of the test instance and expected result.
+		// Kept as an array so icon / image patterns can be added later.
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'FA アイコンクラス（星）指定 => prBlock_icon の <i> に aria-hidden が付く',
+				'instance'            => array(
+					'block_count'        => 1,
+					'label_1'            => 'PR Block 1',
+					'media_image_1'      => '',
+					'iconFont_class_1'   => 'fa-solid fa-star',
+					'iconFont_bgColor_1' => '#337ab7',
+					'iconFont_bgType_1'  => '',
+					'summary_1'          => '',
+					'linkurl_1'          => '',
+				),
+				'expected_has_icon'   => true,
+				'expected_icon_class' => 'fa-solid fa-star',
+			),
+			array(
+				'test_condition_name' => 'FA アイコンクラス（ハート）指定 => prBlock_icon の <i> に aria-hidden が付く',
+				'instance'            => array(
+					'block_count'        => 1,
+					'label_1'            => 'PR Block 1',
+					'media_image_1'      => '',
+					'iconFont_class_1'   => 'fa-solid fa-heart',
+					'iconFont_bgColor_1' => '#337ab7',
+					'iconFont_bgType_1'  => '',
+					'summary_1'          => '',
+					'linkurl_1'          => '',
+				),
+				'expected_has_icon'   => true,
+				'expected_icon_class' => 'fa-solid fa-heart',
+			),
+			array(
+				'test_condition_name' => '画像指定（アイコン未使用）=> prBlock_icon の <i> が出力されない',
+				'instance'            => array(
+					'block_count'        => 1,
+					'label_1'            => 'PR Block 1',
+					'media_image_1'      => 'https://example.com/image.jpg',
+					'media_alt_1'        => 'sample',
+					'iconFont_class_1'   => 'fa-solid fa-star',
+					'iconFont_bgColor_1' => '#337ab7',
+					'iconFont_bgType_1'  => '',
+					'summary_1'          => '',
+					'linkurl_1'          => '',
+				),
+				'expected_has_icon'   => false,
+				'expected_icon_class' => '',
+			),
 		);
 
-		ob_start();
-		$widget->widget( $args, $instance );
-		$output = ob_get_clean();
+		foreach ( $test_cases as $case ) {
+			ob_start();
+			$widget->widget( $args, $case['instance'] );
+			$output = ob_get_clean();
 
-		// アイコンの <i>（prBlock_icon）に aria-hidden="true" が付いている事を確認。
-		// Check the icon's <i> ( prBlock_icon ) has aria-hidden="true".
-		$this->assertMatchesRegularExpression(
-			'/<i class="fa-solid fa-star font_icon prBlock_icon"[^>]*aria-hidden="true"[^>]*><\/i>/',
-			$output,
-			'PR ブロックのアイコンに aria-hidden が付く'
-		);
+			if ( $case['expected_has_icon'] ) {
+				// アイコンの <i>（prBlock_icon）に aria-hidden="true" が付いている事を確認。
+				// Check the icon's <i> ( prBlock_icon ) has aria-hidden="true".
+				$this->assertMatchesRegularExpression(
+					'/<i class="' . preg_quote( $case['expected_icon_class'], '/' ) . ' font_icon prBlock_icon"[^>]*aria-hidden="true"[^>]*><\/i>/',
+					$output,
+					$case['test_condition_name']
+				);
+			} else {
+				// 画像指定時はアイコンの <i>（prBlock_icon）が出力されない事を確認。
+				// When an image is set, the icon's <i> ( prBlock_icon ) must not be output.
+				$this->assertStringNotContainsString( 'prBlock_icon', $output, $case['test_condition_name'] );
+			}
+		}
 	}
 }

--- a/tests/test-widget-pr-blocks.php
+++ b/tests/test-widget-pr-blocks.php
@@ -76,4 +76,52 @@ class WidgetPrBlocksTest extends WP_UnitTestCase {
 			$this->assertFalse( $result[ 'blank_' . $missing ], $case['test_condition_name'] . ' / blank_' . $missing );
 		}
 	}
+
+	/**
+	 * PR ブロックの装飾アイコンの <i> に aria-hidden="true" が付く事のテスト。
+	 * Test that the PR block's decorative icon gets aria-hidden="true" on its <i>.
+	 *
+	 * @return void
+	 */
+	function test_widget() {
+		// アイコンアクセシビリティのフィルター有無に依存しない事を確かめるため、フィルターを外した状態で検証する。
+		// Verify with the filter removed to confirm the attribute does not depend on the icon accessibility filter.
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
+		$widget = new WP_Widget_vkExUnit_PR_Blocks();
+
+		// ウィジェット出力に必要な最小限の $args / Minimal $args required to render the widget.
+		$args = array(
+			'before_widget' => '',
+			'after_widget'  => '',
+			'before_title'  => '',
+			'after_title'   => '',
+		);
+
+		// アイコン（画像未登録・FA クラスあり）を持つブロック1件のインスタンス。
+		// Instance with a single block that has an icon ( no image, FA class present ).
+		$instance = array(
+			'block_count'        => 1,
+			'label_1'            => 'PR Block 1',
+			'media_image_1'      => '',
+			'iconFont_class_1'   => 'fa-solid fa-star',
+			'iconFont_bgColor_1' => '#337ab7',
+			'iconFont_bgType_1'  => '',
+			'summary_1'          => '',
+			'linkurl_1'          => '',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		// アイコンの <i>（prBlock_icon）に aria-hidden="true" が付いている事を確認。
+		// Check the icon's <i> ( prBlock_icon ) has aria-hidden="true".
+		$this->assertMatchesRegularExpression(
+			'/<i class="fa-solid fa-star font_icon prBlock_icon"[^>]*aria-hidden="true"[^>]*><\/i>/',
+			$output,
+			'PR ブロックのアイコンに aria-hidden が付く'
+		);
+	}
 }

--- a/tests/test-widget-profile.php
+++ b/tests/test-widget-profile.php
@@ -292,4 +292,82 @@ class WidgetProfileTest extends WP_UnitTestCase {
 			$this->assertSame( $case['expected_media_align_left'], $result['mediaAlign_left'], $case['test_condition_name'] );
 		}
 	}
+
+	/**
+	 * SNS フォローリンク（アイコンのみリンク）に aria-label と、中の <i> の aria-hidden="true" が付く事のテスト。
+	 * Test that the SNS follow links ( icon-only links ) get an aria-label and aria-hidden="true" on the inner <i>.
+	 *
+	 * @return void
+	 */
+	function test_widget() {
+		// アイコンアクセシビリティのフィルター有無に依存しない事を確かめるため、フィルターを外した状態で検証する。
+		// Verify with the filter removed to confirm the attributes do not depend on the icon accessibility filter.
+		remove_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		remove_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10 );
+
+		$widget = new WP_Widget_vkExUnit_profile();
+
+		// ウィジェット出力に必要な最小限の $args / Minimal $args required to render the widget.
+		$args = array(
+			'before_widget' => '',
+			'after_widget'  => '',
+			'before_title'  => '',
+			'after_title'   => '',
+		);
+
+		// 各 SNS リンクに期待する aria-label と、その <i> のアイコンクラスの組み合わせ。
+		// The expected aria-label for each SNS link and the icon class of its <i>.
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'Facebook => aria-label="Follow us on Facebook" と <i> の aria-hidden',
+				'instance_key'        => 'facebook',
+				'url'                 => 'https://www.facebook.com/vektor/',
+				'icon_class'          => 'fa-brands fa-facebook-f',
+				'aria_label'          => 'Follow us on Facebook',
+			),
+			array(
+				'test_condition_name' => 'X (Twitter) => aria-label="Follow us on X (Twitter)" と <i> の aria-hidden',
+				'instance_key'        => 'twitter',
+				'url'                 => 'https://twitter.com/vektor/',
+				'icon_class'          => 'fa-brands fa-x-twitter',
+				'aria_label'          => 'Follow us on X (Twitter)',
+			),
+			array(
+				'test_condition_name' => 'メール => aria-label="Email" と <i> の aria-hidden',
+				'instance_key'        => 'mail',
+				'url'                 => 'mailto:info@example.com',
+				'icon_class'          => 'fa-solid fa-envelope',
+				'aria_label'          => 'Email',
+			),
+			array(
+				'test_condition_name' => 'RSS => aria-label="Subscribe via RSS" と <i> の aria-hidden',
+				'instance_key'        => 'rss',
+				'url'                 => 'https://example.com/feed/',
+				'icon_class'          => 'fa-solid fa-rss',
+				'aria_label'          => 'Subscribe via RSS',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			// 対象の SNS のみ URL をセットしたインスタンスでウィジェットを描画する。
+			// Render the widget with an instance that only sets the URL for the target SNS.
+			$instance = array( $case['instance_key'] => $case['url'] );
+
+			ob_start();
+			$widget->widget( $args, $instance );
+			$output = ob_get_clean();
+
+			// リンク（<a>）に aria-label（読み上げ名）が付いている事を確認。
+			// Check the link ( <a> ) has an aria-label ( accessible name ).
+			$this->assertStringContainsString( 'aria-label="' . $case['aria_label'] . '"', $output, $case['test_condition_name'] );
+
+			// 中の <i>（該当アイコンクラス）に aria-hidden="true" が付いている事を確認。
+			// Check the inner <i> ( with the matching icon class ) has aria-hidden="true".
+			$this->assertMatchesRegularExpression(
+				'/<i class="' . preg_quote( $case['icon_class'], '/' ) . ' icon"[^>]*aria-hidden="true"[^>]*><\/i>/',
+				$output,
+				$case['test_condition_name']
+			);
+		}
+	}
 }

--- a/tests/test-widget-profile.php
+++ b/tests/test-widget-profile.php
@@ -10,18 +10,6 @@
  */
 class WidgetProfileTest extends WP_UnitTestCase {
 
-	/**
-	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
-	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
-	 *
-	 * @return void
-	 */
-	public function tearDown(): void {
-		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
-		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
-		parent::tearDown();
-	}
-
 	function test_image_align() {
 
 		$test_media_align = array(

--- a/tests/test-widget-profile.php
+++ b/tests/test-widget-profile.php
@@ -346,6 +346,27 @@ class WidgetProfileTest extends WP_UnitTestCase {
 				'icon_class'          => 'fa-solid fa-rss',
 				'aria_label'          => 'Subscribe via RSS',
 			),
+			array(
+				'test_condition_name' => 'YouTube => aria-label="Follow us on YouTube" と <i> の aria-hidden',
+				'instance_key'        => 'youtube',
+				'url'                 => 'https://www.youtube.com/@vektor',
+				'icon_class'          => 'fa-brands fa-youtube',
+				'aria_label'          => 'Follow us on YouTube',
+			),
+			array(
+				'test_condition_name' => 'Instagram => aria-label="Follow us on Instagram" と <i> の aria-hidden',
+				'instance_key'        => 'instagram',
+				'url'                 => 'https://www.instagram.com/vektor/',
+				'icon_class'          => 'fa-brands fa-instagram',
+				'aria_label'          => 'Follow us on Instagram',
+			),
+			array(
+				'test_condition_name' => 'LinkedIn => aria-label="Follow us on LinkedIn" と <i> の aria-hidden',
+				'instance_key'        => 'linkedin',
+				'url'                 => 'https://www.linkedin.com/company/vektor/',
+				'icon_class'          => 'fa-brands fa-linkedin',
+				'aria_label'          => 'Follow us on LinkedIn',
+			),
 		);
 
 		foreach ( $test_cases as $case ) {

--- a/tests/test-widget-profile.php
+++ b/tests/test-widget-profile.php
@@ -10,6 +10,18 @@
  */
 class WidgetProfileTest extends WP_UnitTestCase {
 
+	/**
+	 * 各テスト後に、アイコンアクセシビリティのフィルターを元の登録内容で復元する。
+	 * Restore the icon accessibility filters ( with the original arguments / priority ) after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		add_filter( 'the_content', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ) );
+		add_filter( 'render_block', array( 'VEU_Icon_Accessibility', 'add_aria_hidden_to_fontawesome' ), 10, 2 );
+		parent::tearDown();
+	}
+
 	function test_image_align() {
 
 		$test_media_align = array(


### PR DESCRIPTION
## 関連Issue
- 関連Issue: vektor-inc/multi-repo-tasks#19

横断 issue #19（装飾アイコンの読み上げ抑止・aria 付与）の **ExUnit 分**です。他リポジトリ分（vk-blocks-pro ほか）は本 PR のスコープ外です。

## 変更の目的・理由
ExUnit が PHP で直接出力する装飾目的の FontAwesome アイコンに `aria-hidden="true"` が無く、スクリーンリーダーがアイコン（意味のない記号やアイコン名）を読み上げてしまう問題を解消します。あわせて、アイコンのみで可視テキストを持たないリンク（プロフィールウィジェットの SNS リンク）に読み上げ名（`aria-label`）を付与し、匿名リンクにならないようにします。

参照: WCAG 4.1.2（名前・役割・値）／ 1.1.1（非テキストコンテンツ）

既存の一括付与フィルタ `VEU_Icon_Accessibility`（`render_block` / `the_content`）は、ExUnit 自身が PHP で直接出力するアイコン（ウィジェット・アクションフック・ショートコード経由）には構造的に届きません（優先度・実行タイミングのずれ）。そのため各箇所へインラインで属性を付与する方針としました（issue #19 の「一括置換ではなく個別判定」方針に準拠）。

## 実装内容
PHP 直書きの装飾アイコン19箇所（フロント15 ＋ 管理画面4）に `aria-hidden="true"`、アイコンのみリンク1箇所に `aria-label` ＋ 内側 `<i>` に `aria-hidden="true"` を付与しました。

### 主な変更点
- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] その他: アクセシビリティ対応（装飾アイコンの読み上げ抑止・アイコンのみリンクへの名前付与）

**装飾（`<i>` に `aria-hidden="true"`）:**
- 関連記事の日付前アイコン（related_posts）
- SNS シェアボタンのアイコン（sns）：Threads / Copy（FontAwesome）に加え、Facebook / X / Bluesky / Hatena / LINE（自前 web フォント vk_sns の CSS 疑似要素グリフ）も含む全アイコン。各ボタンは可視ラベル（`.sns_txt`）で読み上げ名を確保
- ボタン／PR ブロックウィジェットのアイコン（other-widget）
- 広告表記アイコン（promotion-alert）
- お問い合わせセクションの電話アイコン・ボタンの封筒／矢印（contact-section）
- CTA（古典・ブロック）の前後アイコン（call-to-action）
- 管理画面メタボックスの開閉キャレット（admin・「Open all / Close all」ボタン、セクションタイトルの開閉インジケータ）

**アイコンのみリンク（`aria-label` ＋ `<i>` に `aria-hidden`）:**
- プロフィールウィジェットの SNS フォローリンク（Facebook / X (Twitter) / YouTube / Instagram / LinkedIn / RSS / メール）。文型のみ i18n（`Follow us on %s` 等）、ブランド名はプレースホルダにしています。

### 技術的な詳細
- 既存の一括フィルタ `VEU_Icon_Accessibility` は未変更です。インライン付与のため「アイコンアクセシビリティ」機能（`icon_accessibility` パッケージ）を OFF にしても装飾の読み上げ除外が残ります。フィルタ側は既存の `aria-hidden` を検知してスキップするため、機能 ON 時も二重付与になりません。
- 対象はすべて PHP 実行時出力で、ブロックの save.js 静的 HTML には非関与です（お問い合わせ・CTA は動的ブロック）。ブロックの検証エラーや deprecated 対応は不要です。
- `promotion-alert` は独自 kses 許可リストに `aria-hidden` が登録済みのため属性が保持されます。
- `contact-section` の電話アイコンは保存値（クラス文字列でも `<i>` タグ丸ごとでも）どちらでも、描画時に `aria-hidden` を付与します。
- pre-commit の phpcbf により `promotion-alert` の代入アライメント1行が自動整形されています（出力は不変）。
- 管理画面（`admin/class-veu-metabox.php`・`admin/admin-post-metabox.php`）の開閉キャレットも、フロントと同じ装飾扱いで `aria-hidden` のみ付与しています。いずれも見出し（`<h3>`）やボタンに可視テキストがあり、キャレット自体はフォーカス可能な操作要素ではないため `aria-label` は不要です。

## スクリーンショット
見た目の変化はありません（ARIA 属性の追加のみで、視覚描画・レイアウト・CSS は不変）。確認はアクセシビリティツリーで行うため、下記のテスト手順を参照してください。

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない（phpcbf による代入アライメント1行の自動整形のみ・上記に明記）
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み
- [x] 既存のテストが通ることを確認（PHPUnit 26 tests / 174 assertions グリーン）
- [x] 手動テストを実施済み（レビュー工程で実施予定）

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順

前提: ExUnit を有効化。確認は Chrome DevTools のアクセシビリティパネルで行います。

**A. アイコンのみリンクに名前が付いたか（プロフィールウィジェットの SNS）**
1. 管理画面 > 外観 > ウィジェット で「[ExUnit] プロフィール」ウィジェットを配置し、いずれかの SNS（例: Facebook）に URL を入力して保存する → フロントに SNS アイコンリンクが表示される
2. フロントで該当ページを開き、SNS アイコンリンクを右クリック > 検証（Chrome DevTools）で HTML を確認する → `<a ... aria-label="Follow us on Facebook">` と、内側の `<i ... aria-hidden="true">` が付いている
3. DevTools の Accessibility パネルで当該リンクを選択し Name を確認する → 「Follow us on Facebook」等の読み上げ名が表示される（変更前は名前が空、または URL が直読みされる）

**B. 装飾アイコンが読み上げツリーから外れるか（関連記事の日付）**
1. 関連記事が表示される投稿ページを開く
2. 日付の前のカレンダーアイコンを検証する → `<i class="fa fa-calendar" aria-hidden="true">` になっている
3. Accessibility パネルのツリーで、当該アイコンがツリーに現れないことを確認する（変更前はアイコン要素がツリーに出る）

**デグレ確認:** すべての対象箇所で、アイコンの表示位置・サイズ・色が変更前と同一であること（属性追加のみのため見た目は変わらない想定）。

### レビューポイント（任意）
- `inc/other-widget/widget-profile.php` の SNS `aria_label`（文型のみ i18n・ブランド名はプレースホルダ）が意図どおりか
- CTA ブロックのインライン付与と既存 `render_block` フィルタが二重付与にならないこと

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] 正しいディレクトリで作業している
- [ ] キャッシュをクリアしている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **アクセシビリティ**
  * ボタン、開閉キャレット、アラート/カレンダー等の装飾アイコンをスクリーンリーダーの読み上げ対象から除外しました（`aria-hidden="true"`）。
  * SNS共有/プロフィールなどでは、必要な要素にアクセシブルなラベル（`aria-label`）を追加・調整しました。
* **テスト**
  * 問い合わせ、CTA、関連記事、プロモーション、SNS、各ウィジェットの表示（ARIA含む）を検証するテストを追加・更新しました。
* **ドキュメント**
  * 変更内容を更新履歴に追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->