### PR TITLE
[ 開発環境 ] リリースワークフローの wp-env override が読み込まれず dist ではなく source を検証してしまう問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
                   path: dist/
             - name: Setup wp-env override for dist
               run: |
-                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > wp-env.override.json
+                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > .wp-env.override.json
             - name: Start wp-env
               run: |
                   for n in 1 2 3; do npx wp-env start --update && break || [ "$n" -lt 3 ] || exit 1; done
@@ -89,7 +89,7 @@ jobs:
                   [ -d tests ] && cp -r tests "dist/${{ env.plugin_name }}/tests" || true
             - name: Setup wp-env override for dist
               run: |
-                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > wp-env.override.json
+                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > .wp-env.override.json
             - name: Start wp-env
               run: |
                   for n in 1 2 3; do npx wp-env start --update && break || [ "$n" -lt 3 ] || exit 1; done


### PR DESCRIPTION
## 概要

リリースワークフロー `release.yml` の C-7 移行不備（親 issue vektor-inc/vk-agents#168）のフォローアップです。

`smoke_test` / `php_unit` ジョブの「Setup wp-env override for dist」ステップで、wp-env の設定オーバーライドを **`wp-env.override.json`（先頭ドット無し）** に書き出していました。wp-env が実際に読み込むのは **`.wp-env.override.json`（先頭ドット有り）** のため、このオーバーライドは無視され、`.wp-env.json` の `"plugins": ["."]`（＝リポジトリ source）が使われていました。

結果として、リリース時の smoke test / phpunit が「実際に配布される dist」ではなく「ビルド前の source」を検証してしまう状態でした。本 PR で出力先を `.wp-env.override.json` にリネームし、意図どおり dist を検証するように是正します。

## 変更内容

- `.github/workflows/release.yml` の 2 箇所（`smoke_test` ジョブ・`php_unit` ジョブ）で、wp-env override の出力先を `wp-env.override.json` → `.wp-env.override.json` に修正

```diff
             - name: Setup wp-env override for dist
               run: |
-                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > wp-env.override.json
+                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > .wp-env.override.json
```

## 対応しなかった項目（調査結果）

元 issue のもう 1 点「WP-CLI 導入の要否」は **対応不要** と判断しました。

- `npm run dist` = `composer install` + `npm run build` + `gulp dist` + zip
- `npm run build` = `gulp text-domain`（文字列置換のみ）+ `wp-scripts`/webpack + `gulp build`
- `gulpfile.js` に `wp i18n make-pot` 等の `wp` コマンド呼び出し・`child_process` は無く、`translate` スクリプトも存在しない

→ `wp` コマンドに非依存のため WP-CLI 導入ステップは追加していません。

## テスト（確認手順）

このワークフローはタグ push（`[0-9]+.[0-9]+.[0-9]+`）でのみ発火するため、静的に確認します。

**Before（修正前・master）**

1. `.github/workflows/release.yml` を開く → `smoke_test` / `php_unit` の「Setup wp-env override for dist」で `> wp-env.override.json`（先頭ドット無し）に書き出している
2. リポジトリ `.wp-env.json` は `"plugins": ["."]` → wp-env はドット無しファイルを読まないため source が起動対象になる（dist を検証できていない）

**After（修正後・本ブランチ）**

1. `.github/workflows/release.yml` を開く → 上記 2 箇所が `> .wp-env.override.json`（先頭ドット有り）になっている
   → `grep -n 'wp-env.override.json' .github/workflows/release.yml` の結果が両方ドット付きであることを確認
2. wp-env が `.wp-env.override.json` を読み込み、`./dist/vk-all-in-one-expansion-unit` が起動対象になる（dist を検証する）
3. 生成される `.wp-env.override.json` は `.distignore`（`.wp-env.override.json` / `*.override.json`）で除外済みのため、配布 zip には含まれない

## 補足

- changelog: `.github/workflows/*.yml` の変更（GitHub Actions ワークフロー設定）で、エンドユーザーに影響しないため `readme.txt` への追記なし（changelog ルールの「更新不要なケース」）
- 参照実装: vektor-inc/vk-ab-testing `6139ed7` / `7546b93`

関連 issue: https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1414
Ref: vektor-inc/vk-agents#168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース前のスモークテストおよびPHPユニットテストで、テスト環境の設定が正しく読み込まれるよう改善しました。
  * これにより、リリース検証時の環境設定に関する不整合を防ぎ、テストの安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/281