### PR TITLE
[ その他 ] PR #1423 の changelog 追記と Contributors への thisismyurl 追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ e.g.
 [ Bug Fix ][ Custom Post Type Manager ] Fixed a fatal TypeError on PHP 8 when re-registering a custom post type whose legacy support data was not stored as an array.
 [ Bug Fix ][ Custom CSS ] Fixed the per-post Custom CSS leaking into the whole admin screen and breaking admin elements such as headings; it is now applied only to the block editor content and the front end.
 [ Bug Fix ][ Smooth Scroll ] Fixed the "CSS only" option label showing outdated information that it does not work on Safari; modern Safari versions support it.
+[ Bug Fix ][ Custom CSS ] Fixed the success and error notices shown after saving the CSS customizer always appearing in English because they referenced an old text domain.
 
 = 9.118.0 =
 [ New Feature ][ SNS Share Button ] Added a Threads share button, with a show / hide toggle under ExUnit > Main Setting.

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === VK All in One Expansion Unit ===
-Contributors: vektor-inc,kurudrive,jim912,hideokamoto,nc30,SaoriMiyazaki,catherine8007,naoki0h,rickaddison7634,una9,kaorock72,kurishimak,chiakikouno,daikiweb23,doshimaf,shimotomoki,mtdkei,mt8biz
+Contributors: vektor-inc,kurudrive,jim912,hideokamoto,nc30,SaoriMiyazaki,catherine8007,naoki0h,rickaddison7634,una9,kaorock72,kurishimak,chiakikouno,daikiweb23,doshimaf,shimotomoki,mtdkei,mt8biz,thisismyurl
 Donate link:
 Tags: Google Analytics, Related Posts, sitemap, Facebook Page Plugin, OG tags
 Requires at least: 6.5


### PR DESCRIPTION
## 概要

PR #1423（マージ済み）で、CSS カスタマイズ画面（ExUnit > CSS カスタマイズ）の保存後に出る「保存しました」「エラーが発生しました」という通知の翻訳用ドメイン（翻訳ファイルを探すときの識別子）が、旧ブランド時代の `biz-vektor` のままになっていた問題が修正されました。このプラグインが読み込んでいる翻訳ドメインは `vk-all-in-one-expansion-unit` のため、旧ドメインのままだと翻訳が見つからず、日本語環境でも通知が英語で表示されていました。

その PR には changelog の追記が含まれていなかったため、readme.txt に 1 行追記します。あわせて、#1423 の作者である thisismyurl（Christopher Ross）を readme.txt の Contributors に追加します。コードの変更はありません。

追記した changelog 行:

```
[ Bug Fix ][ Custom CSS ] Fixed the success and error notices shown after saving the CSS customizer always appearing in English because they referenced an old text domain.
```

## 記載位置

- 既存の changelog がすべて英語のため英語で記載
- 未リリース領域（`= 9.118.0 =` より上）の `[ Bug Fix ]` グループ末尾に挿入
- Contributors は既存リストの末尾に `thisismyurl` を追加

## 確認手順

1. このブランチの `readme.txt` を開く
2. `== Changelog ==` 直下の未リリース領域を確認する
   → 上記の 1 行が `[ Bug Fix ][ Smooth Scroll ] ...` の直後、`= 9.118.0 =` の見出しより上にあること
   → 分類が `[ Bug Fix ]` グループ内に収まっており、`[ Spec Change ]` 群より下、バージョン見出しより上にあること
3. 2 行目の `Contributors:` を確認する
   → 末尾に `,thisismyurl` が追加され、カンマ区切りが崩れていないこと（既存のユーザー名は変更なし）
4. `git diff master...changelog/pr-1423` を確認する
   → 変更が `readme.txt` の 2 箇所のみで、コードファイルに変更がないこと

関連 PR: https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1423

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
