### PR TITLE
[ 不具合修正 ][ Smooth Scroll ] 「CSS のみ」オプションの説明文がSafari非対応という古い情報のままになっている問題を修正

### DIFF
--- a/inc/smooth-scroll/smooth-scroll.php
+++ b/inc/smooth-scroll/smooth-scroll.php
@@ -68,7 +68,9 @@ function veu_smooth_admin() {
 <li>
 <label><input type="radio" name="vkExUnit_smooth[mode]" value="js" <?php checked( $options['mode'], 'js', true ); ?> /> <?php esc_html_e( 'JavaScript', 'vk-all-in-one-expansion-unit' ); ?> </label></li>
 <li>
-<label><input type="radio" name="vkExUnit_smooth[mode]" value="css" <?php checked( $options['mode'], 'css', true ); ?> /> <?php esc_html_e( 'CSS only (recommended).', 'vk-all-in-one-expansion-unit' ); ?> <?php esc_html_e( 'Loading is slightly lighter.', 'vk-all-in-one-expansion-unit' ); ?> <?php esc_html_e( 'Not supported on Safari 15.3 or earlier.', 'vk-all-in-one-expansion-unit' ); ?> </label></li>
+<label><input type="radio" name="vkExUnit_smooth[mode]" value="css" aria-describedby="vkExUnit_smooth_mode_css_description" <?php checked( $options['mode'], 'css', true ); ?> /> <?php esc_html_e( 'CSS only (recommended).', 'vk-all-in-one-expansion-unit' ); ?> </label>
+<p class="description" id="vkExUnit_smooth_mode_css_description"><?php esc_html_e( 'Loading is slightly lighter than the JavaScript mode.', 'vk-all-in-one-expansion-unit' ); ?> <?php esc_html_e( 'Not supported on Safari 15.3 or earlier.', 'vk-all-in-one-expansion-unit' ); ?></p>
+</li>
 </ul>
 </td>
 </tr>

--- a/inc/smooth-scroll/smooth-scroll.php
+++ b/inc/smooth-scroll/smooth-scroll.php
@@ -68,7 +68,7 @@ function veu_smooth_admin() {
 <li>
 <label><input type="radio" name="vkExUnit_smooth[mode]" value="js" <?php checked( $options['mode'], 'js', true ); ?> /> <?php esc_html_e( 'JavaScript', 'vk-all-in-one-expansion-unit' ); ?> </label></li>
 <li>
-<label><input type="radio" name="vkExUnit_smooth[mode]" value="css" <?php checked( $options['mode'], 'css', true ); ?> /> <?php esc_html_e( 'CSS only ( Loading slightly light but do not work on Safari and so on. )', 'vk-all-in-one-expansion-unit' ); ?> </label></li>
+<label><input type="radio" name="vkExUnit_smooth[mode]" value="css" <?php checked( $options['mode'], 'css', true ); ?> /> <?php esc_html_e( 'CSS only (recommended).', 'vk-all-in-one-expansion-unit' ); ?> <?php esc_html_e( 'Loading is slightly lighter.', 'vk-all-in-one-expansion-unit' ); ?> <?php esc_html_e( 'Not supported on Safari 15.3 or earlier.', 'vk-all-in-one-expansion-unit' ); ?> </label></li>
 </ul>
 </td>
 </tr>

--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,7 @@ e.g.
 [ Bug Fix ][ Custom Post Type Manager ] Fixed custom post types saved by older versions losing "title" support when re-registered.
 [ Bug Fix ][ Custom Post Type Manager ] Fixed a fatal TypeError on PHP 8 when re-registering a custom post type whose legacy support data was not stored as an array.
 [ Bug Fix ][ Custom CSS ] Fixed the per-post Custom CSS leaking into the whole admin screen and breaking admin elements such as headings; it is now applied only to the block editor content and the front end.
+[ Bug Fix ][ Smooth Scroll ] Fixed the "CSS only" option label showing outdated information that it does not work on Safari; modern Safari versions support it.
 
 = 9.118.0 =
 [ New Feature ][ SNS Share Button ] Added a Threads share button, with a show / hide toggle under ExUnit > Main Setting.

--- a/tests/e2e/smooth-scroll-css-label.spec.ts
+++ b/tests/e2e/smooth-scroll-css-label.spec.ts
@@ -217,17 +217,32 @@ test.describe( 'Smooth scroll「CSS only」ラベル分離 (#1421 / PR #1422)', 
 			.evaluate( ( el ) => window.getComputedStyle( el ).scrollBehavior );
 		expect( scrollBehavior ).toBe( 'smooth' );
 
-		// ページ内リンク（アンカー）遷移でエラーが起きず、スクロール自体が
-		// 実行されることを確認する（scrollTo 相当のふるまいが壊れていないか）。
+		// 実際のページ内リンク（アンカー）クリックでスクロールが発生することを
+		// 検証する。window.scrollTo を直接呼ぶと scroll-behavior の設定に
+		// 関わらず必ず成功してしまい検証にならないため、実在するアンカー要素
+		// と <a href="#..."> リンクを DOM に追加し、リンクを実際にクリックする
+		// ことでブラウザのページ内遷移（＝ CSS only モードなら
+		// scroll-behavior:smooth が効くスクロール）が機能することを確認する。
 		await page.evaluate( () => {
 			document.body.style.minHeight = '3000px';
+
+			const target = document.createElement( 'div' );
+			target.id = 'veu-e2e-scroll-target';
+			target.style.marginTop = '2000px';
+			target.textContent = 'veu e2e scroll target';
+			document.body.appendChild( target );
+
+			const link = document.createElement( 'a' );
+			link.id = 'veu-e2e-scroll-link';
+			link.href = '#veu-e2e-scroll-target';
+			link.textContent = 'veu e2e scroll link';
+			document.body.insertBefore( link, document.body.firstChild );
 		} );
-		await page.evaluate( () => {
-			window.location.hash = '#wpadminbar-does-not-exist-fallback';
-		} );
-		// scroll-behavior:smooth が適用された状態でも window.scrollTo が
-		// 例外なく動作し、pageYOffset が変化すること。
-		await page.evaluate( () => window.scrollTo( 0, 500 ) );
+
+		await page.locator( '#veu-e2e-scroll-link' ).click();
+
+		// リンククリックによるページ内遷移で実際にスクロール位置が変化する
+		// こと（=ページ内リンクのスムーズスクロールが機能している）。
 		await expect
 			.poll( () => page.evaluate( () => window.pageYOffset ) )
 			.toBeGreaterThan( 0 );

--- a/tests/e2e/smooth-scroll-css-label.spec.ts
+++ b/tests/e2e/smooth-scroll-css-label.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * Smooth scroll「CSS only」ラベル分離の e2e テスト
+ *
+ * issue #1421 / PR #1422 で行った、ExUnit > Main Setting > Smooth scroll の
+ * 「CSS only」ラジオボタンのラベル文言修正を検証する。
+ *
+ * 修正前: `CSS only ( Loading slightly light but do not work on Safari and so on. )`
+ *          という古い情報を含む長い一文がラベル内にそのまま入っていた。
+ * 修正後: ラベル本体 `CSS only (recommended).` と、補足説明
+ *          `Loading is slightly lighter than the JavaScript mode.
+ *           Not supported on Safari 15.3 or earlier.` を
+ *          `<p class="description">` に分離し、`aria-describedby` で紐付けた。
+ *
+ * 検証する挙動:
+ *  1. ラベル本体が短い文言 `CSS only (recommended).` になっていること。
+ *  2. 補足説明が `<p class="description">` として、ラベルとは別要素で
+ *     表示されていること（WP コアの description スタイルで控えめな見た目）。
+ *  3. ラジオボタンの `aria-describedby` と補足説明の `id` が一致しているアクセシビリティ
+ *     結線が取れていること。
+ *  4. 「JavaScript」の選択肢の表示に変化がないこと（デグレ確認）。
+ *  5. 「CSS only」を選択して保存し、リロード後も選択状態が保持されること。
+ *  6. フロント側で `html { scroll-behavior: smooth; }` が出力され、
+ *     ページ内リンクのスムーズスクロールが機能すること。
+ */
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'child_process';
+
+// wp-env の tests-cli コンテナ経由で wp-cli を実行するヘルパー。
+// Playwright の対象は wp-env の tests サイトを向いているため tests-cli を使う。
+const runWpCli = ( args: string[] ): string => {
+	return execFileSync(
+		'npx',
+		[ 'wp-env', 'run', 'tests-cli', 'wp', ...args ],
+		{
+			encoding: 'utf-8',
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+		}
+	);
+};
+
+// vkExUnit_smooth オプションを削除し、デフォルト（mode: js）に戻す。
+// option が存在しない場合のエラーは想定内として握りつぶす。
+const resetSmoothOption = (): void => {
+	try {
+		runWpCli( [ 'option', 'delete', 'vkExUnit_smooth' ] );
+	} catch ( e ) {
+		const stderr =
+			e && typeof e === 'object' && 'stderr' in e
+				? String( ( e as { stderr?: unknown } ).stderr ?? '' )
+				: '';
+		const message = e instanceof Error ? e.message : String( e );
+		const haystack = `${ stderr }\n${ message }`;
+		const isMissingOption =
+			/Could not delete\s+'vkExUnit_smooth'\s+option\.\s*Does it exist\?/i.test(
+				haystack
+			) || ( /vkExUnit_smooth/.test( haystack ) && /does(?:\s+not)?\s+exist/i.test( haystack ) );
+		if ( isMissingOption ) {
+			return;
+		}
+		throw e;
+	}
+};
+
+test.describe( 'Smooth scroll「CSS only」ラベル分離 (#1421 / PR #1422)', () => {
+	// このファイル内のテストは vkExUnit_smooth オプション（共有 DB）を書き換える
+	// テストを含むため、ファイル単位でシリアル実行する。
+	test.describe.configure( { mode: 'serial' } );
+
+	test.beforeEach( () => {
+		resetSmoothOption();
+	} );
+
+	test.afterAll( () => {
+		resetSmoothOption();
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		// 管理画面へログイン。
+		await page.goto( '/wp-login.php' );
+		await page.locator( '#user_login' ).fill( 'admin' );
+		await page.locator( '#user_pass' ).fill( 'password' );
+		await page.locator( '#wp-submit' ).click();
+		await page.waitForURL( /wp-admin\// );
+		await page.locator( '#wpadminbar' ).waitFor();
+
+		// ExUnit > Main Setting 画面へ。
+		await page.goto( '/wp-admin/admin.php?page=vkExUnit_main_setting' );
+	} );
+
+	test( 'CSS only のラベル本体が短い文言 "CSS only (recommended)." になっている', async ( {
+		page,
+	} ) => {
+		const cssRadio = page.locator(
+			'input[name="vkExUnit_smooth[mode]"][value="css"]'
+		);
+		await expect( cssRadio ).toBeVisible();
+
+		// ラベル本体（<label> 直下のテキスト）を確認する。
+		const label = page.locator(
+			'label:has(input[name="vkExUnit_smooth[mode]"][value="css"])'
+		);
+		await expect( label ).toContainText( 'CSS only (recommended).' );
+
+		// 旧文言（Safari で動かない、という古い情報）が残っていないこと。
+		await expect( label ).not.toContainText( 'do not work on Safari' );
+	} );
+
+	test( '補足説明が <p class="description"> として分離表示され、aria-describedby と id が一致する', async ( {
+		page,
+	} ) => {
+		const cssRadio = page.locator(
+			'input[name="vkExUnit_smooth[mode]"][value="css"]'
+		);
+		await expect( cssRadio ).toBeVisible();
+
+		// aria-describedby 属性を取得。
+		const describedBy = await cssRadio.getAttribute( 'aria-describedby' );
+		expect( describedBy ).toBeTruthy();
+
+		// aria-describedby が指す id を持つ <p class="description"> が存在すること。
+		const description = page.locator( `#${ describedBy }` );
+		await expect( description ).toHaveCount( 1 );
+
+		// タグ名と class を確認（WP コア標準の description スタイル）。
+		const tagAndClass = await description.evaluate( ( el ) => ( {
+			tagName: el.tagName.toLowerCase(),
+			className: el.className,
+		} ) );
+		expect( tagAndClass.tagName ).toBe( 'p' );
+		expect( tagAndClass.className ).toContain( 'description' );
+
+		// 補足説明の文言を確認。
+		await expect( description ).toContainText(
+			'Loading is slightly lighter than the JavaScript mode.'
+		);
+		await expect( description ).toContainText(
+			'Not supported on Safari 15.3 or earlier.'
+		);
+
+		// description は label 本体より控えめな見た目（WP コア .description は
+		// 通常フォントサイズが縮小され、グレー系の色になる）。ここでは
+		// 「label 本体のテキストと同一要素ではない」= 視覚的に分離されている
+		// ことを構造面から確認する（色・サイズは環境のコア CSS に依存するため
+		// 厳密な px 一致は求めない）。
+		const descTag = await description.evaluate( ( el ) => el.tagName );
+		expect( descTag ).not.toBe( 'LABEL' );
+	} );
+
+	test( '「JavaScript」の選択肢の表示に変化がない（デグレ確認）', async ( { page } ) => {
+		const jsRadio = page.locator(
+			'input[name="vkExUnit_smooth[mode]"][value="js"]'
+		);
+		await expect( jsRadio ).toBeVisible();
+
+		const jsLabel = page.locator(
+			'label:has(input[name="vkExUnit_smooth[mode]"][value="js"])'
+		);
+		await expect( jsLabel ).toContainText( 'JavaScript' );
+
+		// JavaScript の選択肢には aria-describedby も description も無い
+		// （元々補足説明が無い項目のため、変化していないことの確認）。
+		const describedBy = await jsRadio.getAttribute( 'aria-describedby' );
+		expect( describedBy ).toBeNull();
+	} );
+
+	test( '「CSS only」を選択して保存すると、リロード後も選択状態が保持される', async ( {
+		page,
+	} ) => {
+		const cssRadio = page.locator(
+			'input[name="vkExUnit_smooth[mode]"][value="css"]'
+		);
+		await expect( cssRadio ).toBeVisible();
+		await cssRadio.check();
+		await expect( cssRadio ).toBeChecked();
+
+		// フォーム送信。この管理画面は 1 つの <form> の中に複数セクションが
+		// 並び、セクションごとに `submit_button()` が出力されるため `#submit`
+		// が複数存在する（1 form 全体を送信する仕様）。Smooth scroll セクション
+		// （#vkExUnit_smooth）内のボタンを明示的に指定してクリックする。
+		await page.locator( '#vkExUnit_smooth #submit' ).click();
+		await page.waitForURL( /wp-admin\/admin\.php\?page=vkExUnit_main_setting/ );
+
+		// リダイレクト後の再描画で CSS only が選択された状態になっていること。
+		const cssRadioAfter = page.locator(
+			'input[name="vkExUnit_smooth[mode]"][value="css"]'
+		);
+		await expect( cssRadioAfter ).toBeChecked();
+
+		// 明示的にページをリロードしても選択状態が保持されていること
+		// （option が実際に DB へ保存されたことの裏取り）。
+		await page.reload();
+		const cssRadioAfterReload = page.locator(
+			'input[name="vkExUnit_smooth[mode]"][value="css"]'
+		);
+		await expect( cssRadioAfterReload ).toBeChecked();
+	} );
+
+	test( 'フロント側で scroll-behavior:smooth が適用され、ページ内リンクのスムーズスクロールが機能する', async ( {
+		page,
+	} ) => {
+		// CSS only モードに設定する（wp-cli で直接 option を書き込み、UI 経由の
+		// 保存フローとは独立して検証する）。
+		runWpCli( [
+			'option',
+			'update',
+			'vkExUnit_smooth',
+			JSON.stringify( { mode: 'css' } ),
+			'--format=json',
+		] );
+
+		await page.goto( '/' );
+
+		// html 要素の computed scroll-behavior が smooth になっていること
+		// （veu_add_smooth_css がインラインスタイルとして出力する）。
+		const scrollBehavior = await page
+			.locator( 'html' )
+			.evaluate( ( el ) => window.getComputedStyle( el ).scrollBehavior );
+		expect( scrollBehavior ).toBe( 'smooth' );
+
+		// ページ内リンク（アンカー）遷移でエラーが起きず、スクロール自体が
+		// 実行されることを確認する（scrollTo 相当のふるまいが壊れていないか）。
+		await page.evaluate( () => {
+			document.body.style.minHeight = '3000px';
+		} );
+		await page.evaluate( () => {
+			window.location.hash = '#wpadminbar-does-not-exist-fallback';
+		} );
+		// scroll-behavior:smooth が適用された状態でも window.scrollTo が
+		// 例外なく動作し、pageYOffset が変化すること。
+		await page.evaluate( () => window.scrollTo( 0, 500 ) );
+		await expect
+			.poll( () => page.evaluate( () => window.pageYOffset ) )
+			.toBeGreaterThan( 0 );
+	} );
+} );


### PR DESCRIPTION
## 概要

ExUnit > Main Setting > Smooth scroll の設定画面にある「CSS only」オプションのラベル文言が「Safari 等では動作しない」という古い情報のままになっていました。`scroll-behavior: smooth` は Safari 15.4（2022年3月リリース）以降サポート済みのため、実際には動作するにもかかわらず、ユーザーが誤って避けてしまう可能性がありました。ラベル文言を実情に沿った内容に修正し、あわせて選択肢名と補足説明を視覚的に分離しました。

関連 issue: https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1421

## 変更内容

- `inc/smooth-scroll/smooth-scroll.php`: 「CSS only」ラジオボタンのラベル文言を修正
  - 修正前: `CSS only ( Loading slightly light but do not work on Safari and so on. )`
  - 修正後: ラベル本体 `CSS only (recommended).` + 補足 `Loading is slightly lighter than the JavaScript mode.` / `Not supported on Safari 15.3 or earlier.` を `<p class="description">` に分離
  - アクセシビリティ向上のため `aria-describedby` でラベルと補足説明を紐付け
- `readme.txt`: Changelog に変更内容を追記

## レビュー実施状況

- 🔒 安藤（セキュリティ）: 実施 PASS（静的文言・マークアップ調整のみで、入力値やDB操作の変更なし）
- 🎨 植草（UX）: 実施 PASS（1回目の指摘（視覚的階層・翻訳文脈）を修正後、再レビューで PASS）
- 🧪 麗美（e2e）: 別途実施予定

## テスト（確認手順）

### 前提条件

- 対象環境: wp-env（ポート 9106 / testsPort 9107 を指定）
- 対象プラグイン: vk-all-in-one-expansion-unit（本ブランチを適用）

### 修正前の状態（Before / 参考: `origin/master` 時点）

1. WordPress 管理画面にログインする
2. 「ExUnit > Main Setting」を開き、「Smooth scroll」タブを開く
3. 「CSS only」の選択肢ラベルを確認する
   → 修正前は `CSS only ( Loading slightly light but do not work on Safari and so on. )` と表示され、Safari で動作しないという古い情報が含まれている

### 修正後の確認手順（After）

1. 本ブランチを適用した状態で WordPress 管理画面にログインする
2. 「ExUnit > Main Setting」を開き、「Smooth scroll」タブを開く
3. 「CSS only」の選択肢を確認する
   → ラベル本体が `CSS only (recommended).` と表示される
   → その下に補足として `Loading is slightly lighter than the JavaScript mode. Not supported on Safari 15.3 or earlier.` が、通常のラベルより控えめな見た目（`description` スタイル）で表示される
4. ブラウザの開発者ツール等でラジオボタンの `aria-describedby` 属性と、補足文の `id` 属性が一致していることを確認する
5. 「JavaScript」の選択肢の表示に変化がないことを確認する（デグレ確認）
6. 実際に「CSS only」を選択して保存し、フロント表示でページ内リンクのスムーズスクロールが問題なく動作することを確認する

表示文言のみの変更であり、レイアウト崩れやスタイル的な大きな見た目の変化はないため、スクリーンショットは省略します（レビュー用アセットリポジトリの設定が未設定のため、テキストでの確認手順のみ記載しています）。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * Smooth Scroll設定の「CSS only」オプションで、ラベル文言を簡潔化し、説明文（軽量／Safari 15.3以前は非対応）を追加しました。
  * 説明文を参照するアクセシビリティ連携（ARIA）を行い、保存・反映後も誤情報が出ないようにしました。
* **テスト**
  * E2Eで、管理画面表示、アクセシビリティ結線、保存後の状態保持、フロントのスムーズスクロール動作までを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->