### PR TITLE
[ デザイン不具合修正 ][ ウィジェット・CTA ] 見出しタグの h2 化により Lightning や X-T9 でタイトルに意図しない背景・枠線・余白が付く不具合を、h1 に戻して修正

### DIFF
--- a/inc/call-to-action/package/block/index.php
+++ b/inc/call-to-action/package/block/index.php
@@ -275,7 +275,7 @@ function veu_cta_block_callback( $attributes, $content ) {
 						// wp_kses_post() なら <script> や on* 属性は除去され、同テンプレート内の本文・ボタンラベルとも処理が揃う。
 						// The title has never been filtered and is sometimes given a <br> for line breaks, so esc_html() cannot be used.
 						// wp_kses_post() strips <script> and on* attributes and matches how the body and button label are handled in this template.
-						$content .= '<h2 class="cta_title">' . wp_kses_post( $cta_post->post_title ) . '</h2>';
+						$content .= '<h1 class="cta_title">' . wp_kses_post( $cta_post->post_title ) . '</h1>';
 						$content .= '<div class="cta_body">';
 
 						// 別ウィンドウで開くかどうかのカスタムフィールドの値を取得 //////.

--- a/inc/call-to-action/package/view-actionbox.php
+++ b/inc/call-to-action/package/view-actionbox.php
@@ -65,7 +65,7 @@ $content .= '<section class="veu_cta" id="veu_cta-' . esc_attr( $id ) . '">';
 // wp_kses_post() なら <script> や on* 属性は除去され、同テンプレート内の本文・ボタンラベルとも処理が揃う.
 // The title has never been filtered and is sometimes given a <br> for line breaks, so esc_html() cannot be used.
 // wp_kses_post() strips <script> and on* attributes and matches how the body and button label are handled in this template.
-$content .= '<h2 class="cta_title">' . wp_kses_post( $cta_post->post_title ) . '</h2>';
+$content .= '<h1 class="cta_title">' . wp_kses_post( $cta_post->post_title ) . '</h1>';
 $content .= '<div class="cta_body">';
 
 

--- a/inc/other-widget/widget-3pr-area.php
+++ b/inc/other-widget/widget-3pr-area.php
@@ -164,13 +164,13 @@ value="true" />
 			if ( isset( $instance[ 'label_' . $i ] ) && $instance[ 'label_' . $i ] ) {
 				echo '<div class="prArea col-sm-4">';
 
-				echo '<h2 class="subSection-title">';
+				echo '<h1 class="subSection-title">';
 				if ( isset( $instance[ 'label_' . $i ] ) && $instance[ 'label_' . $i ] ) {
 					echo wp_kses_post( $instance[ 'label_' . $i ] );
 				} else {
 					_e( '3PR area', 'vk-all-in-one-expansion-unit' );
 				}
-				echo '</h2>';
+				echo '</h1>';
 
 				$blank = ( isset( $instance[ 'blank_' . $i ] ) && $instance[ 'blank_' . $i ] ) ? ' target="_blank" ' : '';
 

--- a/inc/other-widget/widget-pr-blocks.php
+++ b/inc/other-widget/widget-pr-blocks.php
@@ -308,13 +308,13 @@ class WP_Widget_vkExUnit_PR_Blocks extends WP_Widget {
 					echo '</div><!--//.prBlock_image -->';
 				}
 				// title text
-				echo '<h2 class="prBlock_title">';
+				echo '<h1 class="prBlock_title">';
 				if ( isset( $instance[ 'label_' . $i ] ) && $instance[ 'label_' . $i ] ) {
 					echo wp_kses_post( $instance[ 'label_' . $i ] );
 				} else {
 					_e( 'PR Block', 'vk-all-in-one-expansion-unit' );
 				}
-				echo '</h2>' . PHP_EOL;
+				echo '</h1>' . PHP_EOL;
 
 				// summary text
 				if ( ! empty( $instance[ 'summary_' . $i ] ) ) {

--- a/inc/related_posts/related_posts.php
+++ b/inc/related_posts/related_posts.php
@@ -233,7 +233,7 @@ function veu_get_related_posts_html() {
 		}
 		// 書き換え用フィルターフック（カスタマイザーで変更出来るが、既存ユーザーで使用しているかもしれないため削除不可）.
 		$related_post_title  = apply_filters( 'veu_related_post_title', $related_post_title );
-		$related_posts_html .= '<h2 class="mainSection-title relatedPosts_title">' . $related_post_title . '</h2>';
+		$related_posts_html .= '<h1 class="mainSection-title relatedPosts_title">' . $related_post_title . '</h1>';
 
 		$i                   = 1;
 		$related_posts_html .= '<div class="row">';

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ Design Bug Fix ][ Widget / CTA ] Reverted the heading tag of the Related Posts, 3PR Area and PR Blocks widgets and the Call To Action block / shortcode back to `<h1>`, because changing it to `<h2>` in 9.119.0 made themes such as Lightning and X-T9 apply their own `<h2>` heading decoration ( background color, borders and spacing ) and changed how these titles looked.
+
 = 9.119.0 =
 [ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5
 [ Spec Change ] Changed the heading tag of the Related Posts, 3PR Area and PR Blocks widgets, and the Call To Action block / shortcode, from `<h1>` to `<h2>` to avoid multiple `<h1>` elements on a page ( the CSS class names are unchanged, so class-based styling is unaffected ).

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ e.g.
 
 == Changelog ==
 
-[ Design Bug Fix ][ Widget / CTA ] Reverted the heading tag of the Related Posts, 3PR Area and PR Blocks widget titles and the Call To Action title back to `<h1>`, because the change in 9.119.0 made themes such as Lightning and X-T9 apply their own heading decoration and altered their appearance.
+[ Design Bug Fix ][ Widget / CTA ] Fixed the Related Posts, 3PR Area, PR Blocks and Call To Action titles getting unintended backgrounds, borders and spacing on themes such as Lightning and X-T9. The `<h1>` to `<h2>` change made in 9.119.0 has been reverted, so a page can again contain more than one `<h1>`.
 
 = 9.119.0 =
 [ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ e.g.
 
 == Changelog ==
 
-[ Design Bug Fix ][ Widget / CTA ] Reverted the heading tag of the Related Posts, 3PR Area and PR Blocks widgets and the Call To Action block / shortcode back to `<h1>`, because changing it to `<h2>` in 9.119.0 made themes such as Lightning and X-T9 apply their own `<h2>` heading decoration ( background color, borders and spacing ) and changed how these titles looked.
+[ Design Bug Fix ][ Widget / CTA ] Reverted the heading tag of the Related Posts, 3PR Area and PR Blocks widget titles and the Call To Action title back to `<h1>`, because the change in 9.119.0 made themes such as Lightning and X-T9 apply their own heading decoration and altered their appearance.
 
 = 9.119.0 =
 [ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5

--- a/tests/test-cta-output-escaping.php
+++ b/tests/test-cta-output-escaping.php
@@ -166,14 +166,14 @@ class CTAOutputEscapingTest extends WP_UnitTestCase {
 				'test_condition_name' => 'タイトルに <br> と <script> が含まれる場合 => <br> は残り <script> は除去される',
 				'image_position'      => 'right',
 				'post_title'          => 'CTA Title<br><script>alert(1)</script>',
-				'expected'            => '<h2 class="cta_title">CTA Title<br>alert(1)</h2>',
+				'expected'            => '<h1 class="cta_title">CTA Title<br>alert(1)</h1>',
 				'not_expected'        => '<script>',
 			),
 			array(
 				'test_condition_name' => 'タイトルに on* 属性付きのタグが含まれる場合 => 属性が除去される',
 				'image_position'      => 'right',
 				'post_title'          => 'CTA <span onmouseover="alert(1)">Title</span>',
-				'expected'            => '<h2 class="cta_title">CTA <span>Title</span></h2>',
+				'expected'            => '<h1 class="cta_title">CTA <span>Title</span></h1>',
 				'not_expected'        => 'onmouseover',
 			),
 		);

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -698,7 +698,7 @@ class CTATest extends WP_UnitTestCase {
 					'vkExUnit_cta_button_text' => 'Read more',
 					'vkExUnit_cta_url'         => 'https://example.com',
 				),
-				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h2 class="cta_title">Classic Title</h2><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">Read more</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">Read more</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 			'classic CTA XSS test'     => array(
 				'cta_title'   => 'Classic Title',
@@ -708,7 +708,7 @@ class CTATest extends WP_UnitTestCase {
 					'vkExUnit_cta_button_text' => '"><script>alert(0)</script>',
 					'vkExUnit_cta_url'         => 'https://example.com',
 				),
-				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h2 class="cta_title">Classic Title</h2><div class="cta_body"><div class="cta_body_txt image_no">"&gt;alert(0)</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">"&gt;alert(0)</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">"&gt;alert(0)</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank">"&gt;alert(0)</a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 			// 前後アイコン付きの古典CTA：装飾アイコンの <i> に aria-hidden="true" が付く事を検証する。
 			// Classic CTA with before / after icons: verify the decorative icons' <i> get aria-hidden="true".
@@ -722,7 +722,7 @@ class CTATest extends WP_UnitTestCase {
 					'vkExUnit_cta_button_icon_before' => 'fa-solid fa-star',
 					'vkExUnit_cta_button_icon_after'  => 'fa-solid fa-arrow-right',
 				),
-				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h2 class="cta_title">Classic Title</h2><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank"><i class="fa-solid fa-star font_icon" aria-hidden="true"></i> Read more<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i> </a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
+				'expected'    => '<section class="veu_cta" id="veu_cta-' . $test_posts['cta_post_id'] . '"><h1 class="cta_title">Classic Title</h1><div class="cta_body"><div class="cta_body_txt image_no">cta</div><div class="cta_body_link"><a href="https://example.com" class="btn btn-primary btn-block btn-lg" target="_blank"><i class="fa-solid fa-star font_icon" aria-hidden="true"></i> Read more<i class="fa-solid fa-arrow-right font_icon" aria-hidden="true"></i> </a></div></div><!-- [ /.vkExUnit_cta_body ] --></section>',
 			),
 		);
 


### PR DESCRIPTION
## 関連Issue

Closes #1441

取り消す対象: #1419（元 issue: #1382）

@coderabbitai ignore

## 変更の目的・理由

9.119.0 に含まれる #1419 で、以下5箇所の見出しタグを `<h1>` から `<h2>` に変更しました（1ページ内に `<h1>` が複数ある状態を解消するのが目的）。

- 関連記事ウィジェット
- 3PR エリアウィジェット
- PR ブロックウィジェット
- CTA（クラシック版）
- CTA（ブロック版・ショートコード）

しかし #1419 では「クラス名を変えていないので見た目は変わらない」と判断していたところ、**実際には Lightning・X-T9 などのテーマで見た目が変わっていました**。

### 原因

テーマ側が、クラス名ではなく **タグ名 `h2` に対して見出し用の装飾（背景色・上下の線・内側の余白）をまとめて指定していた**ためです。`h1` にはその指定が当たっていなかったので、タグを `h1` から `h2` に変えたことで、これまで付いていなかった装飾が新たに付くようになりました。

該当する指定の例:

| テーマ / スキン | 指定 |
|---|---|
| Lightning G3 / origin3 | `h2:where(:not(.wp-block-post-title)) { padding:.5em 0; border-top:2px solid ...; border-bottom:1px solid ... }` |
| Lightning G2・Pro / origin | `.mainSection-title, h2 { background-color:#f5f5f5; padding:14px 15px 10px; border-top:2px solid ...; border-bottom:1px solid ... }` |
| X-T9 | `:is(h2,h3,h4,h5,h6){ margin-block-start:1.5em }`（`h1` は意図的に除外されている） |

### 実測した影響

Playwright で各テーマを実際に表示し、`getComputedStyle` で見出しの寸法・色・余白を測定しました。以下は 9.119.0 より前 → 後の変化です。

| テーマ / スキン | 関連記事 | 3PR エリア | PR ブロック | CTA |
|---|---|---|---|---|
| Lightning G3 / origin3 | 高さ 33.6 → 60.6px | 25.2 → 46.2px | 25.2 → 46.2px | 上下に線が追加 |
| Lightning G2 / origin | 変化なし | **背景が #f5f5f5 の箱に**・39.6 → 55.6px | **背景が #f5f5f5 の箱に**・25.2 → 52.2px | 上下に線が追加 |
| Lightning G2 / origin2 | position のみ | 30.6 → 47.0px | 25.2 → 55.2px | 上下に線が追加 |
| Lightning Pro / origin・origin2 | 同上 | 同上 | 同上 | 同上 |
| X-T9 | 上の余白 0 → 31.5px | 変化なし | 変化なし | 変化なし |

とくに Lightning の origin スキンで見出しがグレーの箱になる点と、CTA の黒帯に上下の線が入る点は、目視で明らかに分かるレベルです。

### なぜ CSS で直さず、取り消しを選んだか

当初はプラグイン側の CSS でテーマの装飾を打ち消す方向で修正を試みましたが、**関連記事の見出しについてはこの方法では直せない**ことが分かりました。

関連記事の見出しは `mainSection-title` という**テーマ側のクラス**を持っており、Lightning ではそのクラスに対しても装飾が指定されています。つまり `h1` だった頃から既にテーマの装飾が乗っていた箇所です（実測でも Lightning G2 / Pro では「変化なし」でした）。ここでプラグイン側から装飾を打ち消すと、**今度は元々あった装飾まで消えてしまい、かえって見た目が壊れます**。

CSS で塞ぎ切るには Lightning・X-T9 側の修正もセットで必要になり、プラグイン単体では完結しません。9.119.0 のリリースから 24 時間以内で影響が広がる前に戻せるタイミングだったため、**#1419 を完全に取り消す**判断としました。

## 実装内容

#1419 で変更した5箇所すべてを `<h1>` に戻しました。クラス名は #1419 でも変更していないため、そのまま維持されます。

### 主な変更点

- [ ] 新機能追加
- [x] バグ修正（デザインの退行修正）
- [ ] リファクタリング
- [ ] ドキュメント更新

### 技術的な詳細

| ファイル | 内容 |
|---|---|
| `inc/related_posts/related_posts.php` | `<h2 class="mainSection-title relatedPosts_title">` → `<h1 ...>` |
| `inc/other-widget/widget-3pr-area.php` | `<h2 class="subSection-title">` → `<h1 ...>` |
| `inc/other-widget/widget-pr-blocks.php` | `<h2 class="prBlock_title">` → `<h1 ...>` |
| `inc/call-to-action/package/view-actionbox.php` | `<h2 class="cta_title">` → `<h1 ...>` |
| `inc/call-to-action/package/block/index.php` | `<h2 class="cta_title">` → `<h1 ...>` |
| `tests/test-cta.php` | 期待値を `<h1 class="cta_title">` に戻す（3箇所） |
| `tests/test-cta-output-escaping.php` | 期待値を `<h1 class="cta_title">` に戻す（2箇所） |
| `readme.txt` | changelog に1行追記 |

### 補足: 単純な `git revert` では足りなかった箇所

`tests/test-cta-output-escaping.php` は #1419 より**後**に追加されたファイル（#1438 のセキュリティ修正で追加）で、`<h2>` 前提の期待値が書かれていました。`git revert` の対象外になるため、手動で追随させています。これを取りこぼすとテストが失敗します。

### 補足: セキュリティ修正との競合解消

CTA の2ファイル（`view-actionbox.php` / `block/index.php`）は、#1438 のセキュリティ修正（CTA 画像位置カスタムフィールドの Stored XSS 修正）が #1419 と同じ行を触っていたため、取り消し時に競合しました。**セキュリティ修正（`esc_attr()` / `wp_kses_post()` 等）は維持したまま、見出しタグだけを戻しています**。

この点は安藤（セキュリティレビュー担当）が3方向から一次確認済みです。

1. `git diff 3d2e9ef6 HEAD -- inc/call-to-action/` の差分が**見出しタグ1行ずつのみ**
2. #1438 で入った対策10項目（画像位置の許可値チェック・保存時の検証・出力時のエスケープ等）が**すべて現在のコードに実在**
3. 9.119.0 より前との突き合わせで、残る差分が**セキュリティ修正のみ**

テストについても、攻撃を検知する側の条件（`<script>` や `onmouseover` が出力に含まれないことの確認）には一切手を入れていません。

## アクセシビリティについて

この取り消しにより、#1419 が目的としていた「1ページ内に `<h1>` が複数ある状態の解消」は未対応に戻ります。

なお植草（UX レビュー担当）の指摘のとおり、**「1ページに `<h1>` が複数ある」ことは WCAG 2.1 の達成基準に違反していません**。「h1 は1ページに1つ」は検索エンジン向けの監査ツールや HTML5 の記述に由来する慣行であり、WCAG のどの達成基準にも「h1 は1つ」という要件は存在しません。スクリーンリーダー利用者への影響は「見出し送りで記事タイトル以外も拾う」というノイズであって、内容に到達できなくなるわけではありません。

対して見た目の退行は影響サイト全件で即座に目に見え、かつプラグイン単体では塞げないため、取り消しを優先しています。

アクセシビリティ対応は **元 issue #1382 を再オープンして仕切り直します**。その際は「複数 `<h1>` の解消」ではなく「**見出し階層を文書構造に一致させる**」を目的に置き直し、見出しタグをフィルターフックで差し替え可能にする（既定は `<h1>` のまま据え置き、テーマ側が自分のリリースで `<h2>` を返すよう選択し、同じリリースで CSS も調整する）方向で検討します。

## スクリーンショット

見た目が 9.119.0 より前の状態に戻ることの Before / After は、e2e テスト実施後に PR コメントで添付します。

## 実装者チェックリスト

### コード品質

- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント

- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載（9.119.0 で告知したアクセシビリティ改善が撤回されることも明記）

### テスト

- [x] 既存のテストが通ることを確認（PHPUnit フルスイート **119 tests, 849 assertions OK**）
- [x] `php -l` は変更7ファイルすべてエラーなし
- [x] コーディング規約チェックは変更前後で指摘件数が同数（新規指摘ゼロ）

### 最終確認

- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---

## レビュワー向け情報

### テスト（確認手順）

#### 前提

- Lightning（G2 / G3）・Lightning Pro・X-T9 のいずれかを有効化した WordPress 環境
- 関連記事ウィジェット・3PR エリアウィジェット・PR ブロックウィジェット・CTA をそれぞれ表示できる状態にしておく

#### Before（9.119.0 の状態で退行を再現する）

1. ExUnit を 9.119.0（このブランチを適用する前）にした状態で、テーマを **Lightning G2 / origin スキン**に切り替える
2. 3PR エリアウィジェットを配置したページをフロントで表示する
   → 各見出しに**グレー（#f5f5f5）の背景**が付き、上に青い線が入っている（高さ約 55.6px）
3. PR ブロックウィジェットを配置したページをフロントで表示する
   → 同様に**グレーの背景**が付いている（高さ約 52.2px）
4. CTA を表示する
   → 黒い帯の**上下に線**が入っている
5. テーマを **Lightning G3 / origin3 スキン**に切り替え、個別投稿を開く
   → 関連記事の見出しの**上下に線が入り、高さが約 60.6px** になっている
6. テーマを **X-T9** に切り替え、個別投稿を開く
   → 関連記事の見出しの**上の余白が広がっている**（約 31.5px）

#### After（このブランチで元に戻ることを確認する）

1. このブランチを適用する
2. 上記 2〜6 と同じ手順で表示する
   → **いずれも 9.118.0（#1419 より前）と同じ見た目に戻っている**
   → 3PR エリア・PR ブロックの見出しにグレーの背景が付かない
   → CTA の黒帯に上下の線が入らない
   → 関連記事の見出しの高さ・余白が元に戻っている
3. ブラウザの開発者ツールで各見出しの HTML を確認する
   → 5箇所すべてが `<h1>` になっている
   → クラス名（`mainSection-title` / `relatedPosts_title` / `subSection-title` / `prBlock_title` / `cta_title`）は変わっていない

#### デグレ確認

4. CTA に画像を設定し、配置（右 / 中央 / 左）を切り替える
   → 設定どおりの位置に表示される（#1438 のセキュリティ修正が維持されていること）
5. CTA のタイトルに `<br>` を含めて保存する
   → 改行として反映される（`wp_kses_post()` が維持されていること）
6. PHPUnit を実行する
   → **119 tests, 849 assertions すべてパスする**

### レビューポイント

- 競合解消により #1438 のセキュリティ修正が巻き戻っていないこと（安藤が一次確認済みですが、重要箇所のため再確認いただけると安心です）
- `tests/test-cta-output-escaping.php` の期待値変更が、タグ名のみで攻撃検知条件に及んでいないこと

### 動作確認時の注意事項

- [ ] 最新のコードをプルしている
- [ ] 正しいディレクトリで作業している
- [ ] キャッシュをクリアしている

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/629