### PR TITLE
[ 機能追加 ] お問い合わせセクションのバナー画像に代替テキスト設定を追加し、リンク名が「contact_txt」と読み上げられる状態を解消

### DIFF
--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -72,6 +72,14 @@ class VkExUnit_Contact {
 	protected function run_init() {
 		add_action( 'veu_package_init', array( $this, 'options_init' ) );
 		add_action( 'save_post', array( $this, 'save_custom_field_postdata' ) );
+
+		// 保存時に一度だけバナー画像の代替テキストをメディアライブラリから補完する。
+		// 管理画面の独自 POST ハンドラもカスタマイザーも最終的に update_option( 'vkExUnit_contact', ... ) を通るため、
+		// このフックひとつで両方の保存経路をカバーできる。フロント表示時に逆引きしないための措置。
+		// Fill the banner image alternative text from the media library once, at save time.
+		// Both the admin screen's own POST handler and the customizer end up calling update_option( 'vkExUnit_contact', ... ),
+		// so this single hook covers both save paths. This avoids reverse lookups on every front-end render.
+		add_filter( 'pre_update_option_vkExUnit_contact', array( __CLASS__, 'fill_contact_image_alt' ), 10, 1 );
 		add_shortcode( 'vkExUnit_contact_section', array( $this, 'shortcode' ) );
 		require_once __DIR__ . '/block/index.php';
 
@@ -119,6 +127,7 @@ class VkExUnit_Contact {
 			'button_text_small'    => '',
 			'short_text'           => __( 'Contact us', 'vk-all-in-one-expansion-unit' ),
 			'contact_image'        => '',
+			'contact_image_alt'    => '',
 			'contact_html'         => '',
 		);
 		$option  = get_option( 'vkExUnit_contact' );
@@ -224,6 +233,13 @@ class VkExUnit_Contact {
 <p><?php _e( 'Display the image instead of the above inquiry information', 'vk-all-in-one-expansion-unit' ); ?><p>
 </td>
 </tr>
+<!-- Alternative text of the inquiry banner image -->
+<tr>
+<th><label for="contact_image_alt"><?php esc_html_e( 'Alternative text of the inquiry banner image', 'vk-all-in-one-expansion-unit' ); ?></label></th>
+<td><input type="text" name="vkExUnit_contact[contact_image_alt]" id="contact_image_alt" value="<?php echo esc_attr( $options['contact_image_alt'] ); ?>" style="width:60%;" />
+<p><?php esc_html_e( 'Describe the banner image for people who can not see it.', 'vk-all-in-one-expansion-unit' ); ?><br /><?php esc_html_e( 'If you leave it blank, the alternative text set on the media library is filled in automatically when you save.', 'vk-all-in-one-expansion-unit' ); ?></p>
+</td>
+</tr>
 <tr>
 <th><?php _e( 'Display HTML message instead of the standard', 'vk-all-in-one-expansion-unit' ); ?></th>
 <td><textarea cols="20" rows="5" name="vkExUnit_contact[contact_html]" id="contact_html" value="" style="width:100%;"><?php echo $options['contact_html']; ?></textarea>
@@ -254,10 +270,53 @@ class VkExUnit_Contact {
 		$option['button_text_small'] = wp_kses_post( stripslashes( $option['button_text_small'] ) );
 		$option['short_text']        = wp_kses_post( stripslashes( $option['short_text'] ) );
 		$option['contact_image']     = esc_url( $option['contact_image'] );
+		// 代替テキストは img の alt 属性にそのまま入るため、タグを許さないテキストとして保存する。
+		// The alternative text goes straight into the img alt attribute, so save it as text that allows no tags.
+		$option['contact_image_alt'] = isset( $option['contact_image_alt'] ) ? sanitize_text_field( stripslashes( $option['contact_image_alt'] ) ) : '';
 		$option['contact_html']      = wp_kses_post( stripslashes( $option['contact_html'] ) );
 		return $option;
 	}
 
+	/**
+	 * バナー画像の代替テキストが空の時に、メディアライブラリ側の代替テキストで補完する。
+	 * update_option( 'vkExUnit_contact', ... ) の直前に呼ばれるため、管理画面・カスタマイザーの
+	 * どちらの保存経路でも動作し、かつ添付ファイルの逆引きは保存時の1回だけで済む。
+	 *
+	 * Fill the banner image alternative text from the media library when it is empty.
+	 * It runs just before update_option( 'vkExUnit_contact', ... ), so it works for both the admin screen
+	 * and the customizer save path, and the attachment lookup happens only once, at save time.
+	 *
+	 * @param  mixed $value 保存されようとしている vkExUnit_contact のオプション値 / The vkExUnit_contact option value about to be saved.
+	 * @return mixed        代替テキストを補完したオプション値 / The option value with the alternative text filled in.
+	 */
+	public static function fill_contact_image_alt( $value ) {
+		// 想定外の型（配列以外）はそのまま返す / Return values of unexpected types ( non array ) untouched.
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		// バナー画像が未設定、または代替テキストが既に入力済みの場合は何もしない。
+		// Do nothing when the banner image is unset, or the alternative text is already filled in.
+		if ( empty( $value['contact_image'] ) || ! empty( $value['contact_image_alt'] ) ) {
+			return $value;
+		}
+
+		// URL からメディアライブラリの添付ファイルを逆引きする。外部 URL などで見つからない場合は 0 が返る。
+		// Resolve the media library attachment from the URL. It returns 0 when not found ( external URLs etc. ).
+		$attachment_id = attachment_url_to_postid( $value['contact_image'] );
+		if ( ! $attachment_id ) {
+			return $value;
+		}
+
+		// メディアライブラリ側に設定された代替テキストを取得する / Get the alternative text set on the media library.
+		$attachment_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		if ( ! is_string( $attachment_alt ) || '' === $attachment_alt ) {
+			return $value;
+		}
+
+		$value['contact_image_alt'] = sanitize_text_field( $attachment_alt );
+		return $value;
+	}
 
 	public function render_meta_box() {
 		$enable = get_post_meta( get_the_id(), 'vkExUnit_contact_enable', true );
@@ -352,9 +411,28 @@ class VkExUnit_Contact {
 			$cont .= $options['contact_html'];
 			$cont .= '</section>';
 		} elseif ( $options['contact_image'] ) {
+			// バナー画像の代替テキスト。alt 属性へそのまま入るためタグを除去する。
+			// The banner image alternative text. Strip tags because it goes straight into the alt attribute.
+			$image_alt = isset( $options['contact_image_alt'] ) ? trim( wp_strip_all_tags( $options['contact_image_alt'] ) ) : '';
+
+			// リンクの中身が画像1枚だけのため、代替テキストと aria-label は排他にする。
+			// aria-label を併記すると alt が無視されて上書きされ、設定した説明文が読み上げられなくなる。
+			// 代替テキストが空の時だけ、リンク名が消えないよう aria-label でお問い合わせボタンの文言を補う。
+			// The link contains nothing but the image, so the alternative text and aria-label are mutually exclusive.
+			// Adding aria-label alongside alt overrides it, and the description set by the user would never be read aloud.
+			// Only when the alternative text is empty, aria-label falls back to the contact button text so the link keeps its name.
+			$aria_label_attr = '';
+			if ( '' === $image_alt ) {
+				$aria_label = isset( $options['button_text'] ) ? trim( wp_strip_all_tags( $options['button_text'] ) ) : '';
+				if ( '' === $aria_label ) {
+					$aria_label = __( 'Contact us', 'vk-all-in-one-expansion-unit' );
+				}
+				$aria_label_attr = ' aria-label="' . esc_attr( $aria_label ) . '"';
+			}
+
 			$cont .= '<section class="veu_contentAddSection' . $additional_classes . '">';
-			$cont .= '<a href="' . esc_url( $options['contact_link'] ) . '"' . $link_target . '>';
-			$cont .= '<img src="' . esc_attr( $options['contact_image'] ) . '" alt="contact_txt">';
+			$cont .= '<a href="' . esc_url( $options['contact_link'] ) . '"' . $link_target . $aria_label_attr . '>';
+			$cont .= '<img src="' . esc_url( $options['contact_image'] ) . '" alt="' . esc_attr( $image_alt ) . '">';
 			$cont .= '</a>';
 			$cont .= '</section>';
 		} else {

--- a/inc/contact-section/contact-section.php
+++ b/inc/contact-section/contact-section.php
@@ -227,7 +227,7 @@ class VkExUnit_Contact {
 		?>
 	<table class="form-table" id="vkEx_contact_info"<?php echo $display; ?>>
 	<tr>
-	<th><?php _e( 'Inquiry Banner image', 'vk-all-in-one-expansion-unit' ); ?></th>
+	<th><label for="contact_image"><?php _e( 'Inquiry Banner image', 'vk-all-in-one-expansion-unit' ); ?></label></th>
 <td><input type="text" name="vkExUnit_contact[contact_image]" id="contact_image" value="<?php echo $options['contact_image']; ?>" style="width:60%;" />
 <button id="media_src_contact_image" class="media_btn button button-default"><?php _e( 'Select Image' ); ?></button>
 <p><?php _e( 'Display the image instead of the above inquiry information', 'vk-all-in-one-expansion-unit' ); ?><p>
@@ -237,7 +237,10 @@ class VkExUnit_Contact {
 <tr>
 <th><label for="contact_image_alt"><?php esc_html_e( 'Alternative text of the inquiry banner image', 'vk-all-in-one-expansion-unit' ); ?></label></th>
 <td><input type="text" name="vkExUnit_contact[contact_image_alt]" id="contact_image_alt" value="<?php echo esc_attr( $options['contact_image_alt'] ); ?>" style="width:60%;" />
-<p><?php esc_html_e( 'Describe the banner image for people who can not see it.', 'vk-all-in-one-expansion-unit' ); ?><br /><?php esc_html_e( 'If you leave it blank, the alternative text set on the media library is filled in automatically when you save.', 'vk-all-in-one-expansion-unit' ); ?></p>
+<p><?php esc_html_e( 'The banner image is a link, so the text you enter here is read aloud as the name of the link.', 'vk-all-in-one-expansion-unit' ); ?>
+<br /><?php esc_html_e( 'Enter a text that tells where the link goes, not a text that describes how the image looks.', 'vk-all-in-one-expansion-unit' ); ?>
+<br /><?php esc_html_e( 'ex) ', 'vk-all-in-one-expansion-unit' ); ?><?php esc_html_e( 'Contact us', 'vk-all-in-one-expansion-unit' ); ?>
+<br /><?php esc_html_e( 'If you leave it blank, and the image is in the media library and has an alternative text set on it, that text is filled in automatically when you save.', 'vk-all-in-one-expansion-unit' ); ?></p>
 </td>
 </tr>
 <tr>
@@ -271,8 +274,12 @@ class VkExUnit_Contact {
 		$option['short_text']        = wp_kses_post( stripslashes( $option['short_text'] ) );
 		$option['contact_image']     = esc_url( $option['contact_image'] );
 		// 代替テキストは img の alt 属性にそのまま入るため、タグを許さないテキストとして保存する。
+		// stripslashes() は配列を渡されると PHP 8 で TypeError になるため、配列安全な wp_unslash() を使い、
+		// 併せて文字列以外が POST された場合は空文字として扱う。
 		// The alternative text goes straight into the img alt attribute, so save it as text that allows no tags.
-		$option['contact_image_alt'] = isset( $option['contact_image_alt'] ) ? sanitize_text_field( stripslashes( $option['contact_image_alt'] ) ) : '';
+		// stripslashes() throws a TypeError on PHP 8 when given an array, so use the array safe wp_unslash(),
+		// and treat any non string POST value as an empty string.
+		$option['contact_image_alt'] = isset( $option['contact_image_alt'] ) && is_string( $option['contact_image_alt'] ) ? sanitize_text_field( wp_unslash( $option['contact_image_alt'] ) ) : '';
 		$option['contact_html']      = wp_kses_post( stripslashes( $option['contact_html'] ) );
 		return $option;
 	}
@@ -295,9 +302,21 @@ class VkExUnit_Contact {
 			return $value;
 		}
 
+		// 代替テキストの現在値。キーが無い場合は空文字として扱う。
+		// The current alternative text. Treat a missing key as an empty string.
+		$current_alt = isset( $value['contact_image_alt'] ) && is_string( $value['contact_image_alt'] ) ? $value['contact_image_alt'] : '';
+
 		// バナー画像が未設定、または代替テキストが既に入力済みの場合は何もしない。
+		// この関数は update_option() を呼ぶあらゆる箇所から値が飛んでくるため、要素の型まで確認する。
+		// contact_image が配列だと attachment_url_to_postid() 内の parse_url() が PHP 8 で TypeError になる。
+		// 空判定は厳密比較にする。! empty() だと代替テキストが文字列 "0" の時に空と見なされ、
+		// 次の保存でメディアライブラリ側の値へ黙って上書きされてしまう。
 		// Do nothing when the banner image is unset, or the alternative text is already filled in.
-		if ( empty( $value['contact_image'] ) || ! empty( $value['contact_image_alt'] ) ) {
+		// Values reach this function from every caller of update_option(), so check the element types too.
+		// An array in contact_image would make parse_url() inside attachment_url_to_postid() throw a TypeError on PHP 8.
+		// The emptiness check is strict: with ! empty() an alternative text of the string "0" would count as empty
+		// and get silently overwritten by the media library value on the next save.
+		if ( empty( $value['contact_image'] ) || ! is_string( $value['contact_image'] ) || '' !== $current_alt ) {
 			return $value;
 		}
 
@@ -316,6 +335,46 @@ class VkExUnit_Contact {
 
 		$value['contact_image_alt'] = sanitize_text_field( $attachment_alt );
 		return $value;
+	}
+
+	/**
+	 * 属性値（alt / aria-label）へ入れる文字列を正規化する。
+	 * タグを除去したうえで、連続する空白・改行・タブを半角スペース1つにまとめて前後を削る。
+	 * 保存値が textarea 由来（button_text など）で改行を含む場合に、属性値へ改行が残るのを防ぐ。
+	 *
+	 * Normalize a string that goes into an attribute value ( alt / aria-label ).
+	 * It strips tags, collapses runs of whitespace, line breaks and tabs into a single space, and trims both ends.
+	 * This prevents line breaks from remaining in the attribute value when the saved value comes from a textarea ( such as button_text ).
+	 *
+	 * @param  mixed $text 正規化する文字列 / The string to normalize.
+	 * @return string      正規化した文字列 / The normalized string.
+	 */
+	public static function normalize_attribute_text( $text ) {
+		// 文字列以外が渡された場合は空文字を返す / Return an empty string when a non string is passed.
+		if ( ! is_string( $text ) ) {
+			return '';
+		}
+
+		// <br> はテキスト上の区切りなので、タグ除去の前に半角スペースへ置き換える。
+		// そのまま strip_tags すると前後の語がくっついてしまい（例: Contact us<br>by email → Contact usby email）、
+		// 読み上げ時に別の語として聞こえてしまうため。
+		// A <br> is a textual separator, so replace it with a space before stripping tags.
+		// Stripping it directly would glue the surrounding words together ( e.g. Contact us<br>by email -> Contact usby email ),
+		// which would be read aloud as a different word.
+		$text = preg_replace( '/<br\s*\/?>/i', ' ', $text );
+		$text = wp_strip_all_tags( (string) $text );
+
+		// 連続する空白類（改行・タブ含む）を半角スペース1つにまとめる。マルチバイト対応のため u 修飾子を付ける。
+		// Collapse runs of whitespace ( including line breaks and tabs ) into a single space. The u modifier keeps it multibyte safe.
+		$normalized = preg_replace( '/\s+/u', ' ', $text );
+
+		// preg_replace は失敗時に null を返すため、その場合は元の文字列にフォールバックする。
+		// preg_replace returns null on failure, so fall back to the original string in that case.
+		if ( null === $normalized ) {
+			$normalized = $text;
+		}
+
+		return trim( $normalized );
 	}
 
 	public function render_meta_box() {
@@ -411,9 +470,9 @@ class VkExUnit_Contact {
 			$cont .= $options['contact_html'];
 			$cont .= '</section>';
 		} elseif ( $options['contact_image'] ) {
-			// バナー画像の代替テキスト。alt 属性へそのまま入るためタグを除去する。
-			// The banner image alternative text. Strip tags because it goes straight into the alt attribute.
-			$image_alt = isset( $options['contact_image_alt'] ) ? trim( wp_strip_all_tags( $options['contact_image_alt'] ) ) : '';
+			// バナー画像の代替テキスト。alt 属性へそのまま入るためタグを除去し、空白を正規化する。
+			// The banner image alternative text. Strip tags and normalize whitespace because it goes straight into the alt attribute.
+			$image_alt = isset( $options['contact_image_alt'] ) ? self::normalize_attribute_text( $options['contact_image_alt'] ) : '';
 
 			// リンクの中身が画像1枚だけのため、代替テキストと aria-label は排他にする。
 			// aria-label を併記すると alt が無視されて上書きされ、設定した説明文が読み上げられなくなる。
@@ -423,7 +482,9 @@ class VkExUnit_Contact {
 			// Only when the alternative text is empty, aria-label falls back to the contact button text so the link keeps its name.
 			$aria_label_attr = '';
 			if ( '' === $image_alt ) {
-				$aria_label = isset( $options['button_text'] ) ? trim( wp_strip_all_tags( $options['button_text'] ) ) : '';
+				// button_text は管理画面が textarea のため改行を含みうる。属性値に改行を残さないよう正規化する。
+				// button_text can contain line breaks because the admin screen uses a textarea. Normalize it so no line break remains in the attribute value.
+				$aria_label = isset( $options['button_text'] ) ? self::normalize_attribute_text( $options['button_text'] ) : '';
 				if ( '' === $aria_label ) {
 					$aria_label = __( 'Contact us', 'vk-all-in-one-expansion-unit' );
 				}

--- a/inc/contact-section/customizer.php
+++ b/inc/contact-section/customizer.php
@@ -316,9 +316,13 @@ function veu_customize_register_contact( $wp_customize ) {
 		)
 	);
 
-	$decription  = __( 'Describe the banner image for people who can not see it.', 'vk-all-in-one-expansion-unit' );
+	$decription  = __( 'The banner image is a link, so the text you enter here is read aloud as the name of the link.', 'vk-all-in-one-expansion-unit' );
 	$decription .= '<br>';
-	$decription .= __( 'If you leave it blank, the alternative text set on the media library is filled in automatically when you save.', 'vk-all-in-one-expansion-unit' );
+	$decription .= __( 'Enter a text that tells where the link goes, not a text that describes how the image looks.', 'vk-all-in-one-expansion-unit' );
+	$decription .= '<br>';
+	$decription .= __( 'ex) ', 'vk-all-in-one-expansion-unit' ) . __( 'Contact us', 'vk-all-in-one-expansion-unit' );
+	$decription .= '<br>';
+	$decription .= __( 'If you leave it blank, and the image is in the media library and has an alternative text set on it, that text is filled in automatically when you save.', 'vk-all-in-one-expansion-unit' );
 
 	$wp_customize->add_control(
 		'contact_image_alt',

--- a/inc/contact-section/customizer.php
+++ b/inc/contact-section/customizer.php
@@ -301,6 +301,37 @@ function veu_customize_register_contact( $wp_customize ) {
 		)
 	);
 
+	// Alternative text of the inquiry banner image
+	// 管理画面（options_page）側にも同じ項目があり、片方だけに実装すると
+	// もう片方の保存でフォームに無いキーが失われるため、両方に用意する。
+	// The same field exists on the admin screen ( options_page ). Implementing only one of them would lose
+	// the key on the other save path, which replaces the whole option, so both screens provide it.
+	$wp_customize->add_setting(
+		'vkExUnit_contact[contact_image_alt]',
+		array(
+			'default'           => '',
+			'type'              => 'option', // 保存先 option or theme_mod
+			'capability'        => 'edit_theme_options',
+			'sanitize_callback' => 'sanitize_text_field',
+		)
+	);
+
+	$decription  = __( 'Describe the banner image for people who can not see it.', 'vk-all-in-one-expansion-unit' );
+	$decription .= '<br>';
+	$decription .= __( 'If you leave it blank, the alternative text set on the media library is filled in automatically when you save.', 'vk-all-in-one-expansion-unit' );
+
+	$wp_customize->add_control(
+		'contact_image_alt',
+		array(
+			'label'       => __( 'Alternative text of the inquiry banner image', 'vk-all-in-one-expansion-unit' ),
+			'section'     => 'veu_contact_setting',
+			'settings'    => 'vkExUnit_contact[contact_image_alt]',
+			'type'        => 'text',
+			'priority'    => 1,
+			'description' => $decription,
+		)
+	);
+
 	// Display HTML message instead of the standard
 	$wp_customize->add_setting(
 		'vkExUnit_contact[contact_html]',

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ e.g.
 
 == Changelog ==
 
+[ New Feature ] Added an alternative text setting for the inquiry banner image. When it is left blank, the alternative text set on the media library is filled in automatically on save.
+[ Spec Change ] Fixed the inquiry banner image being read aloud as "contact_txt" by screen readers; it now uses the alternative text you set, or the contact button text as the link name when it is blank.
+
 = 9.119.0 =
 [ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5
 [ Spec Change ] Changed the heading tag of the Related Posts, 3PR Area and PR Blocks widgets, and the Call To Action block / shortcode, from `<h1>` to `<h2>` to avoid multiple `<h1>` elements on a page ( the CSS class names are unchanged, so class-based styling is unaffected ).

--- a/tests/test-contact-section.php
+++ b/tests/test-contact-section.php
@@ -12,8 +12,13 @@
 class ContactSectionTest extends WP_UnitTestCase {
 
 	/**
-	 * render_contact_section_html の装飾アイコン（電話 / 封筒 / 矢印）に aria-hidden="true" が付く事のテスト。
-	 * Test that the decorative icons ( phone / envelope / arrow ) in render_contact_section_html get aria-hidden="true".
+	 * render_contact_section_html のテスト。
+	 * 1. 装飾アイコン（電話 / 封筒 / 矢印）に aria-hidden="true" が付く事。
+	 * 2. バナー画像表示時に、代替テキストと aria-label が排他で出力される事。
+	 *
+	 * Test for render_contact_section_html.
+	 * 1. The decorative icons ( phone / envelope / arrow ) get aria-hidden="true".
+	 * 2. In banner image mode, the alternative text and aria-label are output exclusively.
 	 *
 	 * @return void
 	 */
@@ -45,11 +50,129 @@ class ContactSectionTest extends WP_UnitTestCase {
 			),
 		);
 
+		// バナー画像表示のテスト用に、メディアライブラリの添付ファイルを2つ用意する。
+		// 片方にはメディアライブラリ側の代替テキストを設定し、もう片方は未設定のままにする。
+		// Prepare two media library attachments for the banner image test.
+		// One has an alternative text set on the media library, the other has none.
+		$plugin_dir                = dirname( __DIR__ );
+		$factory                   = new WP_UnitTest_Factory();
+		$attachment_id_with_alt    = $factory->attachment->create_upload_object( $plugin_dir . '/screenshot-1.png' );
+		$attachment_id_without_alt = $factory->attachment->create_upload_object( $plugin_dir . '/screenshot-2.png' );
+		update_post_meta( $attachment_id_with_alt, '_wp_attachment_image_alt', 'メディアライブラリの代替テキスト' );
+
+		$image_url_with_alt    = wp_get_attachment_url( $attachment_id_with_alt );
+		$image_url_without_alt = wp_get_attachment_url( $attachment_id_without_alt );
+		$external_image_url    = 'https://example.com/foo.jpg';
+
+		// バナー画像モード（contact_image 指定時）の出力テスト。
+		// options は update_option 経由で保存するため、保存時の代替テキスト補完も同時に検証される。
+		// Output test for the banner image mode ( when contact_image is set ).
+		// The options are stored through update_option, so the save-time alternative text fill-in is verified too.
+		$banner_image_cases = array(
+			array(
+				'test_condition_name' => '代替テキストの入力欄に値がある場合 => その値が alt に出て aria-label は出ない',
+				'options'             => array(
+					'contact_link'      => 'https://example.com/contact/',
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => '入力欄に設定した代替テキスト',
+					'button_text'       => 'お問い合わせはこちら',
+				),
+				'expected_contains'   => array(
+					'alt="入力欄に設定した代替テキスト"',
+					'<img src="' . esc_url( $image_url_with_alt ) . '"',
+				),
+				'expected_not'        => array(
+					'aria-label',
+				),
+			),
+			array(
+				'test_condition_name' => '入力欄が空でメディアライブラリ側に代替テキストがある場合 => 保存時に取り込まれ alt に出る',
+				'options'             => array(
+					'contact_link'      => 'https://example.com/contact/',
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => '',
+					'button_text'       => 'お問い合わせはこちら',
+				),
+				'expected_contains'   => array(
+					'alt="メディアライブラリの代替テキスト"',
+				),
+				'expected_not'        => array(
+					'aria-label',
+				),
+			),
+			array(
+				'test_condition_name' => '入力欄もメディアライブラリ側も空の場合 => alt="" かつ aria-label にお問い合わせボタンの文言が出る',
+				'options'             => array(
+					'contact_link'      => 'https://example.com/contact/',
+					'contact_image'     => $image_url_without_alt,
+					'contact_image_alt' => '',
+					'button_text'       => 'お問い合わせはこちら',
+				),
+				'expected_contains'   => array(
+					'alt=""',
+					'aria-label="お問い合わせはこちら"',
+				),
+				'expected_not'        => array(),
+			),
+			array(
+				'test_condition_name' => '代替テキストが空でお問い合わせボタンの文言も空の場合 => aria-label が既定文字列になる',
+				'options'             => array(
+					'contact_link'      => 'https://example.com/contact/',
+					'contact_image'     => $image_url_without_alt,
+					'contact_image_alt' => '',
+					'button_text'       => '',
+				),
+				'expected_contains'   => array(
+					'alt=""',
+					'aria-label="Contact us"',
+				),
+				'expected_not'        => array(),
+			),
+			array(
+				// メディアライブラリに存在しない外部 URL。逆引きに失敗しても致命的エラーにならない事の確認。
+				// An external URL that does not exist in the media library. Confirms the failed lookup causes no fatal error.
+				'test_condition_name' => 'バナー画像が外部 URL の場合 => 逆引きできず alt="" かつ aria-label にお問い合わせボタンの文言が出る',
+				'options'             => array(
+					'contact_link'      => 'https://example.com/contact/',
+					'contact_image'     => $external_image_url,
+					'contact_image_alt' => '',
+					'button_text'       => 'お問い合わせはこちら',
+				),
+				'expected_contains'   => array(
+					'alt=""',
+					'aria-label="お問い合わせはこちら"',
+					'<img src="' . esc_url( $external_image_url ) . '"',
+				),
+				'expected_not'        => array(),
+			),
+		);
+
 		// アサーション失敗時も元の設定値を確実に戻すため、ループ実行前に元の値を保持し try/finally で復元する。
 		// Preserve the original option before the loop and restore it in finally so the value is restored even if an assertion fails.
 		$original_option = get_option( 'vkExUnit_contact', false );
 
 		try {
+			foreach ( $banner_image_cases as $case ) {
+				// バナー画像表示に必要なオプションを設定 / Set the option required to render the banner image.
+				update_option( 'vkExUnit_contact', $case['options'] );
+
+				// お問い合わせセクションの HTML を取得 / Get the contact section HTML.
+				$html = VkExUnit_Contact::render_contact_section_html();
+
+				// 期待する文字列が含まれる事を確認 / Check the expected strings are included.
+				foreach ( $case['expected_contains'] as $expected ) {
+					$this->assertStringContainsString( $expected, $html, $case['test_condition_name'] );
+				}
+
+				// 出力されてはいけない文字列が含まれない事を確認 / Check the strings that must not be output are absent.
+				foreach ( $case['expected_not'] as $not_expected ) {
+					$this->assertStringNotContainsString( $not_expected, $html, $case['test_condition_name'] );
+				}
+
+				// オプションをクリーンアップ / Clean up the option.
+				delete_option( 'vkExUnit_contact' );
+			}
+
 			foreach ( $tel_icon_cases as $case ) {
 				// お問い合わせ情報のオプションを設定 / Set the contact information option.
 				update_option(
@@ -155,6 +278,97 @@ class ContactSectionTest extends WP_UnitTestCase {
 			} else {
 				update_option( 'vkExUnit_contact', $original_option );
 			}
+		}
+	}
+
+	/**
+	 * fill_contact_image_alt が、保存時にメディアライブラリ側の代替テキストで補完する事のテスト。
+	 * Test that fill_contact_image_alt fills the alternative text from the media library at save time.
+	 *
+	 * @return void
+	 */
+	function test_fill_contact_image_alt() {
+		// 代替テキストありの添付ファイルと、代替テキストなしの添付ファイルを用意する。
+		// Prepare an attachment with an alternative text and one without.
+		$plugin_dir                = dirname( __DIR__ );
+		$factory                   = new WP_UnitTest_Factory();
+		$attachment_id_with_alt    = $factory->attachment->create_upload_object( $plugin_dir . '/screenshot-1.png' );
+		$attachment_id_without_alt = $factory->attachment->create_upload_object( $plugin_dir . '/screenshot-2.png' );
+		update_post_meta( $attachment_id_with_alt, '_wp_attachment_image_alt', 'メディアライブラリの代替テキスト' );
+
+		$image_url_with_alt    = wp_get_attachment_url( $attachment_id_with_alt );
+		$image_url_without_alt = wp_get_attachment_url( $attachment_id_without_alt );
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '代替テキストが空でメディアライブラリ側に代替テキストがある場合 => メディアライブラリの値で補完される',
+				'input'               => array(
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => '',
+				),
+				'expected'            => array(
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => 'メディアライブラリの代替テキスト',
+				),
+			),
+			array(
+				'test_condition_name' => '代替テキストが入力済みの場合 => メディアライブラリの値で上書きしない',
+				'input'               => array(
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => '入力欄に設定した代替テキスト',
+				),
+				'expected'            => array(
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => '入力欄に設定した代替テキスト',
+				),
+			),
+			array(
+				'test_condition_name' => 'メディアライブラリ側にも代替テキストが無い場合 => 空のまま',
+				'input'               => array(
+					'contact_image'     => $image_url_without_alt,
+					'contact_image_alt' => '',
+				),
+				'expected'            => array(
+					'contact_image'     => $image_url_without_alt,
+					'contact_image_alt' => '',
+				),
+			),
+			array(
+				// 逆引きできない外部 URL。存在しない添付 ID を参照して致命的エラーにならない事の確認。
+				// An external URL that cannot be resolved. Confirms it does not fatal by referencing a missing attachment ID.
+				'test_condition_name' => 'バナー画像が外部 URL の場合 => 逆引きできず空のまま',
+				'input'               => array(
+					'contact_image'     => 'https://example.com/foo.jpg',
+					'contact_image_alt' => '',
+				),
+				'expected'            => array(
+					'contact_image'     => 'https://example.com/foo.jpg',
+					'contact_image_alt' => '',
+				),
+			),
+			array(
+				'test_condition_name' => 'バナー画像が未設定の場合 => 何もしない',
+				'input'               => array(
+					'contact_image'     => '',
+					'contact_image_alt' => '',
+				),
+				'expected'            => array(
+					'contact_image'     => '',
+					'contact_image_alt' => '',
+				),
+			),
+			array(
+				// オプション値が配列以外で渡された異常系。そのまま返す事を確認する。
+				// Abnormal case where a non array option value is passed. Confirms it is returned untouched.
+				'test_condition_name' => 'オプション値が配列以外の場合 => そのまま返す',
+				'input'               => 'not-an-array',
+				'expected'            => 'not-an-array',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$actual = VkExUnit_Contact::fill_contact_image_alt( $case['input'] );
+			$this->assertEquals( $case['expected'], $actual, $case['test_condition_name'] );
 		}
 	}
 }

--- a/tests/test-contact-section.php
+++ b/tests/test-contact-section.php
@@ -129,6 +129,24 @@ class ContactSectionTest extends WP_UnitTestCase {
 				'expected_not'        => array(),
 			),
 			array(
+				// button_text は管理画面が textarea のため改行を含みうる。属性値に改行が残らない事の確認。
+				// button_text can contain line breaks because the admin screen uses a textarea. Confirms no line break remains in the attribute value.
+				'test_condition_name' => 'お問い合わせボタンの文言が改行を含む場合 => aria-label の改行が半角スペース1つに正規化される',
+				'options'             => array(
+					'contact_link'      => 'https://example.com/contact/',
+					'contact_image'     => $image_url_without_alt,
+					'contact_image_alt' => '',
+					'button_text'       => "  メールで\nお問い合わせ  ",
+				),
+				'expected_contains'   => array(
+					'alt=""',
+					'aria-label="メールで お問い合わせ"',
+				),
+				'expected_not'        => array(
+					"aria-label=\"メールで\nお問い合わせ\"",
+				),
+			),
+			array(
 				// メディアライブラリに存在しない外部 URL。逆引きに失敗しても致命的エラーにならない事の確認。
 				// An external URL that does not exist in the media library. Confirms the failed lookup causes no fatal error.
 				'test_condition_name' => 'バナー画像が外部 URL の場合 => 逆引きできず alt="" かつ aria-label にお問い合わせボタンの文言が出る',
@@ -323,6 +341,42 @@ class ContactSectionTest extends WP_UnitTestCase {
 				),
 			),
 			array(
+				// 空判定が ! empty() だと "0" が空扱いになり、メディアライブラリの値へ黙って上書きされてしまう。
+				// With a ! empty() check, "0" would count as empty and get silently overwritten by the media library value.
+				'test_condition_name' => '代替テキストが文字列 "0" の場合 => 空扱いせず上書きしない',
+				'input'               => array(
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => '0',
+				),
+				'expected'            => array(
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => '0',
+				),
+			),
+			array(
+				'test_condition_name' => '代替テキストのキー自体が無い場合 => 空扱いして補完される',
+				'input'               => array(
+					'contact_image' => $image_url_with_alt,
+				),
+				'expected'            => array(
+					'contact_image'     => $image_url_with_alt,
+					'contact_image_alt' => 'メディアライブラリの代替テキスト',
+				),
+			),
+			array(
+				// 配列のまま attachment_url_to_postid() に渡すと、内部の parse_url() が PHP 8 で TypeError になる。
+				// Passing an array to attachment_url_to_postid() would make its internal parse_url() throw a TypeError on PHP 8.
+				'test_condition_name' => 'バナー画像が文字列以外（配列）の場合 => 致命的エラーにならずそのまま返す',
+				'input'               => array(
+					'contact_image'     => array( 'x' ),
+					'contact_image_alt' => '',
+				),
+				'expected'            => array(
+					'contact_image'     => array( 'x' ),
+					'contact_image_alt' => '',
+				),
+			),
+			array(
 				'test_condition_name' => 'メディアライブラリ側にも代替テキストが無い場合 => 空のまま',
 				'input'               => array(
 					'contact_image'     => $image_url_without_alt,
@@ -369,6 +423,121 @@ class ContactSectionTest extends WP_UnitTestCase {
 		foreach ( $test_cases as $case ) {
 			$actual = VkExUnit_Contact::fill_contact_image_alt( $case['input'] );
 			$this->assertEquals( $case['expected'], $actual, $case['test_condition_name'] );
+		}
+	}
+
+	/**
+	 * option_sanitaize が、バナー画像の代替テキストを安全なテキストとして保存する事のテスト。
+	 * Test that option_sanitaize saves the banner image alternative text as safe text.
+	 *
+	 * @return void
+	 */
+	function test_option_sanitaize() {
+		// サニタイズ対象の他項目は文字列前提のため、代替テキスト以外は固定値で埋めておく。
+		// The other options are expected to be strings, so fill everything but the alternative text with fixed values.
+		$base_option = array(
+			'contact_txt'       => 'お気軽にお問い合わせください',
+			'tel_number'        => '000-000-0000',
+			'tel_icon'          => '<i class="fa-solid fa-phone"></i>',
+			'contact_time'      => '9:00 - 18:00',
+			'contact_link'      => 'https://example.com/contact/',
+			'button_text'       => 'Contact us',
+			'button_text_small' => '',
+			'short_text'        => 'Contact us',
+			'contact_image'     => 'https://example.com/foo.jpg',
+			'contact_html'      => '',
+		);
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '代替テキストが通常の文字列の場合 => そのまま保存される',
+				'contact_image_alt'   => 'お問い合わせはこちら',
+				'expected'            => 'お問い合わせはこちら',
+			),
+			array(
+				'test_condition_name' => '代替テキストに HTML タグが含まれる場合 => タグが除去される',
+				'contact_image_alt'   => '<script>alert(1)</script>お問い合わせはこちら',
+				'expected'            => 'お問い合わせはこちら',
+			),
+			array(
+				// stripslashes() のままだと配列を渡された時点で PHP 8 の TypeError になり保存処理全体が落ちる。
+				// With stripslashes() an array would throw a PHP 8 TypeError and take the whole save down.
+				'test_condition_name' => '代替テキストが文字列以外（配列）で送信された場合 => 致命的エラーにならず空文字になる',
+				'contact_image_alt'   => array( 'x' ),
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => '代替テキストのキー自体が無い場合 => 空文字になる',
+				'contact_image_alt'   => null,
+				'expected'            => '',
+			),
+		);
+
+		$contact = VkExUnit_Contact::instance();
+
+		foreach ( $test_cases as $case ) {
+			$option = $base_option;
+			// null のケースはキー自体が送信されなかった状況を再現する / The null case reproduces a key that was never posted.
+			if ( null !== $case['contact_image_alt'] ) {
+				$option['contact_image_alt'] = $case['contact_image_alt'];
+			}
+
+			$actual = $contact->option_sanitaize( $option );
+
+			$this->assertSame( $case['expected'], $actual['contact_image_alt'], $case['test_condition_name'] );
+		}
+	}
+
+	/**
+	 * normalize_attribute_text が、属性値へ入れる文字列の空白とタグを正規化する事のテスト。
+	 * Test that normalize_attribute_text normalizes the whitespace and tags of a string that goes into an attribute value.
+	 *
+	 * @return void
+	 */
+	function test_normalize_attribute_text() {
+		$test_cases = array(
+			array(
+				'test_condition_name' => '文字列の途中に改行がある場合 => 半角スペース1つにまとまる',
+				'input'               => "メールで\nお問い合わせ",
+				'expected'            => 'メールで お問い合わせ',
+			),
+			array(
+				'test_condition_name' => '改行・タブ・連続空白が混在する場合 => それぞれ半角スペース1つにまとまる',
+				'input'               => "メールで\r\n\tお問い合わせ   ください",
+				'expected'            => 'メールで お問い合わせ ください',
+			),
+			array(
+				'test_condition_name' => '前後に空白と改行がある場合 => 前後が削られる',
+				'input'               => "  \n お問い合わせ \n  ",
+				'expected'            => 'お問い合わせ',
+			),
+			array(
+				'test_condition_name' => 'HTML タグを含む場合 => タグが除去され中身だけ残る',
+				'input'               => '<strong>メールで</strong><br />お問い合わせ',
+				'expected'            => 'メールで お問い合わせ',
+			),
+			array(
+				'test_condition_name' => '空文字の場合 => 空文字のまま',
+				'input'               => '',
+				'expected'            => '',
+			),
+			array(
+				// 想定外の型が渡された異常系。属性値に使えるよう必ず文字列を返す事の確認。
+				// Abnormal case where an unexpected type is passed. Confirms a string is always returned so it can be used as an attribute value.
+				'test_condition_name' => '文字列以外（null）が渡された場合 => 空文字を返す',
+				'input'               => null,
+				'expected'            => '',
+			),
+			array(
+				'test_condition_name' => '文字列以外（配列）が渡された場合 => 空文字を返す',
+				'input'               => array( 'お問い合わせ' ),
+				'expected'            => '',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$actual = VkExUnit_Contact::normalize_attribute_text( $case['input'] );
+			$this->assertSame( $case['expected'], $actual, $case['test_condition_name'] );
 		}
 	}
 }


### PR DESCRIPTION
Closes #1433

@coderabbitai ignore

## 概要

お問い合わせセクションを「バナー画像」で表示しているとき、その画像リンクの読み上げ名が意味を成していなかった問題への対応です。

これまでは、画像の代替テキスト（画像が表示・認識できない環境で読み上げられる説明文）が `contact_txt` という固定の文字列で出力されていました。これは内部の設定キー名と同じ綴りで、利用者向けの説明ではありません。バナー画像モードの出力は「画像1枚を包んだリンク」だけなので、リンクの読み上げ名はこの代替テキストが頼りになります。結果、スクリーンリーダー利用者にはこのリンクが「contact_txt」と読み上げられ、どこへ行くリンクなのか分かりませんでした。

このセクションはお問い合わせ専用ではなく、リンク先を任意に設定できる汎用の誘導としても使われるため、`Contact` のような固定の文言を決め打ちで埋め込むことは避けています。

## 変更内容

### 1. 代替テキストの設定項目を新設

「詳細設定」内のバナー画像の直下に、代替テキストの入力欄を追加しました。設定画面と「カスタマイズ」画面の両方に追加しています。

片方だけに追加すると、もう片方で保存したときに値が消えます。設定画面の保存処理はこの設定をまるごと置き換えるため、フォームに無い項目が失われるからです。

### 2. 入力欄が空のときは保存時に自動で補完

代替テキストを空のまま保存すると、その画像がメディアライブラリの画像で、かつそちら側に代替テキストが設定されていれば、その値が自動で入ります。

補完は**保存時に一度だけ**行います。画像 URL から元の画像を探す処理は、キャッシュを通らず、絞り込みの効かない列に対する検索になるため、ページ表示のたびに走らせると負荷になります（お問い合わせセクションはウィジェットとしてフッター等に置けるため、その場合は全ページで発生します）。

設定画面の保存処理と「カスタマイズ」画面の保存は、どちらも最終的に同じ保存関数を通るため、その直前に挟まる処理ひとつで両方の経路をカバーしています。

### 3. 読み上げ名の出力を整理

代替テキストと `aria-label`（読み上げ用のリンク名）は**同時に出さない**ようにしました。リンクの中身が画像1枚だけの場合、`aria-label` があると代替テキストが無視されて上書きされるためです。

- 代替テキストがある → `<img alt="その説明文">` のみ
- 代替テキストが空 → `<img alt="">` ＋ `<a aria-label="お問い合わせボタンの文言">`
- お問い合わせボタンの文言も空 → 既定の文言にフォールバック

代替テキストを空にするだけ（`aria-label` を付けない）にはしていません。それだとリンクに名前が無くなり、スクリーンリーダーが URL を読み上げてしまうためです。

なお、お問い合わせボタンの文言は複数行入力の項目で改行を含みうるため、属性値に入れる前に連続する空白・改行を半角スペース1つにまとめています。`<br>` はタグを除去する前に空白へ置き換えているので、`Contact us<br>by email` が `Contact usby email` とくっついて読み上げられることもありません。

### 4. あわせて修正

画像の URL 出力に文字列用の無害化処理が使われていたのを、URL 用の処理に修正しました（同じ行を書き換えるため同梱）。

## 確認手順

### 前提条件

- 固定ページを1つ作成し、編集画面の「お問い合わせ情報を表示」にチェックを入れておく
- メディアライブラリに画像を1つアップロードし、その画像の「代替テキスト」を空にしておく

### Before（修正前の状態）

1. 管理画面 > ExUnit > メイン設定 > お問い合わせ情報 を開く
2. 「詳細設定」ボタンを押して詳細設定を開く
3. 「Inquiry Banner image」に画像を選択して保存する
4. 手順の前提で用意した固定ページを表示し、バナー画像部分の HTML を確認する
   → ✗ `<img src="..." alt="contact_txt">` と出力されている
   → ✗ スクリーンリーダーではこのリンクが「contact_txt」と読み上げられる

### After（修正後）

#### 1. 代替テキストを入力した場合

1. 管理画面 > ExUnit > メイン設定 > お問い合わせ情報 > 「詳細設定」を開く
2. 「Inquiry Banner image」の直下に代替テキストの入力欄が増えていることを確認する
   → ✓ 入力欄と、リンク先が分かる文言を入れるよう促す説明文・記入例が表示される
3. 入力欄に `お問い合わせフォームへ` と入力して保存する
4. 固定ページを表示し、バナー画像部分の HTML を確認する
   → ✓ `<img src="..." alt="お問い合わせフォームへ">` と出力される
   → ✓ 画像を包む `<a>` に `aria-label` が付いていない（代替テキストが無視されないため）

#### 2. 入力欄を空にして保存した場合（自動補完）

1. メディアライブラリで、使用中の画像の「代替テキスト」に `お問い合わせバナー` と入力して保存する
2. 手順1で入力した代替テキストの入力欄を空にして保存する
3. 保存後の設定画面を再読み込みする
   → ✓ 入力欄に `お問い合わせバナー` が自動で入っている
4. 固定ページを表示する
   → ✓ `alt="お問い合わせバナー"` と出力される

#### 3. どちらも空の場合（読み上げ名のフォールバック）

1. メディアライブラリで画像の「代替テキスト」を空に戻す
2. 設定画面の代替テキストの入力欄を空にして保存する
3. 固定ページを表示し、バナー画像部分の HTML を確認する
   → ✓ `<img src="..." alt="">` かつ `<a ... aria-label="Contact us">` と出力される
   （`aria-label` の値は「お問い合わせボタンのテキスト」に設定している文言。既定は `Contact us`）
4. 「お問い合わせボタンのテキスト」を空にして保存し、再度固定ページを表示する
   → ✓ `aria-label="Contact us"` のまま（既定の文言にフォールバックする）

#### 4. 外部 URL の画像を指定した場合

1. 代替テキストの入力欄を空にしたまま、「Inquiry Banner image」に外部サイトの画像 URL（例: `https://example.com/foo.jpg`）を直接入力して保存する
   → ✓ エラーにならず保存できる
2. 固定ページを表示する
   → ✓ `alt=""` ＋ `aria-label` のフォールバックが効く（メディアライブラリの画像ではないため自動補完はされない）

#### 5. デグレ確認

1. 「詳細設定」の「Inquiry Banner image」を空にして保存し、固定ページを表示する
   → ✓ 従来どおり、電話番号・受付時間・お問い合わせボタンの標準表示になる
2. 「詳細設定」の HTML 入力欄に任意の HTML を入れて保存し、固定ページを表示する
   → ✓ 従来どおり、その HTML が表示される（HTML は画像より優先される）
3. 外観 > カスタマイズ > お問い合わせ情報 を開く
   → ✓ バナー画像の直下に代替テキストの入力欄があり、設定画面と同じ説明文が表示される
   → ✓ ここで代替テキストを変更して保存すると、設定画面側にも反映される

## テスト

`tests/test-contact-section.php` に PHPUnit テストを追加しました。

- `test_render_contact_section_html()` — 代替テキストあり／自動補完後／両方空／お問い合わせボタンの文言も空／外部 URL／お問い合わせボタンの文言に改行が含まれる場合
- `test_fill_contact_image_alt()` — 補完される／入力済みは上書きしない／メディアライブラリ側も空なら空のまま／外部 URL は空のまま／画像未設定は無処理／代替テキストが文字列 `"0"` のとき上書きされない／想定外の型が渡されても落ちない
- `test_option_sanitaize()` — 通常文字列／タグの除去／配列が送信された異常系／項目欠落
- `test_normalize_attribute_text()` — 途中の改行／改行・タブ・連続空白の混在／前後の空白／`<br>` とタグの混在／空文字／想定外の型

実行結果:

```
ContactSectionTest のみ: OK (5 tests, 48 assertions)
全体:                    OK (122 tests, 884 assertions)
```

## スクリーンショット

### 管理画面 > ExUnit > メイン設定 > お問い合わせ情報 >「詳細設定」

同じ設定値（バナー画像あり）・同じ画面幅（1440px）で撮影しています。

#### Before（`master`）

代替テキストの入力欄がありません。

![before-admin](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1440/before-admin-advanced-setting.png?raw=true)

#### After（この PR）

バナー画像の直下に代替テキストの入力欄が増えています。入力欄の幅・ラベル位置は既存項目と揃っています。

![after-admin](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1440/after-admin-advanced-setting.png?raw=true)

#### After（狭い画面幅 400px）

管理画面が縦積みになる幅でも、ラベル・入力欄・説明文が崩れません。

![after-admin-400](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1440/after-admin-advanced-setting-400.png?raw=true)

### 外観 > カスタマイズ > お問い合わせ情報

#### Before（`master`）

![before-customizer](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1440/before-customizer.png?raw=true)

#### After（この PR）

バナー画像コントロールの直下に代替テキストの入力欄が追加されています。

![after-customizer](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1440/after-customizer.png?raw=true)

## 今回のスコープ外（別 issue で対応）

- 「カスタマイズ」画面で代替テキストを空のまま保存したとき、実際には補完された値が保存されるのに、入力欄は画面を読み込み直すまで空のまま見える
- バナー画像モードは、リンク先が未設定でも空のリンクを出力する（標準の表示モードはリンク先の有無を確認している）
- 「カスタマイズ」画面から保存すると、HTML 表示モードの入力から HTML が全部消える
- 設定画面の既存の未エスケープ出力3箇所（今回の変更とは無関係。管理者しか閲覧・設定できず、保存時の無害化で緩和されている）

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/619
