### PR TITLE
[ 不具合修正 ][ カスタムCSS ] 投稿ごとのカスタムCSSが管理画面全体に出力され見出しなどの表示が崩れる不具合を修正

### DIFF
--- a/inc/css-customize/css-customize-single.php
+++ b/inc/css-customize/css-customize-single.php
@@ -32,21 +32,66 @@ if ( ! function_exists( 'veu_sanitize_custom_css_input' ) ) {
 }
 
 /**
- * CSS Customize Single Load to Edit Page
+ * Add the per-post Custom CSS to the block editor content area.
+ * 投稿ごとのカスタムCSSをブロックエディタの本文領域に適用する。
+ *
+ * The CSS is passed through the editor `styles` setting, so the block editor
+ * injects it inside the editor iframe scoped to `.editor-styles-wrapper`. This
+ * limits the preview to the post content and prevents the CSS from leaking onto
+ * the surrounding admin screen (e.g. sidebar / meta box headings), which was the
+ * cause of the reported admin-screen layout breakage.
+ * エディタの `styles` 設定として渡すことで、ブロックエディタが iframe 内
+ * （`.editor-styles-wrapper` 配下）にスコープして注入する。これによりプレビューは
+ * 投稿本文に限定され、管理画面の枠（サイドバーやメタボックス見出し等）に CSS が
+ * 漏れて表示が崩れる不具合を防ぐ。
+ *
+ * @param array                   $editor_settings The block editor settings.
+ * @param WP_Block_Editor_Context $editor_context  The current editor context.
+ * @return array The filtered block editor settings.
  */
