### PR TITLE
[ セキュリティ修正 ][ CTA ] 画像位置カスタムフィールドの検証・エスケープ漏れにより任意のスクリプトが実行される Stored XSS を修正

### DIFF
--- a/inc/block-editor-panels/enqueue.php
+++ b/inc/block-editor-panels/enqueue.php
@@ -191,6 +191,23 @@ function veu_register_active_feature_meta() {
 			$sanitize = function ( $value ) {
 				return (string) absint( $value );
 			};
+		} elseif ( 'vkExUnit_cta_img_position' === $cta_key ) {
+			// 画像位置はフロント側で class 属性へ連結されるため、許可値 ( right / center / left ) のみを保存する。
+			// sanitize_text_field はダブルクォートを除去しないため、class 属性を抜け出す値を通してしまう。
+			// 許可値の定義が重複しないよう Vk_Call_To_Action の共通メソッドを使う。
+			// CTA パッケージが無効な場合は当該クラスが読み込まれないため、class_exists で確認してから呼び出す
+			// ( その場合は cta 投稿タイプ自体が存在せず保存されないので、空文字を返して表示側の既定値に委ねる )。
+			// The image position is concatenated into a class attribute on the front end, so store allowed values only ( right / center / left ).
+			// sanitize_text_field does not strip double quotes and would let a value break out of the class attribute.
+			// The shared method on Vk_Call_To_Action is used so the allowlist is not duplicated.
+			// The class is not loaded when the CTA package is disabled, so guard with class_exists
+			// ( in that case the cta post type does not exist either, so return an empty string and let the display side fall back to its default ).
+			$sanitize = function ( $value ) {
+				if ( class_exists( 'Vk_Call_To_Action' ) ) {
+					return Vk_Call_To_Action::sanitize_image_position( $value );
+				}
+				return '';
+			};
 		} elseif ( in_array( $cta_key, array( 'vkExUnit_cta_button_text', 'vkExUnit_cta_button_icon', 'vkExUnit_cta_button_icon_before', 'vkExUnit_cta_button_icon_after', 'vkExUnit_cta_text' ), true ) ) {
 			// ボタンテキスト・本文・アイコンは限定HTMLを許可するため wp_kses_post でサニタイズする。
 			// sanitize_text_field はタグと中身を除去してしまい、クラシックメタボックスの保存処理およびフロント表示（いずれも wp_kses_post）と矛盾するため。

--- a/inc/block-editor-panels/enqueue.php
+++ b/inc/block-editor-panels/enqueue.php
@@ -195,15 +195,18 @@ function veu_register_active_feature_meta() {
 			// 画像位置はフロント側で class 属性へ連結されるため、許可値 ( right / center / left ) のみを保存する。
 			// sanitize_text_field はダブルクォートを除去しないため、class 属性を抜け出す値を通してしまう。
 			// 許可値の定義が重複しないよう Vk_Call_To_Action の共通メソッドを使う。
-			// CTA パッケージが無効な場合は当該クラスが読み込まれないため、class_exists で確認してから呼び出す
-			// ( その場合は cta 投稿タイプ自体が存在せず保存されないので、空文字を返して表示側の既定値に委ねる )。
+			// CTA パッケージが無効でクラスが読み込まれていない場合や、当該メソッドを持たない旧版クラス
+			// （ 単体版 CTA プラグインなどが先に Vk_Call_To_Action を定義しているケース ）に備えて
+			// class_exists ではなく method_exists で確認してから呼び出す
+			// ( いずれの場合も空文字を返し、表示側の既定値フォールバックに委ねる )。
 			// The image position is concatenated into a class attribute on the front end, so store allowed values only ( right / center / left ).
 			// sanitize_text_field does not strip double quotes and would let a value break out of the class attribute.
 			// The shared method on Vk_Call_To_Action is used so the allowlist is not duplicated.
-			// The class is not loaded when the CTA package is disabled, so guard with class_exists
-			// ( in that case the cta post type does not exist either, so return an empty string and let the display side fall back to its default ).
+			// Use method_exists rather than class_exists so it also covers an older class without this method
+			// ( e.g. the standalone CTA plugin defining Vk_Call_To_Action first )
+			// ( in either case return an empty string and let the display side fall back to its default ).
 			$sanitize = function ( $value ) {
-				if ( class_exists( 'Vk_Call_To_Action' ) ) {
+				if ( method_exists( 'Vk_Call_To_Action', 'sanitize_image_position' ) ) {
 					return Vk_Call_To_Action::sanitize_image_position( $value );
 				}
 				return '';

--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -271,7 +271,11 @@ function veu_cta_block_callback( $attributes, $content ) {
 						}
 
 						$content .= '<section class="veu_cta" id="veu_cta-' . esc_attr( $cta_id ) . '">';
-						$content .= '<h2 class="cta_title">' . esc_html( $cta_post->post_title ) . '</h2>';
+						// タイトルはこれまでフィルタされておらず、改行調整などに <br> を入れている運用があるため esc_html() は使えない。
+						// wp_kses_post() なら <script> や on* 属性は除去され、同テンプレート内の本文・ボタンラベルとも処理が揃う。
+						// The title has never been filtered and is sometimes given a <br> for line breaks, so esc_html() cannot be used.
+						// wp_kses_post() strips <script> and on* attributes and matches how the body and button label are handled in this template.
+						$content .= '<h2 class="cta_title">' . wp_kses_post( $cta_post->post_title ) . '</h2>';
 						$content .= '<div class="cta_body">';
 
 						// 別ウィンドウで開くかどうかのカスタムフィールドの値を取得 //////.
@@ -317,7 +321,7 @@ function veu_cta_block_callback( $attributes, $content ) {
 					$edit_link = get_edit_post_link( $cta_post->ID );
 					if ( $edit_link ) {
 						$url      = esc_url( $edit_link );
-						$content .= '<div class="veu_adminEdit veu_adminEdit_cta"><a href="' . $url . '" class="btn btn-default" target="_blank">' . __( 'Edit CTA', 'vk-all-in-one-expansion-unit' ) . '</a></div>';
+						$content .= '<div class="veu_adminEdit veu_adminEdit_cta"><a href="' . $url . '" class="btn btn-default" target="_blank">' . esc_html__( 'Edit CTA', 'vk-all-in-one-expansion-unit' ) . '</a></div>';
 					}
 				}
 			}

--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -267,11 +267,11 @@ function veu_cta_block_callback( $attributes, $content ) {
 						$image_position = get_post_meta( $cta_id, 'vkExUnit_cta_img_position', true );
 
 						if ( ! $image_position ) {
-							$image_position = 'right';
+							$image_position = Vk_Call_To_Action::IMAGE_POSITION_DEFAULT;
 						}
 
-						$content .= '<section class="veu_cta" id="veu_cta-' . $cta_id . '">';
-						$content .= '<h2 class="cta_title">' . $cta_post->post_title . '</h2>';
+						$content .= '<section class="veu_cta" id="veu_cta-' . esc_attr( $cta_id ) . '">';
+						$content .= '<h2 class="cta_title">' . esc_html( $cta_post->post_title ) . '</h2>';
 						$content .= '<div class="cta_body">';
 
 						// 別ウィンドウで開くかどうかのカスタムフィールドの値を取得 //////.
@@ -284,7 +284,9 @@ function veu_cta_block_callback( $attributes, $content ) {
 						}
 
 						if ( $imgid ) {
-							$content .= '<div class="cta_body_image cta_body_image_' . $image_position . '">';
+							// $image_position はカスタムフィールドの値をそのまま class 属性へ連結するため必ずエスケープする。
+							// Always escape $image_position because the custom field value is concatenated into a class attribute.
+							$content .= '<div class="cta_body_image cta_body_image_' . esc_attr( $image_position ) . '">';
 							$content .= ( $url ) ? '<a href="' . $url . '"' . $target . '>' : '';
 							$content .= wp_get_attachment_image( $imgid, 'large' );
 							$content .= ( $url ) ? '</a>' : '';
@@ -298,7 +300,9 @@ function veu_cta_block_callback( $attributes, $content ) {
 						if ( $url && $btn_text ) {
 							$content .= '<div class="cta_body_link">';
 							$content .= '<a href="' . $url . '" class="btn btn-primary btn-block btn-lg"' . $target . '>';
-							$content .= $btn_before . $btn_text . $btn_after;
+							// ボタンラベルはカスタムフィールドの値のため、クラシック表示 ( view-actionbox.php ) と同様に許可タグのみへ制限する。
+							// The button label comes from a custom field, so restrict it to allowed tags as the classic view ( view-actionbox.php ) does.
+							$content .= wp_kses_post( $btn_before . $btn_text . $btn_after );
 							$content .= '</a>';
 							$content .= '</div>';
 						}

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -9,6 +9,39 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 
 		const CONTENT_NUMBER = 100;
 
+		/**
+		 * 画像位置 ( vkExUnit_cta_img_position ) として許可する値.
+		 * この値はフロント側で class 属性に連結されるため、許可値以外は保存しない.
+		 * Allowed values for the image position ( vkExUnit_cta_img_position ).
+		 * The value is concatenated into a class attribute on the front end, so anything else must not be stored.
+		 */
+		const IMAGE_POSITIONS = array( 'right', 'center', 'left' );
+
+		/**
+		 * 画像位置の既定値.
+		 * Default value of the image position.
+		 */
+		const IMAGE_POSITION_DEFAULT = 'right';
+
+		/**
+		 * 画像位置の値をホワイトリストで検証する.
+		 * Validate the image position value against the allowlist.
+		 *
+		 * 保存経路が クラシック編集画面 ( メタボックス ) と ブロックエディタ ( REST API ) の2つあるため、
+		 * 許可値の定義が重複しないよう共通のメソッドとして切り出している.
+		 * There are two save paths ( the classic metabox and the block editor REST API ),
+		 * so the allowlist is centralized here to avoid duplicating the definition.
+		 *
+		 * @param mixed $value 検証する値. Value to validate.
+		 * @return string 許可値のいずれか. 許可値以外は既定値 right を返す. One of the allowed values; the default ( right ) otherwise.
+		 */
+		public static function sanitize_image_position( $value ) {
+			// 配列などスカラー以外が渡された場合は許可値に一致しない空文字として扱う.
+			// Treat non-scalar input ( arrays etc. ) as an empty string so it never matches an allowed value.
+			$value = is_scalar( $value ) ? (string) $value : '';
+			return in_array( $value, self::IMAGE_POSITIONS, true ) ? $value : self::IMAGE_POSITION_DEFAULT;
+		}
+
 		public static function init() {
 			add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 			add_action( 'veu_package_init', array( __CLASS__, 'option_init' ) );
@@ -180,7 +213,14 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						},
 					),
 					'vkExUnit_cta_img_position'       => array(
-						'escape_type' => '',
+						// 画像位置は class 属性へ連結されるため、許可値 ( right / center / left ) 以外は既定値に丸めて保存する。
+						// escape_type に配列を渡すと「複数のエスケープ処理の配列」として扱われるため、クロージャで渡している。
+						// The image position is concatenated into a class attribute, so any value outside the allowlist
+						// ( right / center / left ) is normalized to the default before saving.
+						// A closure is used because an array in escape_type is treated as a list of escape callbacks.
+						'escape_type' => function ( $value ) {
+							return self::sanitize_image_position( $value );
+						},
 					),
 					'vkExUnit_cta_button_text'        => array(
 						'escape_type' => array( 'stripslashes', 'wp_kses_post' ),
@@ -487,7 +527,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// Display Edit Button.
 			$url = get_edit_post_link( $cta_post->ID );
 			if ( $url ) {
-				$content .= '<div class="veu_adminEdit veu_adminEdit_cta"><a href="' . $url . '" class="btn btn-default" target="_blank">' . __( 'Edit CTA', 'vk-all-in-one-expansion-unit' ) . '</a></div>';
+				$content .= '<div class="veu_adminEdit veu_adminEdit_cta"><a href="' . esc_url( $url ) . '" class="btn btn-default" target="_blank">' . esc_html__( 'Edit CTA', 'vk-all-in-one-expansion-unit' ) . '</a></div>';
 			}
 
 			// リセットしないと$postが改変されたままでコメント欄が表示されなくなるなどの弊害が発生する.

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -33,12 +33,24 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 		 * so the allowlist is centralized here to avoid duplicating the definition.
 		 *
 		 * @param mixed $value 検証する値. Value to validate.
-		 * @return string 許可値のいずれか. 許可値以外は既定値 right を返す. One of the allowed values; the default ( right ) otherwise.
+		 * @return string 許可値または空文字. それ以外は既定値 right を返す. An allowed value or an empty string; the default ( right ) otherwise.
 		 */
 		public static function sanitize_image_position( $value ) {
-			// 配列などスカラー以外が渡された場合は許可値に一致しない空文字として扱う.
-			// Treat non-scalar input ( arrays etc. ) as an empty string so it never matches an allowed value.
-			$value = is_scalar( $value ) ? (string) $value : '';
+			// 配列などスカラー以外は異常な入力のため既定値へ丸める.
+			// Non-scalar input ( arrays etc. ) is invalid, so fall back to the default.
+			if ( ! is_scalar( $value ) ) {
+				return self::IMAGE_POSITION_DEFAULT;
+			}
+			$value = (string) $value;
+			// 空文字はブロックエディタの「Normal」( 位置を指定しない ) を表す正当な値のため、そのまま保持する.
+			// 空文字を既定値へ丸めると、Normal を選んで保存した後に Right が選択された状態で表示されてしまう.
+			// 表示側に既定値へのフォールバック ( if ( ! $image_position ) ) があるため、そこに委ねてよい.
+			// An empty string is a valid value that means "Normal" ( no position specified ) in the block editor, so keep it as is.
+			// Normalizing it to the default would show "Right" as selected after saving "Normal".
+			// The display side falls back to the default ( if ( ! $image_position ) ), so it can be left to that.
+			if ( '' === $value ) {
+				return '';
+			}
 			return in_array( $value, self::IMAGE_POSITIONS, true ) ? $value : self::IMAGE_POSITION_DEFAULT;
 		}
 

--- a/inc/call-to-action/package/view-actionbox.php
+++ b/inc/call-to-action/package/view-actionbox.php
@@ -61,7 +61,11 @@ if ( ! $image_position ) {
 
 $content  = '';
 $content .= '<section class="veu_cta" id="veu_cta-' . esc_attr( $id ) . '">';
-$content .= '<h2 class="cta_title">' . esc_html( $cta_post->post_title ) . '</h2>';
+// タイトルはこれまでフィルタされておらず、改行調整などに <br> を入れている運用があるため esc_html() は使えない.
+// wp_kses_post() なら <script> や on* 属性は除去され、同テンプレート内の本文・ボタンラベルとも処理が揃う.
+// The title has never been filtered and is sometimes given a <br> for line breaks, so esc_html() cannot be used.
+// wp_kses_post() strips <script> and on* attributes and matches how the body and button label are handled in this template.
+$content .= '<h2 class="cta_title">' . wp_kses_post( $cta_post->post_title ) . '</h2>';
 $content .= '<div class="cta_body">';
 
 

--- a/inc/call-to-action/package/view-actionbox.php
+++ b/inc/call-to-action/package/view-actionbox.php
@@ -57,11 +57,11 @@ $imgid = get_post_meta( $id, 'vkExUnit_cta_img', true );
 
 $image_position = get_post_meta( $id, 'vkExUnit_cta_img_position', true );
 if ( ! $image_position ) {
-	$image_position = 'right'; }
+	$image_position = Vk_Call_To_Action::IMAGE_POSITION_DEFAULT; }
 
 $content  = '';
-$content .= '<section class="veu_cta" id="veu_cta-' . $id . '">';
-$content .= '<h2 class="cta_title">' . $cta_post->post_title . '</h2>';
+$content .= '<section class="veu_cta" id="veu_cta-' . esc_attr( $id ) . '">';
+$content .= '<h2 class="cta_title">' . esc_html( $cta_post->post_title ) . '</h2>';
 $content .= '<div class="cta_body">';
 
 
@@ -73,8 +73,10 @@ if ( 'window_self' !== $target_blank ) {
 	$target = '';
 }
 if ( $imgid ) {
-	$content .= '<div class="cta_body_image cta_body_image_' . $image_position . '">';
-	$content .= ( $url ) ? '<a href="' . $url . '"' . $target . '>' : '';
+	// $image_position はカスタムフィールドの値をそのまま class 属性へ連結するため必ずエスケープする。
+	// Always escape $image_position because the custom field value is concatenated into a class attribute.
+	$content .= '<div class="cta_body_image cta_body_image_' . esc_attr( $image_position ) . '">';
+	$content .= ( $url ) ? '<a href="' . esc_url( $url ) . '"' . $target . '>' : '';
 	$content .= wp_get_attachment_image( $imgid, 'large' );
 	$content .= ( $url ) ? '</a>' : '';
 	$content .= '</div>';
@@ -84,7 +86,7 @@ $content .= wp_kses_post( do_shortcode( $text ) );
 $content .= '</div>';
 if ( $url && $btn_text ) {
 	$content .= '<div class="cta_body_link">';
-	$content .= '<a href="' . $url . '" class="btn btn-primary btn-block btn-lg"' . $target . '>';
+	$content .= '<a href="' . esc_url( $url ) . '" class="btn btn-primary btn-block btn-lg"' . $target . '>';
 	$content .= wp_kses_post( $btn_before . $btn_text . $btn_after );
 	$content .= '</a>';
 	$content .= '</div>';

--- a/readme.txt
+++ b/readme.txt
@@ -94,7 +94,8 @@ e.g.
 [ Bug Fix ][ Smooth Scroll ] Fixed the "CSS only" option label showing outdated information that it does not work on Safari; modern Safari versions support it.
 [ Bug Fix ][ Custom CSS ] Fixed the success and error notices shown after saving the CSS customizer always appearing in English because they referenced an old text domain.
 [ Security Fix ][ CTA ] Added allowlist validation on save and escaping on output for the CTA image position custom field, which allowed stored XSS.
-[ Security Fix ][ CTA ] Filtered the CTA title and escaped the link URLs on the CTA rendering paths ( the title keeps allowed HTML such as <br>, while script and event attributes are removed ).
+[ Security Fix ][ CTA ] Fixed the CTA title being output without any filtering. Decorative HTML such as line breaks and inline tags keeps working, while script tags and event attributes are now removed.
+[ Security Fix ][ CTA ] Fixed the link URLs output by the CTA display not being escaped.
 
 = 9.118.0 =
 [ New Feature ][ SNS Share Button ] Added a Threads share button, with a show / hide toggle under ExUnit > Main Setting.

--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,7 @@ e.g.
 [ Bug Fix ][ Smooth Scroll ] Fixed the "CSS only" option label showing outdated information that it does not work on Safari; modern Safari versions support it.
 [ Bug Fix ][ Custom CSS ] Fixed the success and error notices shown after saving the CSS customizer always appearing in English because they referenced an old text domain.
 [ Security Fix ][ CTA ] Added allowlist validation on save and escaping on output for the CTA image position custom field, which allowed stored XSS.
+[ Security Fix ][ CTA ] Filtered the CTA title and escaped the link URLs on the CTA rendering paths ( the title keeps allowed HTML such as <br>, while script and event attributes are removed ).
 
 = 9.118.0 =
 [ New Feature ][ SNS Share Button ] Added a Threads share button, with a show / hide toggle under ExUnit > Main Setting.

--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,7 @@ e.g.
 [ Bug Fix ][ Custom CSS ] Fixed the per-post Custom CSS leaking into the whole admin screen and breaking admin elements such as headings; it is now applied only to the block editor content and the front end.
 [ Bug Fix ][ Smooth Scroll ] Fixed the "CSS only" option label showing outdated information that it does not work on Safari; modern Safari versions support it.
 [ Bug Fix ][ Custom CSS ] Fixed the success and error notices shown after saving the CSS customizer always appearing in English because they referenced an old text domain.
+[ Security Fix ][ CTA ] Added allowlist validation on save and escaping on output for the CTA image position custom field, which allowed stored XSS.
 
 = 9.118.0 =
 [ New Feature ][ SNS Share Button ] Added a Threads share button, with a show / hide toggle under ExUnit > Main Setting.

--- a/tests/test-cta-image-position.php
+++ b/tests/test-cta-image-position.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * CTA image position ( vkExUnit_cta_img_position ) test
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * CTA image position test case.
+ *
+ * The vkExUnit_cta_img_position value is concatenated into a class attribute on the front end.
+ * This test covers both the save side ( allowlist validation ) and the output side ( escaping ).
+ *
+ * vkExUnit_cta_img_position はフロント側で class 属性に連結されるため、
+ * 保存時のホワイトリスト検証と出力時のエスケープの両方を検証する。
+ */
+class CTAImagePositionTest extends WP_UnitTestCase {
+
+	/**
+	 * Stored XSS PoC value reported in issue #1434.
+	 * issue #1434 で報告された Stored XSS の PoC 値。
+	 */
+	const XSS_IMAGE_POSITION = 'right" onmouseover=alert(1)//';
+
+	/**
+	 * Reset globals after each test.
+	 * テストごとにグローバルを初期化する。
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		$_POST = array();
+	}
+
+	/**
+	 * Create a CTA post rendered with the classic ( non block ) layout.
+	 * クラシックレイアウトで描画される CTA 投稿を作成する。
+	 *
+	 * @return int 作成した CTA の投稿ID / Created CTA post ID.
+	 */
+	private function create_classic_cta() {
+		// post_content を空にするとクラシックレイアウト ( view-actionbox.php ) が使われる。
+		// An empty post_content makes the classic layout ( view-actionbox.php ) render.
+		return self::factory()->post->create(
+			array(
+				'post_type'    => Vk_Call_To_Action::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => 'CTA Image Position',
+				'post_content' => '',
+			)
+		);
+	}
+
+	/**
+	 * Write post meta directly into the database, bypassing sanitize_callback.
+	 * sanitize_callback を経由せずに直接データベースへ post meta を書き込む。
+	 *
+	 * This reproduces the state where a malicious value is already stored in the database,
+	 * because it does not go through the sanitize_callback of register_post_meta().
+	 *
+	 * register_post_meta() の sanitize_callback を通さないため、
+	 * 「不正な値が既にデータベースへ保存されている」状態を再現できる。
+	 *
+	 * @param int    $post_id    投稿ID / Post ID.
+	 * @param string $meta_key   メタキー / Meta key.
+	 * @param string $meta_value 生のメタ値 / Raw meta value.
+	 * @return void
+	 */
+	private function set_raw_post_meta( $post_id, $meta_key, $meta_value ) {
+		global $wpdb;
+		// 意図的に sanitize_callback を迂回するため、直接クエリを実行する。
+		// The query is run directly on purpose so the sanitize_callback is bypassed.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		$wpdb->delete(
+			$wpdb->postmeta,
+			array(
+				'post_id'  => $post_id,
+				'meta_key' => $meta_key,
+			)
+		);
+		$wpdb->insert(
+			$wpdb->postmeta,
+			array(
+				'post_id'    => $post_id,
+				'meta_key'   => $meta_key,
+				'meta_value' => $meta_value,
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		// 直接書き込んだためオブジェクトキャッシュを破棄する。
+		// Flush the object cache because the row was written directly.
+		wp_cache_delete( $post_id, 'post_meta' );
+	}
+
+	/**
+	 * Set up the CTA meta used by the classic layout image block.
+	 * クラシックレイアウトの画像ブロック描画に必要な CTA メタを設定する。
+	 *
+	 * @param int    $cta_id         CTA の投稿ID / CTA post ID.
+	 * @param string $image_position 生の画像位置の値 / Raw image position value.
+	 * @return void
+	 */
+	private function set_image_meta( $cta_id, $image_position ) {
+		// $imgid が真値のときだけ画像ブロックが出力されるため、存在しないアタッチメントIDを入れておく。
+		// 存在しないIDなので wp_get_attachment_image() は空文字を返し、比較対象のHTMLが安定する。
+		// The image block is rendered only when $imgid is truthy, so store a non-existent attachment ID.
+		// Since the ID does not exist, wp_get_attachment_image() returns an empty string and keeps the HTML stable.
+		update_post_meta( $cta_id, 'vkExUnit_cta_img', '999999' );
+		update_post_meta( $cta_id, 'vkExUnit_cta_text', 'cta' );
+		// ボタンを出力させないため URL は空にする。
+		// Empty the URL so the button is not rendered.
+		update_post_meta( $cta_id, 'vkExUnit_cta_url', '' );
+		$this->set_raw_post_meta( $cta_id, 'vkExUnit_cta_img_position', $image_position );
+	}
+
+	/**
+	 * Test cases shared by the classic output path and the block output path.
+	 * クラシック出力経路とブロック出力経路で共有するテストケース。
+	 *
+	 * @return array Test cases. テストケース。
+	 */
+	private function get_image_position_output_cases() {
+		return array(
+			array(
+				'test_condition_name' => '画像位置が right の場合 => cta_body_image_right',
+				'image_position'      => 'right',
+				'expected'            => '<div class="cta_body_image cta_body_image_right">',
+			),
+			array(
+				'test_condition_name' => '画像位置が left の場合 => cta_body_image_left',
+				'image_position'      => 'left',
+				'expected'            => '<div class="cta_body_image cta_body_image_left">',
+			),
+			array(
+				'test_condition_name' => '画像位置が未設定の場合 => 既定値の cta_body_image_right',
+				'image_position'      => '',
+				'expected'            => '<div class="cta_body_image cta_body_image_right">',
+			),
+			array(
+				// 既にデータベースへ保存されてしまった不正値。class 属性を抜け出す形の値でも
+				// エスケープされて属性値の中に留まり、onmouseover 属性が生成されない事を検証する。
+				// A malicious value already stored in the database. Even a value that breaks out of the class
+				// attribute must stay escaped inside the attribute value and must not produce an onmouseover attribute.
+				'test_condition_name' => '画像位置に属性を抜け出す不正値が保存されている場合 => エスケープされ onmouseover 属性にならない',
+				'image_position'      => self::XSS_IMAGE_POSITION,
+				'expected'            => '<div class="cta_body_image cta_body_image_right&quot; onmouseover=alert(1)//">',
+				'not_expected'        => 'cta_body_image_right" onmouseover=alert(1)//',
+			),
+		);
+	}
+
+	/**
+	 * Test Vk_Call_To_Action::sanitize_image_position()
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_image_position() {
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'right の場合 => right',
+				'value'               => 'right',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => 'center の場合 => center',
+				'value'               => 'center',
+				'expected'            => 'center',
+			),
+			array(
+				'test_condition_name' => 'left の場合 => left',
+				'value'               => 'left',
+				'expected'            => 'left',
+			),
+			array(
+				'test_condition_name' => '空文字の場合 => 既定値の right',
+				'value'               => '',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => '許可値以外の文字列の場合 => 既定値の right',
+				'value'               => 'top',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => '大文字の場合は許可値と一致しないため => 既定値の right',
+				'value'               => 'RIGHT',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => '属性を抜け出す不正値の場合 => 既定値の right',
+				'value'               => self::XSS_IMAGE_POSITION,
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => 'null の場合 => 既定値の right',
+				'value'               => null,
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => '配列などスカラー以外の場合 => 既定値の right',
+				'value'               => array( 'right' ),
+				'expected'            => 'right',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$actual = Vk_Call_To_Action::sanitize_image_position( $case['value'] );
+			$this->assertSame( $case['expected'], $actual, $case['test_condition_name'] );
+		}
+	}
+
+	/**
+	 * Test Vk_Call_To_Action::render_cta_content()
+	 *
+	 * クラシック表示経路 ( view-actionbox.php ) の class 属性出力を検証する。
+	 * Verify the class attribute output of the classic display path ( view-actionbox.php ).
+	 *
+	 * @return void
+	 */
+	public function test_render_cta_content() {
+		$cta_id = $this->create_classic_cta();
+
+		foreach ( $this->get_image_position_output_cases() as $case ) {
+			$this->set_image_meta( $cta_id, $case['image_position'] );
+
+			$actual = Vk_Call_To_Action::render_cta_content( $cta_id );
+
+			$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
+			if ( isset( $case['not_expected'] ) ) {
+				$this->assertStringNotContainsString( $case['not_expected'], $actual, $case['test_condition_name'] );
+			}
+		}
+	}
+
+	/**
+	 * Test veu_cta_block_callback()
+	 *
+	 * ブロック表示経路 ( block/index.php ) の class 属性出力を検証する。
+	 * Verify the class attribute output of the block display path ( block/index.php ).
+	 *
+	 * @return void
+	 */
+	public function test_veu_cta_block_callback() {
+		$cta_id = $this->create_classic_cta();
+
+		// CTA を配置する表示先のページ。
+		// The page where the CTA block is placed.
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'CTA Image Position Page',
+				'post_content' => 'page content',
+			)
+		);
+		$this->go_to( get_permalink( $page_id ) );
+
+		foreach ( $this->get_image_position_output_cases() as $case ) {
+			$this->set_image_meta( $cta_id, $case['image_position'] );
+
+			$actual = veu_cta_block_callback( array( 'postId' => $cta_id ), '' );
+
+			$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
+			if ( isset( $case['not_expected'] ) ) {
+				$this->assertStringNotContainsString( $case['not_expected'], $actual, $case['test_condition_name'] );
+			}
+		}
+	}
+
+	/**
+	 * Test Vk_Call_To_Action::save_custom_field()
+	 *
+	 * クラシック編集画面 ( メタボックス ) からの保存時にホワイトリスト検証が働く事を検証する。
+	 * Verify that the allowlist validation is applied when saving from the classic edit screen ( metabox ).
+	 *
+	 * @return void
+	 */
+	public function test_save_custom_field() {
+		$cta_id = $this->create_classic_cta();
+
+		// save_custom_field() が要求する nonce を作成する。
+		// Create the nonce required by save_custom_field().
+		$reflection = new ReflectionClass( 'Vk_Call_To_Action' );
+		$nonce      = wp_create_nonce( plugin_basename( $reflection->getFileName() ) );
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'right が送信された場合 => right',
+				'post_value'          => 'right',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => 'center が送信された場合 => center',
+				'post_value'          => 'center',
+				'expected'            => 'center',
+			),
+			array(
+				'test_condition_name' => 'left が送信された場合 => left',
+				'post_value'          => 'left',
+				'expected'            => 'left',
+			),
+			array(
+				'test_condition_name' => '許可値以外が送信された場合 => 既定値の right',
+				'post_value'          => 'top',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => '属性を抜け出す不正値が送信された場合 => 既定値の right',
+				'post_value'          => self::XSS_IMAGE_POSITION,
+				'expected'            => 'right',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$_POST = array(
+				'_nonce_vkExUnit_custom_cta' => $nonce,
+				'_vkExUnit_cta_switch'       => 'cta_content',
+				'vkExUnit_cta_img_position'  => $case['post_value'],
+			);
+
+			Vk_Call_To_Action::save_custom_field( $cta_id );
+
+			$this->assertSame(
+				$case['expected'],
+				get_post_meta( $cta_id, 'vkExUnit_cta_img_position', true ),
+				$case['test_condition_name']
+			);
+		}
+	}
+
+	/**
+	 * Test veu_register_active_feature_meta()
+	 *
+	 * ブロックエディタ ( REST API ) 経由の保存で使われる sanitize_callback を検証する。
+	 * update_post_meta() は登録済みメタの sanitize_callback を通るため、それを利用して検証する。
+	 * Verify the sanitize_callback used when saving through the block editor ( REST API ).
+	 * update_post_meta() runs the registered sanitize_callback, so it is used for the assertion.
+	 *
+	 * @return void
+	 */
+	public function test_veu_register_active_feature_meta() {
+		$cta_id = $this->create_classic_cta();
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'right を保存した場合 => right',
+				'value'               => 'right',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => 'center を保存した場合 => center',
+				'value'               => 'center',
+				'expected'            => 'center',
+			),
+			array(
+				'test_condition_name' => '許可値以外を保存した場合 => 既定値の right',
+				'value'               => 'top',
+				'expected'            => 'right',
+			),
+			array(
+				'test_condition_name' => '属性を抜け出す不正値を保存した場合 => 既定値の right',
+				'value'               => self::XSS_IMAGE_POSITION,
+				'expected'            => 'right',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			update_post_meta( $cta_id, 'vkExUnit_cta_img_position', $case['value'] );
+
+			$this->assertSame(
+				$case['expected'],
+				get_post_meta( $cta_id, 'vkExUnit_cta_img_position', true ),
+				$case['test_condition_name']
+			);
+		}
+	}
+}

--- a/tests/test-cta-output-escaping.php
+++ b/tests/test-cta-output-escaping.php
@@ -1,20 +1,22 @@
 <?php
 /**
- * CTA image position ( vkExUnit_cta_img_position ) test
+ * CTA display path escaping test
  *
  * @package Vk_All_In_One_Expansion_Unit
  */
 
 /**
- * CTA image position test case.
+ * CTA display path escaping test case.
  *
- * The vkExUnit_cta_img_position value is concatenated into a class attribute on the front end.
- * This test covers both the save side ( allowlist validation ) and the output side ( escaping ).
+ * The classic CTA layout concatenates custom field values straight into the markup.
+ * This test covers the image position ( save side allowlist and output side escaping )
+ * and the CTA title ( output side filtering ).
  *
- * vkExUnit_cta_img_position はフロント側で class 属性に連結されるため、
- * 保存時のホワイトリスト検証と出力時のエスケープの両方を検証する。
+ * クラシックレイアウトの CTA はカスタムフィールドの値をそのままマークアップへ連結する。
+ * ここでは画像位置 ( 保存時のホワイトリストと出力時のエスケープ ) と
+ * CTA タイトル ( 出力時のフィルタ ) を検証する。
  */
-class CTAImagePositionTest extends WP_UnitTestCase {
+class CTAOutputEscapingTest extends WP_UnitTestCase {
 
 	/**
 	 * Stored XSS PoC value reported in issue #1434.
@@ -31,6 +33,7 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		$_POST = array();
+		wp_set_current_user( 0 );
 	}
 
 	/**
@@ -46,7 +49,7 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 			array(
 				'post_type'    => Vk_Call_To_Action::POST_TYPE,
 				'post_status'  => 'publish',
-				'post_title'   => 'CTA Image Position',
+				'post_title'   => 'CTA Output Escaping',
 				'post_content' => '',
 			)
 		);
@@ -94,33 +97,41 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Set up the CTA meta used by the classic layout image block.
-	 * クラシックレイアウトの画像ブロック描画に必要な CTA メタを設定する。
+	 * Save a post title keeping its HTML tags.
+	 * HTML タグを保持したまま投稿タイトルを保存する。
 	 *
-	 * @param int    $cta_id         CTA の投稿ID / CTA post ID.
-	 * @param string $image_position 生の画像位置の値 / Raw image position value.
+	 * WordPress は unfiltered_html 権限を持たないユーザーの保存時にタイトルへ kses を適用し、
+	 * <br> などのタグを除去してしまう。管理者が保存した実運用の状態を再現するため、
+	 * 一時的に管理者ユーザーへ切り替えて保存し、描画前に未ログイン状態へ戻す。
+	 * WordPress applies kses to the title when the saving user lacks the unfiltered_html capability,
+	 * stripping tags such as <br>. To reproduce the real-world state saved by an administrator,
+	 * switch to an administrator to save and switch back to a logged-out state before rendering.
+	 *
+	 * @param int    $post_id 投稿ID / Post ID.
+	 * @param string $title   保存するタイトル / Title to save.
 	 * @return void
 	 */
-	private function set_image_meta( $cta_id, $image_position ) {
-		// $imgid が真値のときだけ画像ブロックが出力されるため、存在しないアタッチメントIDを入れておく。
-		// 存在しないIDなので wp_get_attachment_image() は空文字を返し、比較対象のHTMLが安定する。
-		// The image block is rendered only when $imgid is truthy, so store a non-existent attachment ID.
-		// Since the ID does not exist, wp_get_attachment_image() returns an empty string and keeps the HTML stable.
-		update_post_meta( $cta_id, 'vkExUnit_cta_img', '999999' );
-		update_post_meta( $cta_id, 'vkExUnit_cta_text', 'cta' );
-		// ボタンを出力させないため URL は空にする。
-		// Empty the URL so the button is not rendered.
-		update_post_meta( $cta_id, 'vkExUnit_cta_url', '' );
-		$this->set_raw_post_meta( $cta_id, 'vkExUnit_cta_img_position', $image_position );
+	private function set_unfiltered_post_title( $post_id, $title ) {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => $title,
+			)
+		);
+		// 未ログイン状態に戻す。管理者のままだと描画結果に編集ボタンが混ざるため。
+		// Switch back to a logged-out state, otherwise the edit button would be mixed into the rendered output.
+		wp_set_current_user( 0 );
 	}
 
 	/**
 	 * Test cases shared by the classic output path and the block output path.
 	 * クラシック出力経路とブロック出力経路で共有するテストケース。
 	 *
-	 * @return array Test cases. テストケース。
+	 * @return array テストケース / Test cases.
 	 */
-	private function get_image_position_output_cases() {
+	private function get_output_cases() {
 		return array(
 			array(
 				'test_condition_name' => '画像位置が right の場合 => cta_body_image_right',
@@ -133,7 +144,7 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 				'expected'            => '<div class="cta_body_image cta_body_image_left">',
 			),
 			array(
-				'test_condition_name' => '画像位置が未設定の場合 => 既定値の cta_body_image_right',
+				'test_condition_name' => '画像位置が未設定 ( Normal ) の場合 => 既定値の cta_body_image_right',
 				'image_position'      => '',
 				'expected'            => '<div class="cta_body_image cta_body_image_right">',
 			),
@@ -147,7 +158,50 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 				'expected'            => '<div class="cta_body_image cta_body_image_right&quot; onmouseover=alert(1)//">',
 				'not_expected'        => 'cta_body_image_right" onmouseover=alert(1)//',
 			),
+			array(
+				// タイトルは wp_kses_post で出力するため、<br> は残しつつ <script> は除去される。
+				// esc_html だと <br> が文字として表示されてしまうため、その退行がない事も併せて検証する。
+				// The title is output through wp_kses_post, so <br> is kept while <script> is stripped.
+				// esc_html would render <br> as text, so this also guards against that regression.
+				'test_condition_name' => 'タイトルに <br> と <script> が含まれる場合 => <br> は残り <script> は除去される',
+				'image_position'      => 'right',
+				'post_title'          => 'CTA Title<br><script>alert(1)</script>',
+				'expected'            => '<h2 class="cta_title">CTA Title<br>alert(1)</h2>',
+				'not_expected'        => '<script>',
+			),
+			array(
+				'test_condition_name' => 'タイトルに on* 属性付きのタグが含まれる場合 => 属性が除去される',
+				'image_position'      => 'right',
+				'post_title'          => 'CTA <span onmouseover="alert(1)">Title</span>',
+				'expected'            => '<h2 class="cta_title">CTA <span>Title</span></h2>',
+				'not_expected'        => 'onmouseover',
+			),
 		);
+	}
+
+	/**
+	 * Apply the conditions of one output test case to the CTA post.
+	 * 出力テストケースの条件を CTA 投稿へ適用する。
+	 *
+	 * @param int   $cta_id    CTA の投稿ID / CTA post ID.
+	 * @param array $test_case テストケース / Test case.
+	 * @return void
+	 */
+	private function apply_output_case( $cta_id, $test_case ) {
+		// $imgid が真値のときだけ画像ブロックが出力されるため、存在しないアタッチメントIDを入れておく。
+		// 存在しないIDなので wp_get_attachment_image() は空文字を返し、比較対象のHTMLが安定する。
+		// The image block is rendered only when $imgid is truthy, so store a non-existent attachment ID.
+		// Since the ID does not exist, wp_get_attachment_image() returns an empty string and keeps the HTML stable.
+		update_post_meta( $cta_id, 'vkExUnit_cta_img', '999999' );
+		update_post_meta( $cta_id, 'vkExUnit_cta_text', 'cta' );
+		// ボタンを出力させないため URL は空にする。
+		// Empty the URL so the button is not rendered.
+		update_post_meta( $cta_id, 'vkExUnit_cta_url', '' );
+		$this->set_raw_post_meta( $cta_id, 'vkExUnit_cta_img_position', $test_case['image_position'] );
+
+		if ( isset( $test_case['post_title'] ) ) {
+			$this->set_unfiltered_post_title( $cta_id, $test_case['post_title'] );
+		}
 	}
 
 	/**
@@ -173,9 +227,13 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 				'expected'            => 'left',
 			),
 			array(
-				'test_condition_name' => '空文字の場合 => 既定値の right',
+				// 空文字はブロックエディタの「Normal」( 位置指定なし ) を表す正当な値のため丸めない。
+				// 丸めてしまうと Normal を選んで保存した後に Right が選択された状態で表示される退行になる。
+				// An empty string is the valid "Normal" ( no position ) value in the block editor, so it must not be normalized.
+				// Normalizing it would regress into showing "Right" as selected after saving "Normal".
+				'test_condition_name' => '空文字 ( Normal ) の場合 => 空文字のまま',
 				'value'               => '',
-				'expected'            => 'right',
+				'expected'            => '',
 			),
 			array(
 				'test_condition_name' => '許可値以外の文字列の場合 => 既定値の right',
@@ -193,7 +251,7 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 				'expected'            => 'right',
 			),
 			array(
-				'test_condition_name' => 'null の場合 => 既定値の right',
+				'test_condition_name' => 'null の場合はスカラーではないため => 既定値の right',
 				'value'               => null,
 				'expected'            => 'right',
 			),
@@ -213,16 +271,16 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 	/**
 	 * Test Vk_Call_To_Action::render_cta_content()
 	 *
-	 * クラシック表示経路 ( view-actionbox.php ) の class 属性出力を検証する。
-	 * Verify the class attribute output of the classic display path ( view-actionbox.php ).
+	 * クラシック表示経路 ( view-actionbox.php ) の出力を検証する。
+	 * Verify the output of the classic display path ( view-actionbox.php ).
 	 *
 	 * @return void
 	 */
 	public function test_render_cta_content() {
 		$cta_id = $this->create_classic_cta();
 
-		foreach ( $this->get_image_position_output_cases() as $case ) {
-			$this->set_image_meta( $cta_id, $case['image_position'] );
+		foreach ( $this->get_output_cases() as $case ) {
+			$this->apply_output_case( $cta_id, $case );
 
 			$actual = Vk_Call_To_Action::render_cta_content( $cta_id );
 
@@ -236,8 +294,8 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 	/**
 	 * Test veu_cta_block_callback()
 	 *
-	 * ブロック表示経路 ( block/index.php ) の class 属性出力を検証する。
-	 * Verify the class attribute output of the block display path ( block/index.php ).
+	 * ブロック表示経路 ( block/index.php ) の出力を検証する。
+	 * Verify the output of the block display path ( block/index.php ).
 	 *
 	 * @return void
 	 */
@@ -250,14 +308,14 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 			array(
 				'post_type'    => 'page',
 				'post_status'  => 'publish',
-				'post_title'   => 'CTA Image Position Page',
+				'post_title'   => 'CTA Output Escaping Page',
 				'post_content' => 'page content',
 			)
 		);
 		$this->go_to( get_permalink( $page_id ) );
 
-		foreach ( $this->get_image_position_output_cases() as $case ) {
-			$this->set_image_meta( $cta_id, $case['image_position'] );
+		foreach ( $this->get_output_cases() as $case ) {
+			$this->apply_output_case( $cta_id, $case );
 
 			$actual = veu_cta_block_callback( array( 'postId' => $cta_id ), '' );
 
@@ -299,6 +357,11 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 				'test_condition_name' => 'left が送信された場合 => left',
 				'post_value'          => 'left',
 				'expected'            => 'left',
+			),
+			array(
+				'test_condition_name' => '空文字が送信された場合 => 空文字のまま',
+				'post_value'          => '',
+				'expected'            => '',
 			),
 			array(
 				'test_condition_name' => '許可値以外が送信された場合 => 既定値の right',
@@ -352,6 +415,15 @@ class CTAImagePositionTest extends WP_UnitTestCase {
 				'test_condition_name' => 'center を保存した場合 => center',
 				'value'               => 'center',
 				'expected'            => 'center',
+			),
+			array(
+				// ブロックエディタのセレクトで「Normal」を選んだ場合。空文字のまま保存されないと
+				// リロード時に Right が選択された状態で表示されてしまう。
+				// Selecting "Normal" in the block editor's select. If it is not stored as an empty string,
+				// "Right" would appear selected after reloading.
+				'test_condition_name' => '空文字 ( Normal ) を保存した場合 => 空文字のまま',
+				'value'               => '',
+				'expected'            => '',
 			),
 			array(
 				'test_condition_name' => '許可値以外を保存した場合 => 既定値の right',


### PR DESCRIPTION
Closes #1434

@coderabbitai ignore

## 概要

CTA（Call To Action）の「画像位置」設定を悪用した Stored XSS（保存型クロスサイトスクリプティング）を修正します。

CTA の画像位置は本来「右 / 中央 / 左」から選ぶ設定ですが、**保存する値が正しい選択肢かどうかを検証しておらず、画面に出力するときのエスケープ（HTML として解釈されない形への変換）も行っていませんでした**。そのため、保存リクエストを改ざんして `right" onmouseover=alert(1)//` のような値を送り込むと、CTA を表示したページで任意の JavaScript が実行されました。

あわせて、同じ CTA 表示処理にあった他のエスケープ漏れ（CTA タイトル・リンク URL）も塞いでいます。

## 修正内容

多層防御として、保存時と出力時の両方で対策しています。

### 1. 保存時に選択肢を検証する

`Vk_Call_To_Action::sanitize_image_position()`（画像位置の値が正しい選択肢かを確かめるメソッド）を追加し、`right` / `center` / `left` 以外の値は既定値 `right` に置き換えるようにしました。

このメソッドを、以下の 2 つの保存経路の両方から呼びます。

- クラシックエディタのメタボックス経由の保存
- ブロックエディタのサイドバー（REST API）経由の保存

REST API 側は `register_post_meta()` の `sanitize_callback`（カスタムフィールド保存時に必ず通る変換処理）として登録しているため、**プラグイン外のコードが `update_post_meta()` で直接書き込んだ場合も検証を通ります**。

なお、空文字は「Normal（位置を指定しない）」を意味するブロックエディタ側の正当な選択肢のため、そのまま保持します（表示側に既定値へのフォールバックがあるため、フロントの見た目は従来どおりです）。

### 2. 出力時にエスケープする

**既に不正な値が保存されているサイトを救う**ため、出力側でも `esc_attr()`（HTML 属性として安全な形に変換する関数）を通します。クラシック表示（`view-actionbox.php`）とブロック表示（`block/index.php`）の両方に適用しました。

### 3. 同じ表示処理にあった他のエスケープ漏れ

- **CTA タイトル**: これまで一切フィルタされていませんでした。`wp_kses_post()`（投稿本文と同じ範囲の HTML だけを許可する関数）を適用し、`<script>` タグや `onmouseover` などのイベント属性を除去します。改行や装飾用のタグはこれまでどおり使えます
- **リンク URL**: クラシック表示側の画像リンク・ボタンリンクの URL に `esc_url()` を適用
- **編集ボタンのラベル**: ブロック表示側も `esc_html__()` に統一

## テスト（確認手順）

### 事前準備

1. ExUnit の設定で「CTA」を有効化する
2. 管理画面 > CTA > 新規追加 で CTA を作成し、「Use following data」を有効にして画像を設定、公開する
3. 任意の固定ページを作成し、その CTA を表示する設定にする

### Before（修正前の再現手順）

1. `master` ブランチの状態にする
2. CTA 編集画面をブロックエディタで開き、サイドバーの「VK All in One」パネル > 「CTA Contents」で画像位置を選択して保存する
3. ブラウザの開発ツールでその保存リクエスト（REST API）を傍受し、`"vkExUnit_cta_img_position"` の値を `right" onmouseover=alert(1)//` に書き換えて送信する
4. 手順 3 の CTA を表示している固定ページをフロントで開く
5. CTA の画像にマウスカーソルを乗せる

→ **`alert(1)` のダイアログが表示される**（XSS が発火）

→ ページのソースを見ると `<div class="cta_body_image cta_body_image_right" onmouseover=alert(1)//">` となっており、`class` 属性を抜け出して `onmouseover` 属性が挿入されている

### After（修正後の確認手順）

1. 本ブランチに切り替える
2. Before と同じ手順 2〜3 で不正な値を送信する

→ **保存された時点で `right` に置き換わる**（不正な値が DB に入らない）

3. Before の手順で既に不正な値が保存されている CTA を表示しているページをフロントで開き、画像にマウスカーソルを乗せる

→ **ダイアログは表示されない**

→ ソースを見ると `<div class="cta_body_image cta_body_image_right&quot; onmouseover=alert(1)//">` となっており、ダブルクォートがエスケープされて属性を抜け出せていない

### デグレ確認

以下がこれまでどおり動作することを確認してください。

1. **画像位置の設定が効くこと**
   - クラシックエディタのメタボックスで「right」「center」「left」をそれぞれ選んで保存
   - → フロントで CTA 画像の位置がそれぞれ右・中央・左に変わる

2. **ブロックエディタで「Normal」を選んでも設定が化けないこと**
   - サイドバーの「Image position」で「Normal」を選んで保存し、ページを再読み込みする
   - → セレクトが「Normal」のまま（「Right」に変わらない）

3. **CTA タイトルの装飾がこれまでどおり使えること**
   - CTA のタイトルに `<br>` を入れて保存する（管理者権限で操作）
   - → フロントで改行として表示される（タグが文字として見えない）
   - `<span style="color:red">` のような装飾タグも同様に有効

4. **CTA ボタンのアイコンが消えないこと**
   - ボタンアイコン（Before / After）を設定した CTA をブロック表示・クラシック表示の両方で確認
   - → アイコンが表示される

### 自動テスト

`tests/test-cta-output-escaping.php` を追加しています。

- 保存経路（メタボックス / REST API）と出力経路（クラシック表示 / ブロック表示）の 4 経路をカバー
- 「既に DB に不正な値が保存されている」状態を再現するため、`$wpdb` で直接書き込むヘルパーを使用（`sanitize_callback` を迂回するため）
- 修正を戻すと実際に失敗することを確認済み（`master` に戻すと 1 error + 4 failures、`esc_html()` 版に戻すと 5 failures）

PHPUnit 全体: `OK (119 tests, 849 assertions)`

## スクリーンショット

フロントの表示・レイアウトに変更はないため省略します（エスケープ処理の追加のみで、正常な値での出力結果は従来と同一です）。

## レビュー

- 🔒 セキュリティレビュー（安藤）: PASS
- 🎨 UX レビュー（植草）: 問題なし

## 本 PR に含めなかったもの

レビューで見つかった既存の課題は、スコープが独立するため別 issue に切り出しています。

- #1436 — ブロックエディタの画像位置に center / left の選択肢がない（既存の機能欠落）
- #1437 — CTA 保存処理・管理画面出力の多層防御を強化（保存処理の権限チェック・`wp_unslash()`・管理画面のエスケープ・dead code の `allow_custom_iframes()`）

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/620