### PR TITLE
[ 仕様変更 ][ ウィジェット・CTA ] 各ウィジェットとCTAの見出しタグを h1 から h2 に変更（複数h1の解消）

### DIFF
--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -271,7 +271,7 @@ function veu_cta_block_callback( $attributes, $content ) {
 						}
 
 						$content .= '<section class="veu_cta" id="veu_cta-' . $cta_id . '">';
-						$content .= '<h1 class="cta_title">' . $cta_post->post_title . '</h1>';
+						$content .= '<h2 class="cta_title">' . $cta_post->post_title . '</h2>';
 						$content .= '<div class="cta_body">';
 
 						// 別ウィンドウで開くかどうかのカスタムフィールドの値を取得 //////.

--- a/inc/call-to-action/package/view-actionbox.php
+++ b/inc/call-to-action/package/view-actionbox.php
@@ -61,7 +61,7 @@ if ( ! $image_position ) {
 
 $content  = '';
 $content .= '<section class="veu_cta" id="veu_cta-' . $id . '">';
-$content .= '<h1 class="cta_title">' . $cta_post->post_title . '</h1>';
+$content .= '<h2 class="cta_title">' . $cta_post->post_title . '</h2>';
 $content .= '<div class="cta_body">';
 
 

--- a/inc/other-widget/widget-3pr-area.php
+++ b/inc/other-widget/widget-3pr-area.php
@@ -164,13 +164,13 @@ value="true" />
 			if ( isset( $instance[ 'label_' . $i ] ) && $instance[ 'label_' . $i ] ) {
 				echo '<div class="prArea col-sm-4">';
 
-				echo '<h1 class="subSection-title">';
+				echo '<h2 class="subSection-title">';
 				if ( isset( $instance[ 'label_' . $i ] ) && $instance[ 'label_' . $i ] ) {
 					echo wp_kses_post( $instance[ 'label_' . $i ] );
 				} else {
 					_e( '3PR area', 'vk-all-in-one-expansion-unit' );
 				}
-				echo '</h1>';
+				echo '</h2>';
 
 				$blank = ( isset( $instance[ 'blank_' . $i ] ) && $instance[ 'blank_' . $i ] ) ? ' target="_blank" ' : '';
 

--- a/inc/other-widget/widget-pr-blocks.php
+++ b/inc/other-widget/widget-pr-blocks.php
@@ -308,13 +308,13 @@ class WP_Widget_vkExUnit_PR_Blocks extends WP_Widget {
 					echo '</div><!--//.prBlock_image -->';
 				}
 				// title text
-				echo '<h1 class="prBlock_title">';
+				echo '<h2 class="prBlock_title">';
 				if ( isset( $instance[ 'label_' . $i ] ) && $instance[ 'label_' . $i ] ) {
 					echo wp_kses_post( $instance[ 'label_' . $i ] );
 				} else {
 					_e( 'PR Block', 'vk-all-in-one-expansion-unit' );
 				}
-				echo '</h1>' . PHP_EOL;
+				echo '</h2>' . PHP_EOL;
 
 				// summary text
 				if ( ! empty( $instance[ 'summary_' . $i ] ) ) {

--- a/inc/related_posts/related_posts.php
+++ b/inc/related_posts/related_posts.php
@@ -231,7 +231,7 @@ function veu_get_related_posts_html() {
 		}
 		// 書き換え用フィルターフック（カスタマイザーで変更出来るが、既存ユーザーで使用しているかもしれないため削除不可）.
 		$related_post_title  = apply_filters( 'veu_related_post_title', $related_post_title );
-		$related_posts_html .= '<h1 class="mainSection-title relatedPosts_title">' . $related_post_title . '</h1>';
+		$related_posts_html .= '<h2 class="mainSection-title relatedPosts_title">' . $related_post_title . '</h2>';
 
 		$i                   = 1;
 		$related_posts_html .= '<div class="row">';

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ e.g.
 
 == Changelog ==
 
-[ Spec Change ][ Widget ] Changed the heading tag of the Related Posts and 3PR Area widgets from `<h1>` to `<h2>` to avoid multiple `<h1>` elements on a page ( the CSS class names are unchanged, so class-based styling is unaffected ).
+[ Spec Change ] Changed the heading tag of the Related Posts, 3PR Area and PR Blocks widgets, and the Call To Action block / shortcode, from `<h1>` to `<h2>` to avoid multiple `<h1>` elements on a page ( the CSS class names are unchanged, so class-based styling is unaffected ).
 [ Spec Change ] Hid decorative icons from screen readers so they are no longer read aloud together with the visible label.
 [ Spec Change ] Added accessible names to the Profile widget's icon-only social media links.
 [ Bug Fix ][ Widget ] Fixed a PHP warning that occurred on the admin widget form of the Recent Posts widget when its title was empty.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ e.g.
 
 == Changelog ==
 
+[ Spec Change ][ Widget ] Changed the heading tag of the Related Posts and 3PR Area widgets from `<h1>` to `<h2>` to avoid multiple `<h1>` elements on a page ( the CSS class names are unchanged, so class-based styling is unaffected ).
 [ Bug Fix ][ Widget ] Fixed a PHP warning that occurred on the admin widget form of the Recent Posts widget when its title was empty.
 [ Bug Fix ] Fixed PHP warnings, notices and deprecations ( and a potential fatal error ) logged in debug mode on recent PHP versions, while keeping PHP 7.4 support.
 [ Bug Fix ][ CTA ] Fixed the CTA image not being saved and the button text / message losing their allowed HTML when saved from the classic edit screen.

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -698,7 +698,7 @@ class CTATest extends WP_UnitTestCase {
 					'vkExUnit_cta_button_text' => 'Read more',
 					'vkExUnit_cta_url'         => 'https://example.com',
 				),
-				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">Read more</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h2 class="cta_title">Classic Title</h2><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">Read more</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 			'classic CTA XSS test'     => array(
 				'cta_title'   => 'Classic Title',
@@ -708,7 +708,7 @@ class CTATest extends WP_UnitTestCase {
 					'vkExUnit_cta_button_text' => '"><script>alert(0)</script>',
 					'vkExUnit_cta_url'         => 'https://example.com',
 				),
-				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">"&gt;alert(0)</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">"&gt;alert(0)</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h2 class="cta_title">Classic Title</h2><div class="cta_body"><div class="cta_body_txt image_no">"&gt;alert(0)</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">"&gt;alert(0)</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 			// 前後アイコン付きの古典CTA：装飾アイコンの <i> に aria-hidden="true" が付く事を検証する。
 			// Classic CTA with before / after icons: verify the decorative icons' <i> get aria-hidden="true".
@@ -722,7 +722,7 @@ class CTATest extends WP_UnitTestCase {
 					'vkExUnit_cta_button_icon_before' => 'fa-solid fa-star',
 					'vkExUnit_cta_button_icon_after'  => 'fa-solid fa-arrow-right',
 				),
-				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank"><i class="fa-solid fa-star font_icon" aria-hidden="true"></i> Read more<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i> </a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h2 class="cta_title">Classic Title</h2><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank"><i class="fa-solid fa-star font_icon" aria-hidden="true"></i> Read more<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i> </a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 		);
 


### PR DESCRIPTION
## 関連Issue
- 関連Issue: #1382
- https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1382

## 変更の目的・理由
ExUnit の以下のウィジェット・機能が、投稿本文の下に追加の `<h1>` を出力していました。投稿ページでは記事タイトルが `<h1>` のため、1ページ内に複数の `<h1>` が現れて見出し階層が崩れ、スクリーンリーダーの見出しジャンプや自動アクセシビリティ検証（WAVE 等）で「複数の H1」の注意喚起の原因になります（WCAG 1.3.1 情報及び関係性）。該当箇所の見出しを `<h2>` にすることで、記事タイトル `<h1>` → 各見出し `<h2>` という自然な階層に整えます。

- 関連記事ウィジェット
- 3PR エリアウィジェット
- PR ブロックウィジェット
- CTA（クラシック版 / ブロック版・ショートコード）

### 背景：なぜ元々 h1 だったのか（歴史的経緯・出典）

git履歴を辿ると、関連記事・3PRエリア・PRブロックの各ウィジェットは、2015年に同時期の仕様変更で `<h1>` が採用されていました。

| 対象 | コミット | 日付 | コミットメッセージ |
|---|---|---|---|
| 関連記事ウィジェット | `b8511f5c` | 2015-09-11 | `[ 仕様変更 ][ デザイン・マークアップ ] ウィジェットタイトルやセクションのタイトル調整` |
| 3PRエリアウィジェット | `b707af2b` ほか | 2015 | 初期実装の段階で `<h1 class="subSection-title">` を採用 |
| PR ブロックウィジェット | `039f7034` | 2015-08-11 | `VK PR Blocks に変更 / 3カラム or 4カラムを選択できる機能追加 #58` |
| 同パターン採用の発端 | `fd765c39` | 2015-08-04 | `[ fbPagePlugin Widget / Profile Widget ][ 仕様変更 ][ マークアップ変更 ] 外側のタグを div → aside に、見出しを h1 に変更` |

CTA（クラシック版 / ブロック版）についても同じマークアップパターン（`<h1 class="cta_title">`）が踏襲されていました。

当時の設計意図は、初期のHTML5仕様ドラフトにあった「ドキュメントアウトラインアルゴリズム」（`<section>` / `<article>` / `<aside>` などのセクション要素内に置かれた `<h1>` を、ネストの深さに応じて自動的に下位の見出しレベルとして扱うという仕様）を前提にしていたと推定されます。クラス名 `mainSection-title` / `subSection-title` がその意図を示しています。

ただし、このアウトラインアルゴリズムは**どのブラウザ・支援技術にも実装されないまま**、2022年にWHATWG Living Standardから正式に削除されました（W3C側はそもそも最終仕様に載せたことがなく、HTML 5.1で「h1〜h6タグの並びで文書構造を伝えるべき」と明記）。今の支援技術・自動a11y検証ツールはこの未実装仕様を前提にしておらず、単純に「文書内のh1〜h6タグの並び」だけを見て見出し階層を判定するため、現状は複数h1が存在する状態として扱われ、階層が崩れて見えます。

**出典:**
- [There Is No Document Outline Algorithm — Adrian Roselli](https://adrianroselli.com/2016/08/there-is-no-document-outline-algorithm.html)
- [HTML Outlining Algorithm — Bruce Lawson](https://brucelawson.co.uk/2022/why-the-html-outlining-algorithm-was-removed-from-the-spec-the-truth-will-shock-you/)
- [Document Outlines in HTML 5.1 — bitsofco.de](https://bitsofco.de/document-outlines-in-html-5-1/)

**補足（自動検証ツールについて）:** axe-core / Lighthouse には「複数h1」を検知するルール自体が存在しません（[dequelabs/axe-core#1544](https://github.com/dequelabs/axe-core/issues/1544)で意図的に未実装と明言されています）。「複数の H1」を実際に警告（Alert）として検知するのは WAVE のみです。複数h1はWCAG的にも形式的な違反ではなく、WebAIMのベストプラクティス上の推奨に留まりますが、記事本文と常時同時に見える今回のケースでは、実質的な使い勝手の観点で見出しを整理する価値があると判断しました。

## 実装内容
以下5ファイルの見出しタグを `<h1>` → `<h2>` に変更しました。**クラス名は変更していません**（`mainSection-title` / `subSection-title` / `relatedPosts_title` / `prBlock_title` / `cta_title`）。

### 主な変更点
- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] その他: アクセシビリティ改善（ウィジェット・CTAの見出し階層修正）

### 技術的な詳細
- `inc/related_posts/related_posts.php`（関連記事ウィジェット）: `<h1 class="mainSection-title relatedPosts_title">` → `<h2 ...>`
- `inc/other-widget/widget-3pr-area.php`（3PRエリアウィジェット）: `<h1 class="subSection-title">` → `<h2 ...>`
- `inc/other-widget/widget-pr-blocks.php`（PRブロックウィジェット）: `<h1 class="prBlock_title">` → `<h2 ...>`
- `inc/call-to-action/package/view-actionbox.php`（CTA クラシック版）: `<h1 class="cta_title">` → `<h2 ...>`
- `inc/call-to-action/package/block/index.php`（CTA ブロック版・ショートコード）: `<h1 class="cta_title">` → `<h2 ...>`
- `tests/test-cta.php`: CTAの出力HTMLを検証している既存テストの期待値（`<h1 class="cta_title">` → `<h2 ...>`）を3箇所更新
- `readme.txt`: changelog に1行追記（`[ Spec Change ]`、5箇所まとめた表現）

**既存ユーザーへの影響**: CSS をクラスセレクタ（`.mainSection-title` / `.subSection-title` / `.prBlock_title` / `.cta_title` など）で指定している場合は影響ありません。子孫タグセレクタ（例: `aside.veu_relatedPosts h1 { ... }` や `.veu_cta h1 { ... }`）でタグ名を使って装飾していた場合のみ、そのルールが当たらなくなります。この点は changelog（readme.txt）にも明記しました。

## スクリーンショット
クラス名を維持しているため**視覚的な変更はありません**（変わるのは見出しの意味的なレベルのみ）。そのため Before / After スクリーンショットは省略します。視覚回帰がないことの確認手順は下記テスト手順に記載しています。

### Before（変更前）
（視覚的変更なし）

### After（変更後）
（視覚的変更なし）

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み（CTAの出力HTMLを検証する既存テストの期待値を更新。他4ファイルは見出しタグ名のみの変更で単体テストになじむ新規関数がないため対象外）
- [x] 既存のテストが通ることを確認（wp-env 経由で PHPUnit フルスイートを実行し、114/114 PASS）
- [x] 手動テストを実施済み（wp-env 隔離環境で e2e 実施・PASS。5箇所とも `<h2>` 出力、ページ内 h1 は記事タイトル1つのみ、視覚回帰なし）

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順
1. 関連記事ウィジェットが表示されるテンプレート（個別投稿の下部など）を開く → 関連記事タイトルの出力 HTML が `<h2 class="mainSection-title relatedPosts_title">` になっている
2. 3PR エリアウィジェットをサイドバーまたはフッターに配置して表示する → 各見出しの出力 HTML が `<h2 class="subSection-title">` になっている
3. PR ブロックウィジェットをサイドバーまたはフッターに配置して表示する → 各見出しの出力 HTML が `<h2 class="prBlock_title">` になっている
4. CTA をクラシックエディタ（ショートコード）と Gutenberg ブロックの両方で表示する → いずれも見出しの出力 HTML が `<h2 class="cta_title">` になっている
5. Chrome DevTools のアクセシビリティパネル（見出しツリー / ランドマーク）で、ページの見出し階層が `h1`（記事タイトル） → `h2`（各ウィジェット・CTA見出し）になっている
6. Vektor 純正テーマ（Lightning 等）で、変更前後の見た目に差がない（視覚回帰がない）
7. WAVE でページを検査 → 「複数の H1」の Alert が出ない（axe-core / Lighthouse は複数h1を検知するルール自体を持たないため、これらのツールでは変化を確認できません）

### レビューポイント（任意）
- 見出しをクラスではなくタグ名（`h1`）で装飾しているテーマ / カスタム CSS がないか（対象クラス: `mainSection-title` / `subSection-title` / `prBlock_title` / `cta_title`）

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] 正しいディレクトリで作業している
- [ ] キャッシュをクリアしている