-function veu_css_customize_single_load_edit() {
-	global $post;
-	veu_insert_custom_css();
+function veu_css_customize_single_editor_styles( $editor_settings, $editor_context ) {
+
+	// Only the post editor provides a post; skip the site / widget editors.
+	// 投稿エディタのときだけ post が入る。サイト/ウィジェットエディタでは処理しない。
+	if ( empty( $editor_context->post ) ) {
+		return $editor_settings;
+	}
+
+	// Get and sanitize the per-post Custom CSS.
+	// 投稿ごとのカスタムCSSを取得してサニタイズする。
+	$css = veu_get_the_custom_css_single( $editor_context->post );
+	if ( $css ) {
+		$css = veu_sanitize_custom_css_input( $css );
+	}
+	if ( ! $css ) {
+		return $editor_settings;
+	}
+
+	// Register the CSS as an editor style so it is rendered inside the editor iframe.
+	// エディタスタイルとして登録し、エディタの iframe 内に描画させる。
+	if ( ! isset( $editor_settings['styles'] ) || ! is_array( $editor_settings['styles'] ) ) {
+		$editor_settings['styles'] = array();
+	}
+	$editor_settings['styles'][] = array( 'css' => $css );
+
+	return $editor_settings;
 }
-add_action( 'admin_footer', 'veu_css_customize_single_load_edit', 11 );
+add_filter( 'block_editor_settings_all', 'veu_css_customize_single_editor_styles', 10, 2 );
 
 
-/*
-入力された CSS をソースに出力
-/* ------------------------------------------------ */
+/**
+ * Output the per-post Custom CSS on the front-end singular page.
+ * 個別投稿ページ（フロント）に、投稿ごとのカスタムCSSを出力する。
+ *
+ * @return void
+ */
 function veu_insert_custom_css() {
 
-	if ( is_singular() || ( is_admin() && isset( $_GET['post'] ) ) ) {
+	// Output only on the front-end singular page; the admin/editor preview is
+	// handled by veu_css_customize_single_editor_styles() instead.
+	// フロントの個別投稿ページでのみ出力する。管理画面/エディタのプレビューは
+	// veu_css_customize_single_editor_styles() 側で扱う。
+	if ( is_singular() ) {
 		global $post;
 		if ( $post ) {
 			$css = veu_get_the_custom_css_single( $post );

--- a/inc/css-customize/css-customize-single.php
+++ b/inc/css-customize/css-customize-single.php
@@ -59,10 +59,7 @@ function veu_css_customize_single_editor_styles( $editor_settings, $editor_conte
 
 	// Get and sanitize the per-post Custom CSS.
 	// 投稿ごとのカスタムCSSを取得してサニタイズする。
-	$css = veu_get_the_custom_css_single( $editor_context->post );
-	if ( $css ) {
-		$css = veu_sanitize_custom_css_input( $css );
-	}
+	$css = veu_get_sanitized_custom_css_single( $editor_context->post );
 	if ( ! $css ) {
 		return $editor_settings;
 	}
@@ -94,12 +91,9 @@ function veu_insert_custom_css() {
 	if ( is_singular() ) {
 		global $post;
 		if ( $post ) {
-			$css = veu_get_the_custom_css_single( $post );
+			$css = veu_get_sanitized_custom_css_single( $post );
 			if ( $css ) {
-				$css = veu_sanitize_custom_css_input( $css );
-				if ( $css ) {
-					echo '<style type="text/css">/* ' . esc_html( veu_get_short_name() ) . ' CSS Customize Single */' . $css . '</style>';
-				}
+				echo '<style type="text/css">/* ' . esc_html( veu_get_short_name() ) . ' CSS Customize Single */' . $css . '</style>';
 			}
 		}
 	}
@@ -125,4 +119,24 @@ function veu_get_the_custom_css_single( $post ) {
 		$css_customize = trim( $css_customize );
 	}
 	return $css_customize;
+}
+
+/**
+ * Get the sanitized per-post Custom CSS for a post.
+ * 投稿ごとのカスタムCSSを取得・サニタイズして返す。
+ *
+ * Wraps veu_get_the_custom_css_single() and runs the shared sanitizer so that
+ * the front-end output and the editor-style injection share a single code path.
+ * veu_get_the_custom_css_single() をラップし、共通サニタイザを通すことで、
+ * フロント出力とエディタスタイル注入で処理を1本化する。
+ *
+ * @param WP_Post $post The post object.
+ * @return string The sanitized CSS, or an empty string when there is none.
+ */
+function veu_get_sanitized_custom_css_single( $post ) {
+	$css = veu_get_the_custom_css_single( $post );
+	if ( $css ) {
+		$css = veu_sanitize_custom_css_input( $css );
+	}
+	return $css ? $css : '';
 }

--- a/inc/css-customize/css-customize-single.php
+++ b/inc/css-customize/css-customize-single.php
@@ -138,5 +138,5 @@ function veu_get_sanitized_custom_css_single( $post ) {
 	if ( $css ) {
 		$css = veu_sanitize_custom_css_input( $css );
 	}
-	return $css ? $css : '';
+	return $css;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ e.g.
 [ Bug Fix ][ CTA ] Fixed the CTA image not being saved and the button text / message losing their allowed HTML when saved from the classic edit screen.
 [ Bug Fix ][ Custom Post Type Manager ] Fixed custom post types saved by older versions losing "title" support when re-registered.
 [ Bug Fix ][ Custom Post Type Manager ] Fixed a fatal TypeError on PHP 8 when re-registering a custom post type whose legacy support data was not stored as an array.
+[ Bug Fix ][ Custom CSS ] Fixed the per-post Custom CSS leaking into the whole admin screen and breaking admin elements such as headings; it is now applied only to the block editor content and the front end.
 
 = 9.118.0 =
 [ New Feature ][ SNS Share Button ] Added a Threads share button, with a show / hide toggle under ExUnit > Main Setting.

--- a/tests/test-css-customize.php
+++ b/tests/test-css-customize.php
@@ -147,4 +147,59 @@ class CssCustomizeTest extends WP_UnitTestCase {
 			wp_delete_post( $post_id, true );
 		} // foreach ( $test_array as $key => $value ) {
 	} // function test_veu_get_the_custom_css_single() {
+
+	/**
+	 * Editor styles injection for the block editor.
+	 * ブロックエディタへのエディタスタイル注入のテスト。
+	 */
+	public function test_veu_css_customize_single_editor_styles() {
+
+		// Create a post that has per-post Custom CSS.
+		// 投稿ごとのカスタムCSSを持つ投稿を作成する。
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'タイトル',
+				'post_content' => 'content',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		add_post_meta( $post_id, '_veu_custom_css', 'div > h1 { color:red;   }' );
+		$context = new WP_Block_Editor_Context( array( 'post' => get_post( $post_id ) ) );
+
+		// Case 1: with a post context, the minified CSS is appended to the editor styles.
+		// ケース1: post コンテキストありのとき、圧縮済み CSS がエディタスタイルに追加される。
+		$settings = veu_css_customize_single_editor_styles( array(), $context );
+		$this->assertNotEmpty( $settings['styles'] );
+		$this->assertSame( 'div > h1{color:red;}', $settings['styles'][0]['css'] );
+
+		// Case 2: existing styles are preserved and the new CSS is appended after them.
+		// ケース2: 既存の styles を保持し、新しい CSS はその後ろに追加される。
+		$settings = veu_css_customize_single_editor_styles( array( 'styles' => array( array( 'css' => 'body{}' ) ) ), $context );
+		$this->assertCount( 2, $settings['styles'] );
+		$this->assertSame( 'div > h1{color:red;}', $settings['styles'][1]['css'] );
+
+		// Case 3: without a post in context (site / widget editor), the settings are unchanged.
+		// ケース3: post コンテキストなし（サイト/ウィジェットエディタ）のとき、設定は変更されない。
+		$settings = veu_css_customize_single_editor_styles( array(), new WP_Block_Editor_Context() );
+		$this->assertArrayNotHasKey( 'styles', $settings );
+
+		// Case 4: a post without Custom CSS leaves the settings unchanged.
+		// ケース4: カスタムCSS未設定の投稿では設定は変更されない。
+		$post_id_no_css = wp_insert_post(
+			array(
+				'post_title'  => 'no css',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+		$context_no_css = new WP_Block_Editor_Context( array( 'post' => get_post( $post_id_no_css ) ) );
+		$settings       = veu_css_customize_single_editor_styles( array(), $context_no_css );
+		$this->assertArrayNotHasKey( 'styles', $settings );
+
+		// Cleanup test posts.
+		// テスト用の投稿を削除する。
+		wp_delete_post( $post_id, true );
+		wp_delete_post( $post_id_no_css, true );
+	} // function test_veu_css_customize_single_editor_styles() {
 }

--- a/tests/test-css-customize.php
+++ b/tests/test-css-customize.php
@@ -154,52 +154,86 @@ class CssCustomizeTest extends WP_UnitTestCase {
 	 */
 	public function test_veu_css_customize_single_editor_styles() {
 
-		// Create a post that has per-post Custom CSS.
-		// 投稿ごとのカスタムCSSを持つ投稿を作成する。
-		$post_id = wp_insert_post(
+		// テスト条件と期待する結果
+		// with_post       : エディタコンテキストに投稿を含めるか（false = サイト/ウィジェットエディタ相当）
+		// custom_css      : 投稿に設定するカスタムCSS（null = カスタムCSS未設定）
+		// input           : block_editor_settings_all に渡す既存の editor settings
+		// expected_styles : 期待する $settings['styles']（null = 'styles' が付与されず設定は未変更）
+		$test_cases = array(
 			array(
-				'post_title'   => 'タイトル',
-				'post_content' => 'content',
-				'post_status'  => 'publish',
-				'post_type'    => 'post',
-			)
-		);
-		add_post_meta( $post_id, '_veu_custom_css', 'div > h1 { color:red;   }' );
-		$context = new WP_Block_Editor_Context( array( 'post' => get_post( $post_id ) ) );
-
-		// Case 1: with a post context, the minified CSS is appended to the editor styles.
-		// ケース1: post コンテキストありのとき、圧縮済み CSS がエディタスタイルに追加される。
-		$settings = veu_css_customize_single_editor_styles( array(), $context );
-		$this->assertNotEmpty( $settings['styles'] );
-		$this->assertSame( 'div > h1{color:red;}', $settings['styles'][0]['css'] );
-
-		// Case 2: existing styles are preserved and the new CSS is appended after them.
-		// ケース2: 既存の styles を保持し、新しい CSS はその後ろに追加される。
-		$settings = veu_css_customize_single_editor_styles( array( 'styles' => array( array( 'css' => 'body{}' ) ) ), $context );
-		$this->assertCount( 2, $settings['styles'] );
-		$this->assertSame( 'div > h1{color:red;}', $settings['styles'][1]['css'] );
-
-		// Case 3: without a post in context (site / widget editor), the settings are unchanged.
-		// ケース3: post コンテキストなし（サイト/ウィジェットエディタ）のとき、設定は変更されない。
-		$settings = veu_css_customize_single_editor_styles( array(), new WP_Block_Editor_Context() );
-		$this->assertArrayNotHasKey( 'styles', $settings );
-
-		// Case 4: a post without Custom CSS leaves the settings unchanged.
-		// ケース4: カスタムCSS未設定の投稿では設定は変更されない。
-		$post_id_no_css = wp_insert_post(
+				'test_condition_name' => 'ケース1: post コンテキストありのとき、圧縮済み CSS がエディタスタイルに追加される',
+				'with_post'           => true,
+				'custom_css'          => 'div > h1 { color:red;   }',
+				'input'               => array(),
+				'expected_styles'     => array(
+					array( 'css' => 'div > h1{color:red;}' ),
+				),
+			),
 			array(
-				'post_title'  => 'no css',
-				'post_status' => 'publish',
-				'post_type'   => 'post',
-			)
+				'test_condition_name' => 'ケース2: 既存の styles を保持し、新しい CSS はその後ろに追加される',
+				'with_post'           => true,
+				'custom_css'          => 'div > h1 { color:red;   }',
+				'input'               => array( 'styles' => array( array( 'css' => 'body{}' ) ) ),
+				'expected_styles'     => array(
+					array( 'css' => 'body{}' ),
+					array( 'css' => 'div > h1{color:red;}' ),
+				),
+			),
+			array(
+				'test_condition_name' => 'ケース3: post コンテキストなし（サイト/ウィジェットエディタ）のとき、設定は未変更',
+				'with_post'           => false,
+				'custom_css'          => null,
+				'input'               => array(),
+				'expected_styles'     => null,
+			),
+			array(
+				'test_condition_name' => 'ケース4: カスタムCSS未設定の投稿では設定は未変更',
+				'with_post'           => true,
+				'custom_css'          => null,
+				'input'               => array(),
+				'expected_styles'     => null,
+			),
 		);
-		$context_no_css = new WP_Block_Editor_Context( array( 'post' => get_post( $post_id_no_css ) ) );
-		$settings       = veu_css_customize_single_editor_styles( array(), $context_no_css );
-		$this->assertArrayNotHasKey( 'styles', $settings );
 
-		// Cleanup test posts.
-		// テスト用の投稿を削除する。
-		wp_delete_post( $post_id, true );
-		wp_delete_post( $post_id_no_css, true );
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_veu_css_customize_single_editor_styles' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		foreach ( $test_cases as $case ) {
+
+			// テスト用の投稿とエディタコンテキストを準備する。
+			$post_id = 0;
+			if ( $case['with_post'] ) {
+				$post_id = wp_insert_post(
+					array(
+						'post_title'   => 'タイトル',
+						'post_content' => 'content',
+						'post_status'  => 'publish',
+						'post_type'    => 'post',
+					)
+				);
+				if ( null !== $case['custom_css'] ) {
+					add_post_meta( $post_id, '_veu_custom_css', $case['custom_css'] );
+				}
+				$context = new WP_Block_Editor_Context( array( 'post' => get_post( $post_id ) ) );
+			} else {
+				$context = new WP_Block_Editor_Context();
+			}
+
+			$settings = veu_css_customize_single_editor_styles( $case['input'], $context );
+
+			if ( null === $case['expected_styles'] ) {
+				// 設定は未変更のまま返る。
+				$this->assertSame( $case['input'], $settings, $case['test_condition_name'] );
+			} else {
+				$this->assertSame( $case['expected_styles'], $settings['styles'], $case['test_condition_name'] );
+			}
+
+			// テスト用データを削除する。
+			if ( $post_id ) {
+				wp_delete_post( $post_id, true );
+			}
+		} // foreach ( $test_cases as $case ) {
 	} // function test_veu_css_customize_single_editor_styles() {
 }


### PR DESCRIPTION
## 関連Issue
- 関連Issue: #1252

## 変更の目的・理由
投稿編集画面の「カスタムCSS」（投稿ごとに設定する CSS。post meta `_veu_custom_css`）が、フロントだけでなく管理画面全体にも出力され、管理画面のクローム（サイドバーやメタボックスの見出し h2 など）にまで適用されて表示が崩れていました。特に `h2::before` のような擬似要素を使うと、管理画面の h2 に装飾が付いてしまいます。

この管理画面への出力はブロックエディタ本文（iframe 内に独立表示される領域）には届かず、管理画面の枠にしか効かないため、プレビューとして機能せず崩れだけを起こしていました。本 PR ではこの漏れを解消し、代わりにブロックエディタ本文にだけ CSS が効くよう正しく配信します。

## 実装内容
### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

### 技術的な詳細
- **原因**: `inc/css-customize/css-customize-single.php` の `veu_css_customize_single_load_edit()` が `admin_footer`（管理画面フッター出力フック）で `<style>` を適用範囲の限定なしに管理画面全体へ出力していたため。
- **対策**:
  - `admin_footer` への出力を廃止（`veu_insert_custom_css()` の条件を `is_singular()`（個別投稿ページ判定）に整理し、フロントのみ出力）。
  - `block_editor_settings_all`（ブロックエディタ設定フィルタ）で、投稿の `_veu_custom_css` をエディタの `styles` 設定として渡し、ブロックエディタが iframe 内（`.editor-styles-wrapper` 配下）にスコープして描画するようにしました。これにより CSS は投稿本文にだけ効き、管理画面クロームには漏れません。
- **スコープ**: 今回のプレビュー対応は**ブロックエディタのみ**です。クラシックエディタ（TinyMCE）でのプレビューは今回対象外（漏れの解消は両エディタで有効）。必要になれば別 issue で整えます。
- **補足**: ブロックエディタのプレビューは保存後の再読み込み時に反映されます（入力しながらのライブ反映ではありません）。

## スクリーンショット
### Before（変更前）
擬似要素を含むカスタムCSSを保存すると、管理画面の h2（サイドバーの設定項目見出しなど）にも装飾が適用され表示が崩れます（issue #1252 に再現スクリーンショットあり）。

### After（変更後）
- ブロックエディタ本文の h2 にのみ CSS が適用され、管理画面クロームには漏れません。
- フロント表示は従来どおり CSS が適用されます。
- （下記「テスト手順」の自動テストで検証済み）

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み
- [x] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順

前提: WordPress（ブロックエディタ）環境で、VK All in One Expansion Unit を有効化していること。

**Before（修正前の再現）**
1. master のコードで、任意の投稿の編集画面を開く
2. 「VK All in One Expansion Unit > カスタムCSS」に `h2::before { content: "●"; }` を入力して「更新」
3. 編集画面を再読み込みする
   → 管理画面のサイドバー等の h2 見出しにも ● が付き、表示が崩れる

**After（修正後の確認）**
1. 本 PR のブランチで、上と同じ手順でカスタムCSSを保存する
2. 編集画面を再読み込みする
   → ブロックエディタ**本文**の h2 に ● が付く（プレビューが効く）
   → 管理画面のサイドバー等（クローム）の h2 には ● が**付かない**（漏れない）
3. フロントで当該投稿を表示する
   → 本文の h2 に ● が付く（フロント出力は従来どおり・回帰なし）

**自動テスト（実施済み）**
- `npm run phpunit`（`CssCustomizeTest`）: 新規テスト `test_veu_css_customize_single_editor_styles` を含め PASS（3 tests / 18 assertions OK）
- Playwright（実機）: ①エディタ本文 iframe の h2 の `::before` に CSS が適用される ②管理画面ドキュメントに当該 CSS の `<style>` が存在しない ③フロントに CSS が出力される、を確認済み

### レビューポイント（任意）
- `block_editor_settings_all` の `styles` 経由の配信で、CSS が `.editor-styles-wrapper` にスコープされ iframe 内にのみ効くこと
- `veu_insert_custom_css()` の条件を `is_singular()` に変更したことでフロント出力に回帰がないこと

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

### 追加の確認事項
- 純粋な PHP 変更（フック/フィルタの差し替え）のためアセットのビルドは不要です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 投稿ごとのカスタムCSSが管理画面全体へ誤って適用され、管理UI（見出しなど）を崩す問題を修正しました。
  - カスタムCSSの適用範囲を、ブロックエディターの本文プレビューとフロントの単一ページに限定しました。
- **テスト**
  - 投稿コンテキストやカスタムCSSの有無、既存スタイルへの追記挙動を検証するテストを追加しました。
- **ドキュメント**
  - 変更履歴（[ Bug Fix ][ Custom CSS ]）に反映しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->