### PR TITLE
[Require 7.1 以上になってから][ 7.1対応 ][ その他 ] WordPress 7.1で不要になったフォームの高さ指定を削除

### DIFF
--- a/src/editor-panel/index.js
+++ b/src/editor-panel/index.js
@@ -270,7 +270,6 @@ const VeuSidebarInner = ( { postType } ) => {
 				>
 					<TextControl
 						__nextHasNoMarginBottom
-						__next40pxDefaultSize
 						label={ i18n.snsTitle || 'SNS Title' }
 						value={ meta?.vkExUnit_sns_title || '' }
 						onChange={ ( v ) => update( 'vkExUnit_sns_title', v ) }
@@ -329,7 +328,6 @@ const VeuSidebarInner = ( { postType } ) => {
 					initialOpen={ false }
 				>
 					<TextControl
-						__next40pxDefaultSize
 						label={ i18n.headTitle || 'Head Title' }
 						value={ headTitleObject?.title || '' }
 						onChange={ ( v ) => updateHeadTitle( 'title', v ) }
@@ -389,7 +387,6 @@ const VeuSidebarInner = ( { postType } ) => {
 				>
 					<SelectControl
 						__nextHasNoMarginBottom
-						__next40pxDefaultSize
 						label={ i18n.ctaSection || 'Call to Action setting' }
 						value={ meta?.vkexunit_cta_each_option ?? '0' }
 						options={ ctaOptions }
@@ -546,7 +543,6 @@ const VeuSidebarInner = ( { postType } ) => {
 
 						<SelectControl
 							__nextHasNoMarginBottom
-							__next40pxDefaultSize
 							label={ ctaI18n.imgPosition || 'Image position' }
 							value={ meta?.vkExUnit_cta_img_position || '' }
 							options={ [
@@ -571,7 +567,6 @@ const VeuSidebarInner = ( { postType } ) => {
 					>
 						<TextControl
 							__nextHasNoMarginBottom
-							__next40pxDefaultSize
 							label={ ctaI18n.buttonText || 'Button text' }
 							value={ meta?.vkExUnit_cta_button_text || '' }
 							onChange={ ( v ) =>
@@ -580,7 +575,6 @@ const VeuSidebarInner = ( { postType } ) => {
 						/>
 						<TextControl
 							__nextHasNoMarginBottom
-							__next40pxDefaultSize
 							label={ ctaI18n.ctaUrl || 'URL' }
 							value={ meta?.vkExUnit_cta_url || '' }
 							onChange={ ( v ) =>


### PR DESCRIPTION
## 関連Issue
- 関連Issue: https://github.com/vektor-inc/multi-repo-tasks/issues/30

## 変更の目的・理由
WordPress 7.1 ではフォームコントロールのデフォルト高さが 40px になり、これまでコンソール警告回避のために付けていた `__next40pxDefaultSize` は実行時に無視される（no-op）ようになりました。不要な指定を削除してコードを整理します。

見た目・挙動の変更はありません。

## 実装内容

### 主な変更点
- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] その他: 不要になった `__next40pxDefaultSize` プロパティの削除

### 技術的な詳細
- 参照: [Editor components updates in WordPress 7.1](https://make.wordpress.org/core/2026/07/23/editor-components-updates-in-wordpress-7-1/)
- `__nextHasNoMarginBottom` はそのまま残しています

## スクリーンショット
見た目の変更がないため省略します。

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載（エンドユーザー影響なしのため changelog 追記なし）
- [x] エンドユーザーが理解できる内容で記載（該当なし）

### テスト
- [x] 書けるテストは実装済み（UI prop 削除のため単体テスト追加なし）
- [ ] 既存のテストが通ることを確認
- [x] 手動テストを実施済み（削除対象が no-op であることを Field Guide およびローカル 7.1-RC1 で確認）

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順
1. WordPress 7.1（RC1 以上）の環境で本ブランチをビルドして有効化する
2. 投稿編集画面を開き、対象プラグインの設定 UI（サイドバー／ブロック設定）を表示する
3. テキスト入力やセレクトの見た目・操作が従来どおり使えることを確認する
   → フォームが操作でき、コンソールに `__next40pxDefaultSize` 関連の警告が出ない

### レビューポイント（任意）
- 削除漏れがないか（`__next40pxDefaultSize` の残存）
- `__nextHasNoMarginBottom` を誤って消していないか

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * SNSタイトル、見出し、CTA関連の入力・選択項目の余白設定を更新しました。
  * 各コントロールの表示が統一され、より一貫した編集画面になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->