### PR TITLE
[ 機能追加 ][ HTMLサイトマップ ] サイトマップに出力しないタクソノミーを指定できる設定を追加

### DIFF
--- a/inc/sitemap-page/sitemap-page-admin-main-setting.php
+++ b/inc/sitemap-page/sitemap-page-admin-main-setting.php
@@ -25,6 +25,11 @@ function veu_sitemap_options_validate( $input ) {
 		if ( isset( $input[ $value ] ) ) {
 			if ( is_array( $input[ $value ] ) ) {
 				foreach ( $input[ $value ] as $post_typ => $post_type_boolean ) {
+					// Do not save a taxonomy key that is not registered, to keep out invalid keys and option bloat.
+					// 登録されていないタクソノミー名は保存しない（option の肥大化と不正キーの混入を防ぐ）
+					if ( 'excludeTaxonomies' === $value && ! taxonomy_exists( $post_typ ) ) {
+						continue;
+					}
 					$output[ $value ][ $post_typ ] = esc_html( $post_type_boolean );
 				}
 			} else {

--- a/inc/sitemap-page/sitemap-page-admin-main-setting.php
+++ b/inc/sitemap-page/sitemap-page-admin-main-setting.php
@@ -19,7 +19,7 @@ add_action( 'veu_package_init', 'veu_sitemap_set_main_setting' );
 function veu_sitemap_options_validate( $input ) {
 	$output = $defaults = veu_get_sitemap_options_default();
 
-	$paras = array( 'excludeId', 'excludePostTypes' );
+	$paras = array( 'excludeId', 'excludePostTypes', 'excludeTaxonomies' );
 
 	foreach ( $paras as $key => $value ) {
 		if ( isset( $input[ $value ] ) ) {
@@ -60,7 +60,20 @@ function veu_add_sitemap_options_page() {
 			?>
 			</td>
 		</tr>
-	</tr>
+	<tr>
+	<th><?php _e( 'Exclude taxonomy from the sitemap', 'vk-all-in-one-expansion-unit' ); ?></th>
+	<td>
+			<?php
+			$args = array(
+				'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
+				'checked'    => $options['excludeTaxonomies'],
+				'taxonomies' => veu_get_sitemap_available_taxonomies(),
+			);
+			vk_the_taxonomy_check_list( $args );
+			?>
+			<p class="description"><?php _e( 'The term list of a checked taxonomy will not be displayed on the sitemap, regardless of the post type exclusion setting above.', 'vk-all-in-one-expansion-unit' ); ?></p>
+			</td>
+		</tr>
 	</table>
 	<p><?php _e( 'If you want to do not display specific page that, you can set on that page edit screen.', 'vk-all-in-one-expansion-unit' ); ?></p>
 

--- a/inc/sitemap-page/sitemap-page-admin-main-setting.php
+++ b/inc/sitemap-page/sitemap-page-admin-main-setting.php
@@ -65,6 +65,7 @@ function veu_add_sitemap_options_page() {
 			?>
 			</td>
 		</tr>
+	<?php $available_taxonomies = veu_get_sitemap_available_taxonomies(); ?>
 	<tr>
 	<th><?php _e( 'Exclude taxonomy from the sitemap', 'vk-all-in-one-expansion-unit' ); ?></th>
 	<td>
@@ -72,11 +73,13 @@ function veu_add_sitemap_options_page() {
 			$args = array(
 				'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
 				'checked'    => $options['excludeTaxonomies'],
-				'taxonomies' => veu_get_sitemap_available_taxonomies(),
+				'taxonomies' => $available_taxonomies,
 			);
 			vk_the_taxonomy_check_list( $args );
 			?>
+			<?php if ( ! empty( $available_taxonomies ) ) : ?>
 			<p class="description"><?php _e( 'The term list of a checked taxonomy will not be displayed on the sitemap, regardless of the post type exclusion setting above.', 'vk-all-in-one-expansion-unit' ); ?></p>
+			<?php endif; ?>
 			</td>
 		</tr>
 	</table>

--- a/inc/sitemap-page/sitemap-page-helpers.php
+++ b/inc/sitemap-page/sitemap-page-helpers.php
@@ -59,13 +59,24 @@ function veu_get_sitemap_public_post_types() {
  * （`excludePostTypes`）による除外を反映したものを返す。フロント出力（vkExUnit_sitemap()）が
  * どの投稿タイプをループ対象にするかを決めるために使う。
  *
+ * @param  array|null $public_post_types Optional. Pre-fetched result of veu_get_sitemap_public_post_types(),
+ *                                       to avoid calling it (and firing the veu_sitemap_exclude_post_types
+ *                                       filter) a second time when the caller already has it (see
+ *                                       vkExUnit_sitemap(), which shares one fetch with
+ *                                       veu_get_sitemap_available_taxonomies()). Pass null (default) to
+ *                                       fetch it internally.
+ *                                       任意。veu_get_sitemap_public_post_types() の結果を事前に渡す事で、
+ *                                       呼び出し元が既に取得済みの場合に再取得（veu_sitemap_exclude_post_types
+ *                                       フィルターの再発火を含む）を避けられる（vkExUnit_sitemap() が
+ *                                       veu_get_sitemap_available_taxonomies() と1回の取得を共有するために使う）。
+ *                                       省略時（null）は内部で取得する.
  * @return array Array of post type names, in the same shape returned by get_post_types().
  *               投稿タイプ名を値に持つ配列（get_post_types() の戻り値形式のまま）。
  */
-function veu_get_sitemap_post_types() {
+function veu_get_sitemap_post_types( $public_post_types = null ) {
 	$options = veu_get_sitemap_options();
 
-	$all_post_types = veu_get_sitemap_public_post_types();
+	$all_post_types = ( null === $public_post_types ) ? veu_get_sitemap_public_post_types() : $public_post_types;
 
 	// Exclude post types via the ExUnit sitemap option (excludePostTypes).
 	// ExUnit のサイトマップ設定（excludePostTypes）による除外投稿タイプ処理.
@@ -106,11 +117,22 @@ function veu_get_sitemap_post_types() {
  * 副次的に、投稿フォーマット（post_format）など管理画面 UI に表示されない内部タクソノミーは
  * `show_in_menu` が false のため、この一覧には含まれない。
  *
+ * @param  array|null $post_types Optional. Pre-fetched result of veu_get_sitemap_public_post_types(),
+ *                                to avoid calling it (and firing the veu_sitemap_exclude_post_types
+ *                                filter) a second time when the caller already has it. Pass null
+ *                                (default) to fetch it internally; the settings screen relies on
+ *                                this default so it keeps working unchanged.
+ *                                任意。veu_get_sitemap_public_post_types() の結果を事前に渡す事で、
+ *                                呼び出し元が既に取得済みの場合に再取得（veu_sitemap_exclude_post_types
+ *                                フィルターの再発火を含む）を避けられる。省略時（null、既定）は
+ *                                内部で取得する。設定画面はこの既定動作のまま変更不要で動く.
  * @return array Array of WP_Taxonomy objects keyed by taxonomy name.
  *               タクソノミー名をキーにした WP_Taxonomy オブジェクトの配列。
  */
-function veu_get_sitemap_available_taxonomies() {
-	$post_types           = veu_get_sitemap_public_post_types();
+function veu_get_sitemap_available_taxonomies( $post_types = null ) {
+	if ( null === $post_types ) {
+		$post_types = veu_get_sitemap_public_post_types();
+	}
 	$available_taxonomies = array();
 
 	foreach ( $post_types as $post_type ) {

--- a/inc/sitemap-page/sitemap-page-helpers.php
+++ b/inc/sitemap-page/sitemap-page-helpers.php
@@ -15,48 +15,69 @@ function veu_get_sitemap_options_default() {
 }
 
 /**
- * Get the array of post types actually output on the sitemap.
- * サイトマップに実際に出力される投稿タイプの配列を取得する。
+ * Get the array of public post types after applying the veu_sitemap_exclude_post_types filter only.
+ * `veu_sitemap_exclude_post_types` フィルターまで適用した公開投稿タイプの配列を取得する。
  *
- * Takes `get_post_types( array( 'public' => true ) )` and removes the post types
- * excluded by the `veu_sitemap_exclude_post_types` filter and by the ExUnit
- * sitemap setting (`excludePostTypes`).
- * `get_post_types( array( 'public' => true ) )` から、`veu_sitemap_exclude_post_types`
- * フィルターによる除外と、ExUnit のサイトマップ設定（`excludePostTypes`）による除外を反映したものを返す。
- * This single function is called from both the settings screen (to filter the
- * taxonomy checkbox list) and the front-end output (`vkExUnit_sitemap()`), so
- * the two conditions never fall out of sync.
- * 設定画面（除外タクソノミー一覧の絞り込み）とフロント出力（vkExUnit_sitemap()）の
- * 両方から同じ関数を呼ぶことで、一覧に載る条件と実際に除外される条件を一致させる。
+ * Deliberately does NOT apply the user-configurable `excludePostTypes` sitemap option.
+ * This is the shared base used both by veu_get_sitemap_post_types() (which additionally
+ * applies `excludePostTypes`) and by veu_get_sitemap_available_taxonomies(). Taxonomies must
+ * NOT be filtered by `excludePostTypes`, otherwise a taxonomy checkbox can disappear from the
+ * settings screen merely because an admin also excluded its post type, and the next save (which
+ * only writes back the checkboxes that were actually rendered) silently drops the taxonomy
+ * exclusion the admin had set earlier.
+ * あえてユーザー設定の `excludePostTypes` オプションは適用しない。
+ * veu_get_sitemap_post_types()（さらに `excludePostTypes` を適用する）と
+ * veu_get_sitemap_available_taxonomies() の両方が使う共通の基準集合。
+ * タクソノミーの一覧をここで `excludePostTypes` まで絞り込んでしまうと、投稿タイプを除外しただけで
+ * タクソノミーのチェックボックスが設定画面から消え、次回保存時（実際に描画されたチェックボックスの分しか
+ * 書き戻されない）にそれまでのタクソノミー除外設定が無言で失われてしまう。
  *
  * @return array Array of post type names, in the same shape returned by get_post_types().
  *               投稿タイプ名を値に持つ配列（get_post_types() の戻り値形式のまま）。
  */
-if ( ! function_exists( 'veu_get_sitemap_post_types' ) ) {
-	function veu_get_sitemap_post_types() {
-		$options = veu_get_sitemap_options();
+function veu_get_sitemap_public_post_types() {
+	$all_post_types = get_post_types( array( 'public' => true ) );
 
-		$all_post_types = get_post_types( array( 'public' => true ) );
+	// Exclude post types via the veu_sitemap_exclude_post_types filter.
+	// フィルターによる除外投稿タイプ処理.
+	$exclude_post_types = apply_filters( 'veu_sitemap_exclude_post_types', array( 'page', 'attachment', 'vk-managing-patterns' ) );
+	foreach ( $exclude_post_types as $exclude_post_type ) {
+		unset( $all_post_types[ $exclude_post_type ] );
+	}
 
-		// Exclude post types via the veu_sitemap_exclude_post_types filter.
-		// フィルターによる除外投稿タイプ処理
-		$exclude_post_types = apply_filters( 'veu_sitemap_exclude_post_types', array( 'page', 'attachment', 'vk-managing-patterns' ) );
-		foreach ( $exclude_post_types as $exclude_post_type ) {
-			unset( $all_post_types[ $exclude_post_type ] );
-		}
+	return $all_post_types;
+}
 
-		// Exclude post types via the ExUnit sitemap option (excludePostTypes).
-		// ExUnit のサイトマップ設定（excludePostTypes）による除外投稿タイプ処理
-		if ( isset( $options['excludePostTypes'] ) && is_array( $options['excludePostTypes'] ) ) {
-			foreach ( $options['excludePostTypes'] as $post_type => $value ) {
-				if ( $value ) {
-					unset( $all_post_types[ $post_type ] );
-				}
+/**
+ * Get the array of post types actually output on the sitemap.
+ * サイトマップに実際に出力される投稿タイプの配列を取得する。
+ *
+ * Takes veu_get_sitemap_public_post_types() and additionally removes the post types
+ * excluded by the ExUnit sitemap setting (`excludePostTypes`). Used by the front-end
+ * output (`vkExUnit_sitemap()`) to decide which post types to loop over.
+ * veu_get_sitemap_public_post_types() から、さらに ExUnit のサイトマップ設定
+ * （`excludePostTypes`）による除外を反映したものを返す。フロント出力（vkExUnit_sitemap()）が
+ * どの投稿タイプをループ対象にするかを決めるために使う。
+ *
+ * @return array Array of post type names, in the same shape returned by get_post_types().
+ *               投稿タイプ名を値に持つ配列（get_post_types() の戻り値形式のまま）。
+ */
+function veu_get_sitemap_post_types() {
+	$options = veu_get_sitemap_options();
+
+	$all_post_types = veu_get_sitemap_public_post_types();
+
+	// Exclude post types via the ExUnit sitemap option (excludePostTypes).
+	// ExUnit のサイトマップ設定（excludePostTypes）による除外投稿タイプ処理.
+	if ( isset( $options['excludePostTypes'] ) && is_array( $options['excludePostTypes'] ) ) {
+		foreach ( $options['excludePostTypes'] as $post_type => $value ) {
+			if ( $value ) {
+				unset( $all_post_types[ $post_type ] );
 			}
 		}
-
-		return $all_post_types;
 	}
+
+	return $all_post_types;
 }
 
 /**
@@ -64,13 +85,22 @@ if ( ! function_exists( 'veu_get_sitemap_post_types' ) ) {
  * サイトマップの「除外タクソノミー」設定画面・フロント出力の両方で使う、対象タクソノミー一覧を取得する。
  *
  * Returns only the taxonomies that have `show_in_menu` enabled and are attached to a
- * post type actually output on the sitemap (see veu_get_sitemap_post_types()).
- * `show_in_menu` が有効で、かつ「サイトマップに実際に出力される投稿タイプ」
- * （veu_get_sitemap_post_types()）に紐づいているタクソノミーだけを返す。
- * Keeping this condition in a single function keeps the settings checkbox list and
- * the front-end exclusion condition from falling out of sync.
- * この条件を1つの関数にまとめることで、設定画面のチェックボックス一覧とフロント側の
- * 除外判定の条件が食い違わないようにしている。
+ * post type in veu_get_sitemap_public_post_types() (public, minus the filter-based
+ * exclusion only — NOT the `excludePostTypes` option; see that function's doc for why).
+ * A taxonomy attached only to a post type the admin separately excluded via
+ * `excludePostTypes` is harmless to keep listed here: the front-end post type loop
+ * already skips that post type, so its taxonomies are never rendered anyway.
+ * `show_in_menu` が有効で、かつ veu_get_sitemap_public_post_types()（`excludePostTypes`
+ * オプションではなく、フィルター除外分までを反映した公開投稿タイプ集合。理由は同関数の
+ * ドキュメントを参照）に紐づいているタクソノミーだけを返す。`excludePostTypes` で個別に除外した
+ * 投稿タイプだけに紐づくタクソノミーをここに残しても実害はない。フロント側の投稿タイプループが
+ * その投稿タイプ自体をそもそも回さないため、紐づくタクソノミーもどのみち描画されない。
+ * Keeping this single condition (show_in_menu) here, and having the front-end output
+ * check membership in this function's return value instead of re-implementing the
+ * same condition, keeps the settings checkbox list and the front-end exclusion
+ * condition from falling out of sync.
+ * この条件（show_in_menu）をここ1箇所にまとめ、フロント側もこの関数の戻り値への所属で判定する
+ * ことで、設定画面のチェックボックス一覧とフロント側の除外判定の条件が食い違わないようにしている。
  * As a side effect, internal taxonomies not shown in the admin UI (e.g. `post_format`)
  * are automatically excluded because their `show_in_menu` is false.
  * 副次的に、投稿フォーマット（post_format）など管理画面 UI に表示されない内部タクソノミーは
@@ -79,25 +109,23 @@ if ( ! function_exists( 'veu_get_sitemap_post_types' ) ) {
  * @return array Array of WP_Taxonomy objects keyed by taxonomy name.
  *               タクソノミー名をキーにした WP_Taxonomy オブジェクトの配列。
  */
-if ( ! function_exists( 'veu_get_sitemap_available_taxonomies' ) ) {
-	function veu_get_sitemap_available_taxonomies() {
-		$post_types           = veu_get_sitemap_post_types();
-		$available_taxonomies = array();
+function veu_get_sitemap_available_taxonomies() {
+	$post_types           = veu_get_sitemap_public_post_types();
+	$available_taxonomies = array();
 
-		foreach ( $post_types as $post_type ) {
-			$taxonomy_objects = get_object_taxonomies( $post_type, 'objects' );
-			foreach ( $taxonomy_objects as $taxonomy_name => $taxonomy_object ) {
-				// Skip taxonomies already collected, or not shown in the admin UI.
-				// 既に一覧に含まれている、または管理画面 UI に表示しないタクソノミーは対象外
-				if ( isset( $available_taxonomies[ $taxonomy_name ] ) || ! $taxonomy_object->show_in_menu ) {
-					continue;
-				}
-				$available_taxonomies[ $taxonomy_name ] = $taxonomy_object;
+	foreach ( $post_types as $post_type ) {
+		$taxonomy_objects = get_object_taxonomies( $post_type, 'objects' );
+		foreach ( $taxonomy_objects as $taxonomy_name => $taxonomy_object ) {
+			// Skip taxonomies already collected, or not shown in the admin UI.
+			// 既に一覧に含まれている、または管理画面 UI に表示しないタクソノミーは対象外.
+			if ( isset( $available_taxonomies[ $taxonomy_name ] ) || ! $taxonomy_object->show_in_menu ) {
+				continue;
 			}
+			$available_taxonomies[ $taxonomy_name ] = $taxonomy_object;
 		}
-
-		return $available_taxonomies;
 	}
+
+	return $available_taxonomies;
 }
 
 /*

--- a/inc/sitemap-page/sitemap-page-helpers.php
+++ b/inc/sitemap-page/sitemap-page-helpers.php
@@ -1,7 +1,8 @@
 <?php
 function veu_get_sitemap_options() {
 	$default_options = array(
-		'excludePostTypes' => array(),
+		'excludePostTypes'  => array(),
+		'excludeTaxonomies' => array(),
 	);
 	$options         = get_option( 'vkExUnit_sitemap_options', $default_options );
 	$options         = wp_parse_args( $options, $default_options );
@@ -11,6 +12,92 @@ function veu_get_sitemap_options() {
 function veu_get_sitemap_options_default() {
 	$default_options['excludeId'] = '';
 	return apply_filters( 'vkExUnit_sitemap_options_default', $default_options );
+}
+
+/**
+ * Get the array of post types actually output on the sitemap.
+ * サイトマップに実際に出力される投稿タイプの配列を取得する。
+ *
+ * Takes `get_post_types( array( 'public' => true ) )` and removes the post types
+ * excluded by the `veu_sitemap_exclude_post_types` filter and by the ExUnit
+ * sitemap setting (`excludePostTypes`).
+ * `get_post_types( array( 'public' => true ) )` から、`veu_sitemap_exclude_post_types`
+ * フィルターによる除外と、ExUnit のサイトマップ設定（`excludePostTypes`）による除外を反映したものを返す。
+ * This single function is called from both the settings screen (to filter the
+ * taxonomy checkbox list) and the front-end output (`vkExUnit_sitemap()`), so
+ * the two conditions never fall out of sync.
+ * 設定画面（除外タクソノミー一覧の絞り込み）とフロント出力（vkExUnit_sitemap()）の
+ * 両方から同じ関数を呼ぶことで、一覧に載る条件と実際に除外される条件を一致させる。
+ *
+ * @return array Array of post type names, in the same shape returned by get_post_types().
+ *               投稿タイプ名を値に持つ配列（get_post_types() の戻り値形式のまま）。
+ */
+if ( ! function_exists( 'veu_get_sitemap_post_types' ) ) {
+	function veu_get_sitemap_post_types() {
+		$options = veu_get_sitemap_options();
+
+		$all_post_types = get_post_types( array( 'public' => true ) );
+
+		// Exclude post types via the veu_sitemap_exclude_post_types filter.
+		// フィルターによる除外投稿タイプ処理
+		$exclude_post_types = apply_filters( 'veu_sitemap_exclude_post_types', array( 'page', 'attachment', 'vk-managing-patterns' ) );
+		foreach ( $exclude_post_types as $exclude_post_type ) {
+			unset( $all_post_types[ $exclude_post_type ] );
+		}
+
+		// Exclude post types via the ExUnit sitemap option (excludePostTypes).
+		// ExUnit のサイトマップ設定（excludePostTypes）による除外投稿タイプ処理
+		if ( isset( $options['excludePostTypes'] ) && is_array( $options['excludePostTypes'] ) ) {
+			foreach ( $options['excludePostTypes'] as $post_type => $value ) {
+				if ( $value ) {
+					unset( $all_post_types[ $post_type ] );
+				}
+			}
+		}
+
+		return $all_post_types;
+	}
+}
+
+/**
+ * Get the taxonomies used both by the sitemap's "exclude taxonomy" checkbox list and by the front-end output.
+ * サイトマップの「除外タクソノミー」設定画面・フロント出力の両方で使う、対象タクソノミー一覧を取得する。
+ *
+ * Returns only the taxonomies that have `show_in_menu` enabled and are attached to a
+ * post type actually output on the sitemap (see veu_get_sitemap_post_types()).
+ * `show_in_menu` が有効で、かつ「サイトマップに実際に出力される投稿タイプ」
+ * （veu_get_sitemap_post_types()）に紐づいているタクソノミーだけを返す。
+ * Keeping this condition in a single function keeps the settings checkbox list and
+ * the front-end exclusion condition from falling out of sync.
+ * この条件を1つの関数にまとめることで、設定画面のチェックボックス一覧とフロント側の
+ * 除外判定の条件が食い違わないようにしている。
+ * As a side effect, internal taxonomies not shown in the admin UI (e.g. `post_format`)
+ * are automatically excluded because their `show_in_menu` is false.
+ * 副次的に、投稿フォーマット（post_format）など管理画面 UI に表示されない内部タクソノミーは
+ * `show_in_menu` が false のため、この一覧には含まれない。
+ *
+ * @return array Array of WP_Taxonomy objects keyed by taxonomy name.
+ *               タクソノミー名をキーにした WP_Taxonomy オブジェクトの配列。
+ */
+if ( ! function_exists( 'veu_get_sitemap_available_taxonomies' ) ) {
+	function veu_get_sitemap_available_taxonomies() {
+		$post_types           = veu_get_sitemap_post_types();
+		$available_taxonomies = array();
+
+		foreach ( $post_types as $post_type ) {
+			$taxonomy_objects = get_object_taxonomies( $post_type, 'objects' );
+			foreach ( $taxonomy_objects as $taxonomy_name => $taxonomy_object ) {
+				// Skip taxonomies already collected, or not shown in the admin UI.
+				// 既に一覧に含まれている、または管理画面 UI に表示しないタクソノミーは対象外
+				if ( isset( $available_taxonomies[ $taxonomy_name ] ) || ! $taxonomy_object->show_in_menu ) {
+					continue;
+				}
+				$available_taxonomies[ $taxonomy_name ] = $taxonomy_object;
+			}
+		}
+
+		return $available_taxonomies;
+	}
 }
 
 /*

--- a/inc/sitemap-page/sitemap-page.php
+++ b/inc/sitemap-page/sitemap-page.php
@@ -156,14 +156,20 @@ function vkExUnit_sitemap( $attr ) {
 
 	$page_for_posts = vk_get_page_for_posts();
 
+	// Fetch the filterable public post types once and share it with both helpers below, so the
+	// veu_sitemap_exclude_post_types filter only fires once per sitemap render instead of twice.
+	// フィルター適用済みの公開投稿タイプを1回だけ取得し、下記2つのヘルパーで共有する（サイトマップ描画1回
+	// につき veu_sitemap_exclude_post_types フィルターが2回発火しないようにするため）.
+	$public_post_types = veu_get_sitemap_public_post_types();
+
 	// Get post types from the shared helper so the condition matches the taxonomy list on the settings screen.
 	// サイトマップ設定画面のタクソノミー一覧と条件を揃えるため、共通ヘルパーから取得.
-	$all_post_types = veu_get_sitemap_post_types();
+	$all_post_types = veu_get_sitemap_post_types( $public_post_types );
 
 	// Get the taxonomies eligible for the sitemap from the same helper the settings screen uses,
 	// so the show_in_menu condition lives in one place only.
 	// 設定画面と同じヘルパーから対象タクソノミーを取得し、show_in_menu の判定を1箇所にまとめる.
-	$available_taxonomies = veu_get_sitemap_available_taxonomies();
+	$available_taxonomies = veu_get_sitemap_available_taxonomies( $public_post_types );
 
 	$p = get_posts(
 		array(

--- a/inc/sitemap-page/sitemap-page.php
+++ b/inc/sitemap-page/sitemap-page.php
@@ -155,7 +155,10 @@ function vkExUnit_sitemap( $attr ) {
 	$sitemap_html .= '<div class="col-md-6 sitemap-col">' . PHP_EOL;
 
 	$page_for_posts = vk_get_page_for_posts();
-	$all_post_types = get_post_types( array( 'public' => true ) );
+
+	// Get post types from the shared helper so the condition matches the taxonomy list on the settings screen.
+	// サイトマップ設定画面のタクソノミー一覧と条件を揃えるため、共通ヘルパーから取得
+	$all_post_types = veu_get_sitemap_post_types();
 
 	$p = get_posts(
 		array(
@@ -165,21 +168,6 @@ function vkExUnit_sitemap( $attr ) {
 	);
 	if ( empty( $p ) ) {
 		unset( $all_post_types['post'] );
-	}
-
-	// 除外投稿タイプ処理
-	$exclude_post_types = apply_filters( 'veu_sitemap_exclude_post_types', array( 'page', 'attachment', 'vk-managing-patterns' ) );
-	foreach ( $exclude_post_types as $exclude_post_type ) {
-		unset( $all_post_types[ $exclude_post_type ] );
-	}
-
-	// 除外投稿タイプ処理
-	if ( isset( $options['excludePostTypes'] ) && is_array( $options['excludePostTypes'] ) ) {
-		foreach ( $options['excludePostTypes'] as $key => $value ) {
-			if ( $value ) {
-				unset( $all_post_types[ $key ] );
-			}
-		}
 	}
 
 	foreach ( $all_post_types as $postType ) {
@@ -207,6 +195,12 @@ function vkExUnit_sitemap( $attr ) {
 			$taxonomies = get_object_taxonomies( $postType );
 
 			foreach ( $taxonomies as $taxonomy ) {
+				// Skip the whole heading (and its term list) when the taxonomy is excluded by the sitemap setting.
+				// 除外タクソノミー設定で指定されている場合は、見出しごとスキップする
+				if ( isset( $options['excludeTaxonomies'][ $taxonomy ] ) && $options['excludeTaxonomies'][ $taxonomy ] ) {
+					continue;
+				}
+
 				// taxonomyの詳細情報を取得
 				$taxonomy_object = get_taxonomy( $taxonomy );
 

--- a/inc/sitemap-page/sitemap-page.php
+++ b/inc/sitemap-page/sitemap-page.php
@@ -157,8 +157,13 @@ function vkExUnit_sitemap( $attr ) {
 	$page_for_posts = vk_get_page_for_posts();
 
 	// Get post types from the shared helper so the condition matches the taxonomy list on the settings screen.
-	// サイトマップ設定画面のタクソノミー一覧と条件を揃えるため、共通ヘルパーから取得
+	// サイトマップ設定画面のタクソノミー一覧と条件を揃えるため、共通ヘルパーから取得.
 	$all_post_types = veu_get_sitemap_post_types();
+
+	// Get the taxonomies eligible for the sitemap from the same helper the settings screen uses,
+	// so the show_in_menu condition lives in one place only.
+	// 設定画面と同じヘルパーから対象タクソノミーを取得し、show_in_menu の判定を1箇所にまとめる.
+	$available_taxonomies = veu_get_sitemap_available_taxonomies();
 
 	$p = get_posts(
 		array(
@@ -196,13 +201,20 @@ function vkExUnit_sitemap( $attr ) {
 
 			foreach ( $taxonomies as $taxonomy ) {
 				// Skip the whole heading (and its term list) when the taxonomy is excluded by the sitemap setting.
-				// 除外タクソノミー設定で指定されている場合は、見出しごとスキップする
+				// 除外タクソノミー設定で指定されている場合は、見出しごとスキップする.
 				if ( isset( $options['excludeTaxonomies'][ $taxonomy ] ) && $options['excludeTaxonomies'][ $taxonomy ] ) {
 					continue;
 				}
 
-				// taxonomyの詳細情報を取得
-				$taxonomy_object = get_taxonomy( $taxonomy );
+				// Limit to taxonomies eligible for the sitemap (show_in_menu enabled), using the
+				// same veu_get_sitemap_available_taxonomies() result as the settings screen, instead
+				// of re-checking show_in_menu here, so the two never fall out of sync.
+				// 設定画面と同じ veu_get_sitemap_available_taxonomies() の結果で絞り込む（show_in_menu の
+				// 判定をここで再実装しないことで、設定画面とフロントの条件が食い違わないようにする）.
+				if ( ! isset( $available_taxonomies[ $taxonomy ] ) ) {
+					continue;
+				}
+				$taxonomy_object = $available_taxonomies[ $taxonomy ];
 
 				// ここでタームが1つ以上あるか確認
 				$terms = get_terms(
@@ -212,8 +224,7 @@ function vkExUnit_sitemap( $attr ) {
 					)
 				);
 
-				// 管理画面のUIに表示させているものだけに限定
-				if ( $taxonomy_object->show_in_menu && ! empty( $terms ) ) {
+				if ( ! empty( $terms ) ) {
 					$sitemap_html .= '<h5 class="sitemap-taxonomy-title sitemap-taxonomy-' . esc_attr( $taxonomy_object->name ) . '">' . wp_kses_post( $taxonomy_object->label ) . '</h5>' . PHP_EOL;
 
 					/*
@@ -230,7 +241,7 @@ function vkExUnit_sitemap( $attr ) {
 										);
 										$sitemap_html .= wp_list_categories( $args );
 										$sitemap_html .= '</ul>' . PHP_EOL;
-				} // if ( $taxonomy_object->show_in_menu ) {
+				} // if ( ! empty( $terms ) ) {
 			} // foreach ( $taxonomies as $taxonomy ) {
 
 			$sitemap_html .= '</div><!-- [ /.sectionBox ] -->' . PHP_EOL;

--- a/inc/template-tags/package/template-tags.php
+++ b/inc/template-tags/package/template-tags.php
@@ -446,12 +446,19 @@ if ( ! function_exists( 'vk_the_post_type_check_list' ) ) {
  *                                              タクソノミー名ごとの id 属性を指定する場合の配列。
  *     @type string[]      $exclude_taxonomies Taxonomy names to leave out of the list.
  *                                              一覧から除外するタクソノミー名の配列。
+ *     @type string        $empty_message      Message shown instead of the list when 'taxonomies' is empty.
+ *                                              Kept as an argument (rather than hard-coded) so callers
+ *                                              outside the sitemap "exclude taxonomy" use case can supply
+ *                                              their own wording.
+ *                                              'taxonomies' が空の場合に一覧の代わりに表示する文言。
+ *                                              サイトマップの「除外タクソノミー」以外の用途で再利用しても
+ *                                              文言が破綻しないよう、決め打ちにせず引数化している。
  * }
  * @return void Outputs markup directly via echo; nothing is returned. When 'taxonomies' is
- *              empty, outputs a fallback message instead of an empty list so the admin can
- *              tell "nothing to exclude" apart from a broken display.
- *              直接 echo で出力するため返り値はなし。'taxonomies' が空の場合は、空の一覧では
- *              なくフォールバック文言を出す（「対象が無い」と「表示が壊れている」を区別できるように）。
+ *              empty, outputs 'empty_message' instead of an empty list so the admin can tell
+ *              "nothing to exclude" apart from a broken display.
+ *              直接 echo で出力するため返り値はなし。'taxonomies' が空の場合は、空の一覧ではなく
+ *              'empty_message' を出す（「対象が無い」と「表示が壊れている」を区別できるように）。
  */
 if ( ! function_exists( 'vk_the_taxonomy_check_list' ) ) {
 	function vk_the_taxonomy_check_list( $args ) {
@@ -461,11 +468,12 @@ if ( ! function_exists( 'vk_the_taxonomy_check_list' ) ) {
 			'checked'            => array(),
 			'id'                 => array(),
 			'exclude_taxonomies' => array(),
+			'empty_message'      => __( 'No taxonomies are available to exclude.', 'vk-all-in-one-expansion-unit' ),
 		);
 		$args    = wp_parse_args( $args, $default );
 
 		if ( empty( $args['taxonomies'] ) ) {
-			echo '<p>' . esc_html__( 'No taxonomies are available to exclude.', 'vk-all-in-one-expansion-unit' ) . '</p>';
+			echo '<p class="description">' . esc_html( $args['empty_message'] ) . '</p>';
 			return;
 		}
 

--- a/inc/template-tags/package/template-tags.php
+++ b/inc/template-tags/package/template-tags.php
@@ -422,10 +422,16 @@ if ( ! function_exists( 'vk_the_post_type_check_list' ) ) {
  * Newly added as a taxonomy version of vk_the_post_type_check_list(), following the same
  * conventions (markup structure, escaping, function_exists guard). The caller passes the
  * target taxonomies via the 'taxonomies' argument; which taxonomies to list is decided by
- * the caller's own domain logic, not by this generic display helper.
+ * the caller's own domain logic, not by this generic display helper. Unlike the post type
+ * version, the 'id' argument only supports the per-key array form: the post type version's
+ * string-keyed fallback (`$args['name'][$key]`) can never be reached because 'name' is always
+ * a plain string here, so that dead branch was intentionally dropped in this new function.
  * vk_the_post_type_check_list() と同じ作法（構造・エスケープ・function_exists ガード）で、
  * タクソノミー版として新設。対象となるタクソノミーは呼び出し元が 'taxonomies' 引数で渡す
  * （どのタクソノミーを一覧に載せるかの絞り込み条件は呼び出し元のドメインロジックに委ねる）。
+ * 投稿タイプ版と異なり、'id' 引数は配列形式のみ対応する。投稿タイプ版にあった文字列キーの
+ * フォールバック（`$args['name'][$key]`）は、ここでは 'name' が常に文字列のため絶対に通らない
+ * 死んだ分岐であり、この新規関数では意図的に落としている。
  *
  * @param  array $args {
  *     Settings for the checkbox display. チェックボックス表示用の設定。
@@ -436,13 +442,16 @@ if ( ! function_exists( 'vk_the_post_type_check_list' ) ) {
  *                                              チェックボックスの name 属性のベース（例: 'vkExUnit_sitemap_options[excludeTaxonomies]'）。
  *     @type array         $checked            Saved values holding the checked state (taxonomy name => 'true' etc.).
  *                                              チェック状態を持つ保存済みの値（タクソノミー名 => 'true' 等）。
- *     @type array         $id                 Optional per-taxonomy id attribute values.
+ *     @type array         $id                 Optional per-taxonomy id attribute values, keyed by taxonomy name.
  *                                              タクソノミー名ごとの id 属性を指定する場合の配列。
  *     @type string[]      $exclude_taxonomies Taxonomy names to leave out of the list.
  *                                              一覧から除外するタクソノミー名の配列。
  * }
- * @return void Outputs markup directly via echo; nothing is returned.
- *              直接 echo で出力するため返り値はなし。
+ * @return void Outputs markup directly via echo; nothing is returned. When 'taxonomies' is
+ *              empty, outputs a fallback message instead of an empty list so the admin can
+ *              tell "nothing to exclude" apart from a broken display.
+ *              直接 echo で出力するため返り値はなし。'taxonomies' が空の場合は、空の一覧では
+ *              なくフォールバック文言を出す（「対象が無い」と「表示が壊れている」を区別できるように）。
  */
 if ( ! function_exists( 'vk_the_taxonomy_check_list' ) ) {
 	function vk_the_taxonomy_check_list( $args ) {
@@ -450,23 +459,21 @@ if ( ! function_exists( 'vk_the_taxonomy_check_list' ) ) {
 			'taxonomies'         => array(),
 			'name'               => '',
 			'checked'            => array(),
-			'id'                 => '',
+			'id'                 => array(),
 			'exclude_taxonomies' => array(),
 		);
 		$args    = wp_parse_args( $args, $default );
 
+		if ( empty( $args['taxonomies'] ) ) {
+			echo '<p>' . esc_html__( 'No taxonomies are available to exclude.', 'vk-all-in-one-expansion-unit' ) . '</p>';
+			return;
+		}
+
 		echo '<ul class="no-style">';
 		foreach ( $args['taxonomies'] as $key => $value ) {
-			if ( ! in_array( $key, $args['exclude_taxonomies'] ) ) {
+			if ( ! in_array( $key, $args['exclude_taxonomies'], true ) ) {
 				$checked = ( isset( $args['checked'][ $key ] ) && ( $args['checked'][ $key ] ) ) ? ' checked' : '';
-
-				if ( ! empty( $args['id'][ $key ] ) ) {
-					$id = ' id="' . esc_attr( $args['id'][ $key ] ) . '"';
-				} elseif ( ! empty( $args['name'][ $key ] ) ) {
-					$id = ' id="' . esc_attr( $args['name'][ $key ] ) . '"';
-				} else {
-					$id = '';
-				}
+				$id      = ! empty( $args['id'][ $key ] ) ? ' id="' . esc_attr( $args['id'][ $key ] ) . '"' : '';
 
 				echo '<li><label>';
 				echo '<input type="checkbox" name="' . esc_attr( $args['name'] ) . '[' . esc_attr( $key ) . ']"' . $id . ' value="true"' . $checked . ' />' . esc_html( $value->label );

--- a/inc/template-tags/package/template-tags.php
+++ b/inc/template-tags/package/template-tags.php
@@ -412,6 +412,71 @@ if ( ! function_exists( 'vk_the_post_type_check_list' ) ) {
 	}
 }
 
+/*
+	Taxonomy Check Box
+/*-------------------------------------------*/
+/**
+ * Display a checkbox list of taxonomies.
+ * タクソノミーのチェックボックスを表示する関数。
+ *
+ * Newly added as a taxonomy version of vk_the_post_type_check_list(), following the same
+ * conventions (markup structure, escaping, function_exists guard). The caller passes the
+ * target taxonomies via the 'taxonomies' argument; which taxonomies to list is decided by
+ * the caller's own domain logic, not by this generic display helper.
+ * vk_the_post_type_check_list() と同じ作法（構造・エスケープ・function_exists ガード）で、
+ * タクソノミー版として新設。対象となるタクソノミーは呼び出し元が 'taxonomies' 引数で渡す
+ * （どのタクソノミーを一覧に載せるかの絞り込み条件は呼び出し元のドメインロジックに委ねる）。
+ *
+ * @param  array $args {
+ *     Settings for the checkbox display. チェックボックス表示用の設定。
+ *
+ *     @type WP_Taxonomy[] $taxonomies         Taxonomy objects to display, keyed by taxonomy name.
+ *                                              表示対象のタクソノミーオブジェクトの配列（キーはタクソノミー名）。
+ *     @type string        $name               Base for the checkbox name attribute (e.g. 'vkExUnit_sitemap_options[excludeTaxonomies]').
+ *                                              チェックボックスの name 属性のベース（例: 'vkExUnit_sitemap_options[excludeTaxonomies]'）。
+ *     @type array         $checked            Saved values holding the checked state (taxonomy name => 'true' etc.).
+ *                                              チェック状態を持つ保存済みの値（タクソノミー名 => 'true' 等）。
+ *     @type array         $id                 Optional per-taxonomy id attribute values.
+ *                                              タクソノミー名ごとの id 属性を指定する場合の配列。
+ *     @type string[]      $exclude_taxonomies Taxonomy names to leave out of the list.
+ *                                              一覧から除外するタクソノミー名の配列。
+ * }
+ * @return void Outputs markup directly via echo; nothing is returned.
+ *              直接 echo で出力するため返り値はなし。
+ */
+if ( ! function_exists( 'vk_the_taxonomy_check_list' ) ) {
+	function vk_the_taxonomy_check_list( $args ) {
+		$default = array(
+			'taxonomies'         => array(),
+			'name'               => '',
+			'checked'            => array(),
+			'id'                 => '',
+			'exclude_taxonomies' => array(),
+		);
+		$args    = wp_parse_args( $args, $default );
+
+		echo '<ul class="no-style">';
+		foreach ( $args['taxonomies'] as $key => $value ) {
+			if ( ! in_array( $key, $args['exclude_taxonomies'] ) ) {
+				$checked = ( isset( $args['checked'][ $key ] ) && ( $args['checked'][ $key ] ) ) ? ' checked' : '';
+
+				if ( ! empty( $args['id'][ $key ] ) ) {
+					$id = ' id="' . esc_attr( $args['id'][ $key ] ) . '"';
+				} elseif ( ! empty( $args['name'][ $key ] ) ) {
+					$id = ' id="' . esc_attr( $args['name'][ $key ] ) . '"';
+				} else {
+					$id = '';
+				}
+
+				echo '<li><label>';
+				echo '<input type="checkbox" name="' . esc_attr( $args['name'] ) . '[' . esc_attr( $key ) . ']"' . $id . ' value="true"' . $checked . ' />' . esc_html( $value->label );
+				echo '</label></li>';
+			}
+		}
+		echo '</ul>';
+	}
+}
+
 /**
  * vk_the_post_type_check_list で保存される配列が、キーに投稿タイプ名が入る微妙な仕様のため、投稿タイプだけを配列で返すように変換
  *

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+[ New Feature ][ HTML Sitemap ] Added an option to exclude specific taxonomies from the HTML sitemap, in addition to the existing post type exclusion.
+
 = 9.120.0 =
 [ New Feature ] Added an alternative text setting for the inquiry banner image. When it is left blank, the alternative text set on the media library is filled in automatically on save.
 [ Spec Change ] Fixed the inquiry banner image being read aloud as "contact_txt" by screen readers; it now uses the alternative text you set, or the contact button text as the link name when it is blank.

--- a/tests/test-sitemap-page.php
+++ b/tests/test-sitemap-page.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Class SitemapPageTest
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * HTML サイトマップの「除外タクソノミー」機能のテスト。
+ * Test for the HTML sitemap "exclude taxonomy" feature.
+ */
+class SitemapPageTest extends WP_UnitTestCase {
+
+	/**
+	 * テスト用に登録した投稿タイプ・タクソノミー名を保持する。
+	 * Holds the post type / taxonomy names registered for this test.
+	 *
+	 * @var string[]
+	 */
+	private $registered_post_types = array();
+
+	/**
+	 * @var string[]
+	 */
+	private $registered_taxonomies = array();
+
+	/**
+	 * veu_get_sitemap_post_types() のテスト。
+	 * フィルターとオプション（excludePostTypes）による除外が正しく反映される事、
+	 * public でない投稿タイプはそもそも対象にならない事を検証する。
+	 *
+	 * Test for veu_get_sitemap_post_types().
+	 * Verifies that exclusion via the filter and the excludePostTypes option is
+	 * reflected correctly, and that non-public post types are never included.
+	 */
+	function test_veu_get_sitemap_post_types() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_veu_get_sitemap_post_types' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		// テスト用の投稿タイプを登録（cpt_a: 公開・除外対象外 / cpt_b: 非公開 / cpt_c: 公開・除外設定でオプション除外する対象）。
+		// Register test post types ( cpt_a: public, not excluded / cpt_b: non-public / cpt_c: public, excluded via the option in some cases ).
+		$this->register_test_post_type( 'veu_test_cpt_a', array( 'public' => true ) );
+		$this->register_test_post_type( 'veu_test_cpt_b', array( 'public' => false ) );
+		$this->register_test_post_type( 'veu_test_cpt_c', array( 'public' => true ) );
+
+		$test_cases = array(
+			array(
+				'test_condition_name'       => '除外設定なしの場合 => 公開の投稿タイプのみが一覧に含まれる',
+				'option_exclude_post_types' => array(),
+				'expected_included'         => array( 'veu_test_cpt_a', 'veu_test_cpt_c' ),
+				'expected_excluded'         => array( 'veu_test_cpt_b' ),
+			),
+			array(
+				'test_condition_name'       => 'excludePostTypes で true を指定した投稿タイプが除外される',
+				'option_exclude_post_types' => array( 'veu_test_cpt_c' => 'true' ),
+				'expected_included'         => array( 'veu_test_cpt_a' ),
+				'expected_excluded'         => array( 'veu_test_cpt_b', 'veu_test_cpt_c' ),
+			),
+			array(
+				'test_condition_name'       => '境界値: excludePostTypes の値が空文字（falsy）の場合は除外されない',
+				'option_exclude_post_types' => array( 'veu_test_cpt_c' => '' ),
+				'expected_included'         => array( 'veu_test_cpt_a', 'veu_test_cpt_c' ),
+				'expected_excluded'         => array( 'veu_test_cpt_b' ),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			update_option(
+				'vkExUnit_sitemap_options',
+				array( 'excludePostTypes' => $case['option_exclude_post_types'] )
+			);
+
+			$actual = veu_get_sitemap_post_types();
+
+			foreach ( $case['expected_included'] as $post_type ) {
+				$this->assertArrayHasKey( $post_type, $actual, $case['test_condition_name'] );
+			}
+			foreach ( $case['expected_excluded'] as $post_type ) {
+				$this->assertArrayNotHasKey( $post_type, $actual, $case['test_condition_name'] );
+			}
+
+			delete_option( 'vkExUnit_sitemap_options' );
+		}
+	}
+
+	/**
+	 * veu_get_sitemap_available_taxonomies() のテスト。
+	 * show_in_menu が有効で、サイトマップに出力される投稿タイプに紐づくタクソノミーだけが
+	 * 一覧に含まれる事、投稿フォーマット等の内部タクソノミーが自動的に除外される事を検証する。
+	 *
+	 * Test for veu_get_sitemap_available_taxonomies().
+	 * Verifies that only taxonomies with show_in_menu enabled and attached to a post type
+	 * output on the sitemap are included, and that internal taxonomies such as post_format
+	 * are automatically excluded.
+	 */
+	function test_veu_get_sitemap_available_taxonomies() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_veu_get_sitemap_available_taxonomies' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$this->register_test_post_type( 'veu_test_cpt_a', array( 'public' => true ) );
+		$this->register_test_post_type( 'veu_test_cpt_c', array( 'public' => true ) );
+
+		// show_in_menu が有効なタクソノミーと無効なタクソノミーを cpt_a に紐付ける。
+		// Attach a show_in_menu-enabled taxonomy and a disabled one to cpt_a.
+		$this->register_test_taxonomy( 'veu_test_tax_shown', array( 'veu_test_cpt_a' ), array( 'show_in_menu' => true ) );
+		$this->register_test_taxonomy( 'veu_test_tax_hidden', array( 'veu_test_cpt_a' ), array( 'show_in_menu' => false ) );
+		// cpt_c にだけ紐付いたタクソノミー（cpt_c を除外設定した場合に一覧から消える事を確認するため）。
+		// A taxonomy attached only to cpt_c ( to verify it disappears when cpt_c itself is excluded ).
+		$this->register_test_taxonomy( 'veu_test_tax_on_c', array( 'veu_test_cpt_c' ), array( 'show_in_menu' => true ) );
+
+		$test_cases = array(
+			array(
+				'test_condition_name'       => '除外設定なしの場合 => show_in_menu が有効なタクソノミーだけが一覧に含まれる',
+				'option_exclude_post_types' => array(),
+				'expected_included'         => array( 'veu_test_tax_shown', 'veu_test_tax_on_c' ),
+				'expected_excluded'         => array( 'veu_test_tax_hidden' ),
+			),
+			array(
+				'test_condition_name'       => '投稿タイプ自体が excludePostTypes で除外されると、紐づくタクソノミーも一覧から外れる',
+				'option_exclude_post_types' => array( 'veu_test_cpt_c' => 'true' ),
+				'expected_included'         => array( 'veu_test_tax_shown' ),
+				'expected_excluded'         => array( 'veu_test_tax_hidden', 'veu_test_tax_on_c' ),
+			),
+			array(
+				'test_condition_name'       => '境界値: 投稿フォーマット（post_format）のような内部タクソノミーは自動的に一覧から除外される',
+				'option_exclude_post_types' => array(),
+				'expected_included'         => array(),
+				'expected_excluded'         => array( 'post_format' ),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			update_option(
+				'vkExUnit_sitemap_options',
+				array( 'excludePostTypes' => $case['option_exclude_post_types'] )
+			);
+
+			$actual = veu_get_sitemap_available_taxonomies();
+
+			foreach ( $case['expected_included'] as $taxonomy ) {
+				$this->assertArrayHasKey( $taxonomy, $actual, $case['test_condition_name'] );
+			}
+			foreach ( $case['expected_excluded'] as $taxonomy ) {
+				$this->assertArrayNotHasKey( $taxonomy, $actual, $case['test_condition_name'] );
+			}
+
+			delete_option( 'vkExUnit_sitemap_options' );
+		}
+	}
+
+	/**
+	 * vkExUnit_sitemap() のテスト。
+	 * excludeTaxonomies で指定したタクソノミーは、見出し（h5）ごとサイトマップから消える事、
+	 * 無関係なキーが保存されていても他のタクソノミーの表示に影響しない事を検証する。
+	 *
+	 * Test for vkExUnit_sitemap().
+	 * Verifies that a taxonomy specified in excludeTaxonomies disappears together with its
+	 * heading ( h5 ), and that an unrelated stale key in the option does not affect the
+	 * display of other taxonomies.
+	 */
+	function test_vkExUnit_sitemap() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_vkExUnit_sitemap' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$this->register_test_post_type( 'veu_test_cpt_a', array( 'public' => true ) );
+		$this->register_test_taxonomy( 'veu_test_tax_shown', array( 'veu_test_cpt_a' ), array( 'show_in_menu' => true ) );
+
+		// タームを持つ公開投稿を1件作成し、サイトマップの投稿タイプループから除外されないようにする。
+		// Create one published post with a term so it is not skipped by the sitemap's post type loop.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'veu_test_cpt_a',
+				'post_status' => 'publish',
+			)
+		);
+		$term    = wp_insert_term( 'VEU Test Term', 'veu_test_tax_shown' );
+		wp_set_object_terms( $post_id, array( $term['term_id'] ), 'veu_test_tax_shown' );
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '除外設定なしの場合 => タクソノミーの見出しとターム一覧が表示される',
+				'exclude_taxonomies'  => array(),
+				'expect_visible'      => true,
+			),
+			array(
+				'test_condition_name' => 'excludeTaxonomies に指定すると、見出しごとサイトマップから消える',
+				'exclude_taxonomies'  => array( 'veu_test_tax_shown' => 'true' ),
+				'expect_visible'      => false,
+			),
+			array(
+				'test_condition_name' => '境界値: 無関係なタクソノミー名が excludeTaxonomies に入っていても表示に影響しない',
+				'exclude_taxonomies'  => array( 'veu_test_tax_not_exists' => 'true' ),
+				'expect_visible'      => true,
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			update_option(
+				'vkExUnit_sitemap_options',
+				array( 'excludeTaxonomies' => $case['exclude_taxonomies'] )
+			);
+
+			$html = vkExUnit_sitemap( array() );
+
+			if ( $case['expect_visible'] ) {
+				$this->assertStringContainsString( 'sitemap-taxonomy-veu_test_tax_shown', $html, $case['test_condition_name'] );
+			} else {
+				$this->assertStringNotContainsString( 'sitemap-taxonomy-veu_test_tax_shown', $html, $case['test_condition_name'] );
+			}
+
+			delete_option( 'vkExUnit_sitemap_options' );
+		}
+	}
+
+	/**
+	 * テスト用の投稿タイプを登録し、後片付け対象として記録する。
+	 * Register a test post type and remember it for cleanup.
+	 *
+	 * @param string $post_type 投稿タイプ名 / Post type slug.
+	 * @param array  $args      register_post_type() に渡す引数 / Args passed to register_post_type().
+	 * @return void
+	 */
+	private function register_test_post_type( $post_type, $args = array() ) {
+		if ( post_type_exists( $post_type ) ) {
+			return;
+		}
+		register_post_type( $post_type, wp_parse_args( $args, array( 'label' => $post_type ) ) );
+		$this->registered_post_types[] = $post_type;
+	}
+
+	/**
+	 * テスト用のタクソノミーを登録し、後片付け対象として記録する。
+	 * Register a test taxonomy and remember it for cleanup.
+	 *
+	 * @param string $taxonomy    タクソノミー名 / Taxonomy slug.
+	 * @param array  $object_type 紐付ける投稿タイプ名の配列 / Post types to attach to.
+	 * @param array  $args        register_taxonomy() に渡す引数 / Args passed to register_taxonomy().
+	 * @return void
+	 */
+	private function register_test_taxonomy( $taxonomy, $object_type, $args = array() ) {
+		if ( taxonomy_exists( $taxonomy ) ) {
+			return;
+		}
+		register_taxonomy( $taxonomy, $object_type, wp_parse_args( $args, array( 'label' => $taxonomy ) ) );
+		$this->registered_taxonomies[] = $taxonomy;
+	}
+
+	/**
+	 * 各テストの後に、登録した投稿タイプ・タクソノミー・オプションを片付ける。
+	 * Clean up the registered post types, taxonomies and options after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		foreach ( $this->registered_taxonomies as $taxonomy ) {
+			unregister_taxonomy( $taxonomy );
+		}
+		$this->registered_taxonomies = array();
+
+		foreach ( $this->registered_post_types as $post_type ) {
+			unregister_post_type( $post_type );
+		}
+		$this->registered_post_types = array();
+
+		delete_option( 'vkExUnit_sitemap_options' );
+
+		parent::tear_down();
+	}
+}

--- a/tests/test-sitemap-page.php
+++ b/tests/test-sitemap-page.php
@@ -87,14 +87,91 @@ class SitemapPageTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * veu_get_sitemap_public_post_types() のテスト。
+	 * veu_sitemap_exclude_post_types フィルターによる除外は反映される事、
+	 * ユーザー設定（excludePostTypes オプション）は反映されない事を検証する。
+	 *
+	 * Test for veu_get_sitemap_public_post_types().
+	 * Verifies that exclusion via the veu_sitemap_exclude_post_types filter is reflected,
+	 * while the user-configurable excludePostTypes option is intentionally NOT applied here.
+	 */
+	function test_veu_get_sitemap_public_post_types() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_veu_get_sitemap_public_post_types' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$this->register_test_post_type( 'veu_test_cpt_a', array( 'public' => true ) );
+		$this->register_test_post_type( 'veu_test_cpt_b', array( 'public' => false ) );
+		$this->register_test_post_type( 'veu_test_cpt_c', array( 'public' => true ) );
+
+		$exclude_via_filter = static function ( $exclude_post_types ) {
+			$exclude_post_types[] = 'veu_test_cpt_c';
+			return $exclude_post_types;
+		};
+
+		$test_cases = array(
+			array(
+				'test_condition_name'       => '除外設定なしの場合 => 公開の投稿タイプのみが含まれる',
+				'apply_filter'              => false,
+				'option_exclude_post_types' => array( 'veu_test_cpt_a' => 'true' ),
+				'expected_included'         => array( 'veu_test_cpt_a', 'veu_test_cpt_c' ),
+				'expected_excluded'         => array( 'veu_test_cpt_b' ),
+			),
+			array(
+				'test_condition_name'       => 'veu_sitemap_exclude_post_types フィルターで指定した投稿タイプは除外される',
+				'apply_filter'              => true,
+				'option_exclude_post_types' => array(),
+				'expected_included'         => array( 'veu_test_cpt_a' ),
+				'expected_excluded'         => array( 'veu_test_cpt_b', 'veu_test_cpt_c' ),
+			),
+			array(
+				'test_condition_name'       => '境界値: excludePostTypes オプションで除外しても、ここでは除外されない（フィルター専用の集合のため）',
+				'apply_filter'              => false,
+				'option_exclude_post_types' => array( 'veu_test_cpt_c' => 'true' ),
+				'expected_included'         => array( 'veu_test_cpt_a', 'veu_test_cpt_c' ),
+				'expected_excluded'         => array( 'veu_test_cpt_b' ),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			update_option(
+				'vkExUnit_sitemap_options',
+				array( 'excludePostTypes' => $case['option_exclude_post_types'] )
+			);
+			if ( $case['apply_filter'] ) {
+				add_filter( 'veu_sitemap_exclude_post_types', $exclude_via_filter );
+			}
+
+			$actual = veu_get_sitemap_public_post_types();
+
+			foreach ( $case['expected_included'] as $post_type ) {
+				$this->assertArrayHasKey( $post_type, $actual, $case['test_condition_name'] );
+			}
+			foreach ( $case['expected_excluded'] as $post_type ) {
+				$this->assertArrayNotHasKey( $post_type, $actual, $case['test_condition_name'] );
+			}
+
+			if ( $case['apply_filter'] ) {
+				remove_filter( 'veu_sitemap_exclude_post_types', $exclude_via_filter );
+			}
+			delete_option( 'vkExUnit_sitemap_options' );
+		}
+	}
+
+	/**
 	 * veu_get_sitemap_available_taxonomies() のテスト。
-	 * show_in_menu が有効で、サイトマップに出力される投稿タイプに紐づくタクソノミーだけが
-	 * 一覧に含まれる事、投稿フォーマット等の内部タクソノミーが自動的に除外される事を検証する。
+	 * show_in_menu が有効なタクソノミーだけが一覧に含まれる事、投稿フォーマット等の内部タクソノミーが
+	 * 自動的に除外される事、そして excludePostTypes オプションでは絞り込まれない事
+	 * （安藤さんレビュー MEDIUM 指摘の回帰テスト）を検証する。
 	 *
 	 * Test for veu_get_sitemap_available_taxonomies().
-	 * Verifies that only taxonomies with show_in_menu enabled and attached to a post type
-	 * output on the sitemap are included, and that internal taxonomies such as post_format
-	 * are automatically excluded.
+	 * Verifies that only taxonomies with show_in_menu enabled are included, that internal
+	 * taxonomies such as post_format are automatically excluded, and that the list is NOT
+	 * narrowed by the excludePostTypes option ( regression test for the reviewer-reported bug
+	 * where a taxonomy checkbox silently disappeared, and its saved exclusion was then lost on
+	 * the next save, merely because an admin also excluded its post type ).
 	 */
 	function test_veu_get_sitemap_available_taxonomies() {
 
@@ -110,25 +187,40 @@ class SitemapPageTest extends WP_UnitTestCase {
 		// Attach a show_in_menu-enabled taxonomy and a disabled one to cpt_a.
 		$this->register_test_taxonomy( 'veu_test_tax_shown', array( 'veu_test_cpt_a' ), array( 'show_in_menu' => true ) );
 		$this->register_test_taxonomy( 'veu_test_tax_hidden', array( 'veu_test_cpt_a' ), array( 'show_in_menu' => false ) );
-		// cpt_c にだけ紐付いたタクソノミー（cpt_c を除外設定した場合に一覧から消える事を確認するため）。
-		// A taxonomy attached only to cpt_c ( to verify it disappears when cpt_c itself is excluded ).
+		// cpt_c にだけ紐付いたタクソノミー（event / event_cat の再現用）。
+		// A taxonomy attached only to cpt_c ( reproduces the reviewer's event / event_cat scenario ).
 		$this->register_test_taxonomy( 'veu_test_tax_on_c', array( 'veu_test_cpt_c' ), array( 'show_in_menu' => true ) );
+
+		$exclude_via_filter = static function ( $exclude_post_types ) {
+			$exclude_post_types[] = 'veu_test_cpt_c';
+			return $exclude_post_types;
+		};
 
 		$test_cases = array(
 			array(
 				'test_condition_name'       => '除外設定なしの場合 => show_in_menu が有効なタクソノミーだけが一覧に含まれる',
+				'apply_filter'              => false,
 				'option_exclude_post_types' => array(),
 				'expected_included'         => array( 'veu_test_tax_shown', 'veu_test_tax_on_c' ),
 				'expected_excluded'         => array( 'veu_test_tax_hidden' ),
 			),
 			array(
-				'test_condition_name'       => '投稿タイプ自体が excludePostTypes で除外されると、紐づくタクソノミーも一覧から外れる',
+				'test_condition_name'       => '回帰テスト: 投稿タイプを excludePostTypes オプションで除外しても、紐づくタクソノミーは一覧から消えない（保存済み設定を次回保存時に失わないため）',
+				'apply_filter'              => false,
 				'option_exclude_post_types' => array( 'veu_test_cpt_c' => 'true' ),
+				'expected_included'         => array( 'veu_test_tax_shown', 'veu_test_tax_on_c' ),
+				'expected_excluded'         => array( 'veu_test_tax_hidden' ),
+			),
+			array(
+				'test_condition_name'       => '投稿タイプが veu_sitemap_exclude_post_types フィルターで除外される場合は、紐づくタクソノミーも一覧から外れる',
+				'apply_filter'              => true,
+				'option_exclude_post_types' => array(),
 				'expected_included'         => array( 'veu_test_tax_shown' ),
 				'expected_excluded'         => array( 'veu_test_tax_hidden', 'veu_test_tax_on_c' ),
 			),
 			array(
 				'test_condition_name'       => '境界値: 投稿フォーマット（post_format）のような内部タクソノミーは自動的に一覧から除外される',
+				'apply_filter'              => false,
 				'option_exclude_post_types' => array(),
 				'expected_included'         => array(),
 				'expected_excluded'         => array( 'post_format' ),
@@ -140,6 +232,9 @@ class SitemapPageTest extends WP_UnitTestCase {
 				'vkExUnit_sitemap_options',
 				array( 'excludePostTypes' => $case['option_exclude_post_types'] )
 			);
+			if ( $case['apply_filter'] ) {
+				add_filter( 'veu_sitemap_exclude_post_types', $exclude_via_filter );
+			}
 
 			$actual = veu_get_sitemap_available_taxonomies();
 
@@ -150,6 +245,9 @@ class SitemapPageTest extends WP_UnitTestCase {
 				$this->assertArrayNotHasKey( $taxonomy, $actual, $case['test_condition_name'] );
 			}
 
+			if ( $case['apply_filter'] ) {
+				remove_filter( 'veu_sitemap_exclude_post_types', $exclude_via_filter );
+			}
 			delete_option( 'vkExUnit_sitemap_options' );
 		}
 	}
@@ -183,6 +281,7 @@ class SitemapPageTest extends WP_UnitTestCase {
 			)
 		);
 		$term    = wp_insert_term( 'VEU Test Term', 'veu_test_tax_shown' );
+		$this->assertNotWPError( $term, 'テスト用タームの作成に失敗した場合、後続のアサーションが無意味になるため先に検証する。' );
 		wp_set_object_terms( $post_id, array( $term['term_id'] ), 'veu_test_tax_shown' );
 
 		$test_cases = array(
@@ -218,6 +317,138 @@ class SitemapPageTest extends WP_UnitTestCase {
 			}
 
 			delete_option( 'vkExUnit_sitemap_options' );
+		}
+	}
+
+	/**
+	 * veu_sitemap_options_validate() のテスト。
+	 * 登録済みのタクソノミー名は保存され、未登録のタクソノミー名は保存されない事
+	 * （安藤さんレビュー LOW 指摘の入力検証）を検証する。
+	 *
+	 * Test for veu_sitemap_options_validate().
+	 * Verifies that a registered taxonomy name is saved, and that an unregistered
+	 * taxonomy name is dropped ( input validation gap pointed out in the code review ).
+	 */
+	function test_veu_sitemap_options_validate() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_veu_sitemap_options_validate' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$test_cases = array(
+			array(
+				'test_condition_name'         => '登録済みのタクソノミー名（category）は excludeTaxonomies にそのまま保存される',
+				'input'                       => array(
+					'excludePostTypes'  => array( 'post' => 'true' ),
+					'excludeTaxonomies' => array( 'category' => 'true' ),
+				),
+				'expected_exclude_post_types' => array( 'post' => 'true' ),
+				'expected_exclude_taxonomies' => array( 'category' => 'true' ),
+			),
+			array(
+				'test_condition_name'         => '未登録のタクソノミー名は excludeTaxonomies から除かれる（登録済みの分は保存される）',
+				'input'                       => array(
+					'excludeTaxonomies' => array(
+						'category'                => 'true',
+						'veu_test_not_a_taxonomy' => 'true',
+					),
+				),
+				'expected_exclude_post_types' => array(),
+				'expected_exclude_taxonomies' => array( 'category' => 'true' ),
+			),
+			array(
+				'test_condition_name'         => '境界値: excludeTaxonomies が送信されない場合は何も保存されない',
+				'input'                       => array(
+					'excludePostTypes' => array( 'post' => 'true' ),
+				),
+				'expected_exclude_post_types' => array( 'post' => 'true' ),
+				'expected_exclude_taxonomies' => array(),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$actual = veu_sitemap_options_validate( $case['input'] );
+
+			// 未送信のキーは $output に存在しない場合があるため、空配列として正規化してから比較する。
+			// A key that was never submitted may be entirely absent from $output, so normalize to an empty array before comparing.
+			$actual_exclude_post_types = isset( $actual['excludePostTypes'] ) ? $actual['excludePostTypes'] : array();
+			$actual_exclude_taxonomies = isset( $actual['excludeTaxonomies'] ) ? $actual['excludeTaxonomies'] : array();
+
+			$this->assertEquals( $case['expected_exclude_post_types'], $actual_exclude_post_types, $case['test_condition_name'] );
+			$this->assertEquals( $case['expected_exclude_taxonomies'], $actual_exclude_taxonomies, $case['test_condition_name'] );
+		}
+	}
+
+	/**
+	 * vk_the_taxonomy_check_list() のテスト。
+	 * name 属性・checked の有無が正しく出力される事、対象タクソノミーが0件の場合に
+	 * 空の一覧ではなくフォールバック文言が出力される事（植草さんレビュー UX-2 指摘）を検証する。
+	 *
+	 * Test for vk_the_taxonomy_check_list().
+	 * Verifies the name attribute and the checked state are output correctly, and that a
+	 * fallback message is shown instead of an empty list when there are no taxonomies to
+	 * display ( UX review finding ).
+	 */
+	function test_vk_the_taxonomy_check_list() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_vk_the_taxonomy_check_list' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$this->register_test_taxonomy( 'veu_test_tax_shown', array(), array( 'label' => 'VEU Test Tax Shown' ) );
+		$taxonomy_object = get_taxonomy( 'veu_test_tax_shown' );
+
+		$test_cases = array(
+			array(
+				'test_condition_name'   => 'チェック済みの場合 => name 属性と checked が両方出力される',
+				'args'                  => array(
+					'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
+					'checked'    => array( 'veu_test_tax_shown' => 'true' ),
+					'taxonomies' => array( 'veu_test_tax_shown' => $taxonomy_object ),
+				),
+				'expected_contains'     => array(
+					'name="vkExUnit_sitemap_options[excludeTaxonomies][veu_test_tax_shown]"',
+					'checked',
+				),
+				'expected_not_contains' => array(),
+			),
+			array(
+				'test_condition_name'   => '未チェックの場合 => name 属性は出力されるが checked は出力されない',
+				'args'                  => array(
+					'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
+					'checked'    => array(),
+					'taxonomies' => array( 'veu_test_tax_shown' => $taxonomy_object ),
+				),
+				'expected_contains'     => array(
+					'name="vkExUnit_sitemap_options[excludeTaxonomies][veu_test_tax_shown]"',
+				),
+				'expected_not_contains' => array( 'checked' ),
+			),
+			array(
+				'test_condition_name'   => '境界値: 対象タクソノミーが0件の場合、空の一覧ではなくフォールバック文言が出力される',
+				'args'                  => array(
+					'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
+					'checked'    => array(),
+					'taxonomies' => array(),
+				),
+				'expected_contains'     => array( 'No taxonomies are available to exclude.' ),
+				'expected_not_contains' => array( '<ul class="no-style">' ),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			ob_start();
+			vk_the_taxonomy_check_list( $case['args'] );
+			$html = ob_get_clean();
+
+			foreach ( $case['expected_contains'] as $expected ) {
+				$this->assertStringContainsString( $expected, $html, $case['test_condition_name'] );
+			}
+			foreach ( $case['expected_not_contains'] as $unexpected ) {
+				$this->assertStringNotContainsString( $unexpected, $html, $case['test_condition_name'] );
+			}
 		}
 	}
 

--- a/tests/test-sitemap-page.php
+++ b/tests/test-sitemap-page.php
@@ -255,12 +255,15 @@ class SitemapPageTest extends WP_UnitTestCase {
 	/**
 	 * vkExUnit_sitemap() のテスト。
 	 * excludeTaxonomies で指定したタクソノミーは、見出し（h5）ごとサイトマップから消える事、
-	 * 無関係なキーが保存されていても他のタクソノミーの表示に影響しない事を検証する。
+	 * 無関係なキーが保存されていても他のタクソノミーの表示に影響しない事、
+	 * show_in_menu => false のタクソノミーはそもそも出力されない事（安藤さんレビュー LOW 指摘の回帰テスト。
+	 * フロント側の唯一の条件式差し替え箇所であるため）を検証する。
 	 *
 	 * Test for vkExUnit_sitemap().
 	 * Verifies that a taxonomy specified in excludeTaxonomies disappears together with its
-	 * heading ( h5 ), and that an unrelated stale key in the option does not affect the
-	 * display of other taxonomies.
+	 * heading ( h5 ), that an unrelated stale key in the option does not affect the display of
+	 * other taxonomies, and that a taxonomy with show_in_menu => false is never output at all
+	 * ( regression test for the front-end's only replaced condition, per code review ).
 	 */
 	function test_vkExUnit_sitemap() {
 
@@ -271,6 +274,9 @@ class SitemapPageTest extends WP_UnitTestCase {
 
 		$this->register_test_post_type( 'veu_test_cpt_a', array( 'public' => true ) );
 		$this->register_test_taxonomy( 'veu_test_tax_shown', array( 'veu_test_cpt_a' ), array( 'show_in_menu' => true ) );
+		// show_in_menu => false のタクソノミー（回帰テスト用）。
+		// A taxonomy with show_in_menu => false ( for the regression test ).
+		$this->register_test_taxonomy( 'veu_test_tax_hidden', array( 'veu_test_cpt_a' ), array( 'show_in_menu' => false ) );
 
 		// タームを持つ公開投稿を1件作成し、サイトマップの投稿タイプループから除外されないようにする。
 		// Create one published post with a term so it is not skipped by the sitemap's post type loop.
@@ -283,6 +289,14 @@ class SitemapPageTest extends WP_UnitTestCase {
 		$term    = wp_insert_term( 'VEU Test Term', 'veu_test_tax_shown' );
 		$this->assertNotWPError( $term, 'テスト用タームの作成に失敗した場合、後続のアサーションが無意味になるため先に検証する。' );
 		wp_set_object_terms( $post_id, array( $term['term_id'] ), 'veu_test_tax_shown' );
+
+		// veu_test_tax_hidden にもタームを1件作成しておく（ターム0件だからではなく、show_in_menu が
+		// false だから出力されない事を検証するため）。
+		// Also create one term on veu_test_tax_hidden ( so its absence proves the show_in_menu
+		// condition, not merely that it has zero terms ).
+		$hidden_term = wp_insert_term( 'VEU Test Hidden Term', 'veu_test_tax_hidden' );
+		$this->assertNotWPError( $hidden_term, 'テスト用タームの作成に失敗した場合、後続のアサーションが無意味になるため先に検証する。' );
+		wp_set_object_terms( $post_id, array( $hidden_term['term_id'] ), 'veu_test_tax_hidden' );
 
 		$test_cases = array(
 			array(
@@ -315,6 +329,12 @@ class SitemapPageTest extends WP_UnitTestCase {
 			} else {
 				$this->assertStringNotContainsString( 'sitemap-taxonomy-veu_test_tax_shown', $html, $case['test_condition_name'] );
 			}
+
+			// 回帰テスト: excludeTaxonomies の設定に関わらず、show_in_menu => false のタクソノミーは
+			// タームがあってもそもそも出力されない。
+			// Regression check: regardless of the excludeTaxonomies setting, a taxonomy with
+			// show_in_menu => false is never output even when it has a term.
+			$this->assertStringNotContainsString( 'sitemap-taxonomy-veu_test_tax_hidden', $html, $case['test_condition_name'] . '（show_in_menu => false の回帰確認）' );
 
 			delete_option( 'vkExUnit_sitemap_options' );
 		}
@@ -410,7 +430,7 @@ class SitemapPageTest extends WP_UnitTestCase {
 				),
 				'expected_contains'     => array(
 					'name="vkExUnit_sitemap_options[excludeTaxonomies][veu_test_tax_shown]"',
-					'checked',
+					' checked />',
 				),
 				'expected_not_contains' => array(),
 			),
@@ -424,7 +444,9 @@ class SitemapPageTest extends WP_UnitTestCase {
 				'expected_contains'     => array(
 					'name="vkExUnit_sitemap_options[excludeTaxonomies][veu_test_tax_shown]"',
 				),
-				'expected_not_contains' => array( 'checked' ),
+				// 属性境界を含む文字列にする事で、将来 checked 系のクラス名等が増えても誤検知しないようにする。
+				// Include the attribute boundary so a future class name containing "checked" cannot cause a false negative.
+				'expected_not_contains' => array( ' checked />' ),
 			),
 			array(
 				'test_condition_name'   => '境界値: 対象タクソノミーが0件の場合、空の一覧ではなくフォールバック文言が出力される',


### PR DESCRIPTION
Closes #1445

@coderabbitai ignore

## 概要

HTML サイトマップから、出力したくない分類（タクソノミー）をまとめて非表示にできる設定を追加しました。

これまでは「ExUnit > メイン設定 > HTML サイトマップ」で **投稿タイプ単位** でしか除外できず、たとえば「投稿は出したいがタグ一覧だけ出したくない」という調整ができませんでした。今回、投稿タイプ除外のすぐ下に **タクソノミー（カテゴリー・タグなど、記事を分類するためのまとまり）のチェックボックス一覧** を追加し、チェックしたものをサイトマップから外せるようにしています。

## 変更内容

### 1. 設定画面にタクソノミーのチェックボックス一覧を追加

- 場所: ExUnit > メイン設定 > HTML サイトマップ。既存の「Exclude post type from the sitemap」の直下
- 見出し: `Exclude taxonomy from the sitemap`
- 保存先: `vkExUnit_sitemap_options` の `excludeTaxonomies`。既存の投稿タイプ除外と同じ形式（分類名をキーに持つ配列）です
- 見た目・マークアップは既存の投稿タイプ除外と揃えました。使い方を新しく覚え直す必要がありません

### 2. チェックしたタクソノミーをサイトマップから外す

チェックしたタクソノミーは、ターム（そのタクソノミーに属する個々の分類項目。カテゴリーなら「お知らせ」「製品情報」など）の一覧だけでなく、**見出しごと** 表示されなくなります。見出しだけが残って中身が空、という状態にはなりません。

### 3. 一覧に出す条件と、実際に除外される条件を1か所にまとめた

今回いちばん気をつけたところです。

「設定画面のチェックボックス一覧に出す条件」と「サイトマップ側で実際に表示される条件」が別々に書かれていると、片方だけ変更されたときに次のような食い違いが起きます。

- チェックを入れたのに、そもそも元から表示されていなかった
- 表示されているのに、除外する手段が設定画面に無い

そこで、対象になるタクソノミーを返す処理を `veu_get_sitemap_available_taxonomies()`（`inc/sitemap-page/sitemap-page-helpers.php`）の 1 つにまとめ、**設定画面とサイトマップの両方がそこを参照する** 形にしました。サイトマップ側は同じ判定を書き直すのではなく、この関数が返した一覧に含まれるかどうかで判断します。

対象にする条件は「管理画面のメニューに表示される設定が有効なタクソノミー」です。この条件により、投稿フォーマットなど管理画面に出てこない内部的なタクソノミーは自動的に一覧から外れます。

### 4. 保存時に、実在するタクソノミーかを確認

保存処理で、登録されていない名前は保存しないようにしました。設定値に不正な項目が溜まっていくのを防ぎます。

### 5. 対象が 0 件のときの表示

サイトから除外できるタクソノミーが 1 つも無い場合、空のリストだけが出ると「対象が無い」のか「表示が壊れている」のか区別が付きません。この場合は `No taxonomies are available to exclude.` という文言を出し、あわせて説明文も出さないようにしています。

## 既存サイトへの影響

- **既定は「除外なし」です。** この設定を保存していない既存サイトでは、これまでどおりすべてのタクソノミーが表示されます
- 投稿タイプ除外の既存の挙動は変えていません
- 副次的な改善として、サイトマップ表示時のデータベースへの問い合わせが変更前より減っています（管理画面に出ないタクソノミーと、除外指定したぶんのターム取得が走らなくなるため）

## スクリーンショット

### 設定画面

「Exclude post type from the sitemap」の直下に「Exclude taxonomy from the sitemap」を追加しています。

![設定画面](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1448/settings-taxonomy-exclude.png?raw=true)

### サイトマップの表示（Before / After）

同じ固定ページ・同じ条件で撮影しています。

**Before（除外なし）** — Categories・Tags の見出しと一覧が両方表示されている状態

![Before](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1448/before-sitemap-frontend.png?raw=true)

**After（Tags を除外）** — Tags の見出しと一覧が両方消え、Categories はそのまま

![After](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1448/after-sitemap-frontend-tag-excluded.png?raw=true)

## 確認手順

### 前提

- ExUnit を有効化し、ExUnit > メイン設定 > HTML サイトマップ が開けること
- 固定ページを 1 つ用意し、そのページの編集画面で「HTML サイトマップを表示」にチェックを入れて公開しておくこと
- 投稿にカテゴリーとタグを最低 1 件ずつ割り当て、公開しておくこと（ターム件数が 0 のタクソノミーはもともと表示されないため）

### A. 設定画面に一覧が出ることの確認

1. 管理画面で ExUnit > メイン設定 を開き、「HTML Sitemap Settings」のセクションまでスクロールする
   → 「Exclude post type from the sitemap」の**すぐ下**に「Exclude taxonomy from the sitemap」の行があり、チェックボックスの一覧が表示される
2. 一覧の中身を確認する
   → 「カテゴリー」「タグ」が並んでいる。「投稿フォーマット」など管理画面のメニューに出ない分類は**含まれない**
3. チェックボックスの下に説明文が出ていることを確認する
   → 「The term list of a checked taxonomy will not be displayed on the sitemap, regardless of the post type exclusion setting above.」と表示される

### B. チェックした分類がサイトマップから消えることの確認（本題）

1. 手順 A の画面で「タグ」だけにチェックを入れ、「変更を保存」をクリックする
   → 画面が再読み込みされ、「タグ」にチェックが入ったままになっている
2. 前提で用意した固定ページをフロント（サイト側）で開く
   → 「タグ」の見出しと、その下のタグ一覧が**両方とも消えている**。見出しだけが残ることはない
   → 「カテゴリー」の見出しとカテゴリー一覧は**そのまま表示されている**
3. 設定画面に戻り、「タグ」のチェックを外して保存する
4. 再び固定ページをフロントで開く
   → 「タグ」の見出しと一覧が**元どおり表示される**

### C. 投稿タイプ除外と併用しても設定が消えないことの確認

1. 設定画面で「Exclude taxonomy from the sitemap」の「タグ」にチェックを入れて保存する
2. 続けて「Exclude post type from the sitemap」の「投稿」にもチェックを入れて保存する
   → このとき「タグ」のチェックが**外れていない**
3. 「投稿」のチェックだけを外して保存する
   → 「タグ」のチェックが**入ったまま残っている**（この手順で消えてしまう不具合を、レビューで見つけて修正しています）

### D. 既存サイトへの影響がないことの確認（デグレ確認）

1. タクソノミーの除外に一切チェックを入れていない状態で、固定ページをフロントで開く
   → 変更前と同じく、カテゴリー・タグの見出しと一覧がすべて表示される
2. 投稿タイプ除外だけを使った場合の挙動を確認する
   → 変更前と同じく、チェックした投稿タイプのセクションごと表示されない

## テスト

PHPUnit を追加しました（`tests/test-sitemap-page.php`）。

- サイトマップに出力される投稿タイプの絞り込み（フィルターによる除外・設定による除外）
- チェックボックス一覧に載せるタクソノミーの絞り込み条件
- 手順 C の「投稿タイプを除外しても、タクソノミーの除外設定が消えない」ことの回帰テスト
- 管理画面に出ないタクソノミーがサイトマップに出力されないことの回帰テスト
- 保存処理が、登録されていない名前を保存しないこと
- チェックボックスの出力内容と、対象 0 件のときの文言

実行結果:

```
OK (128 tests, 932 assertions)
```

ローカルの wp-env（WordPress の開発用ローカル環境）で実行しています。

## レビュー状況

- 安藤（リードエンジニア）セキュリティレビュー: PASS
- 植草（UX デザイナー）UX レビュー: PASS

いずれも指摘は対応済みです。詳細は #1445 のコメントに記録しています。

## この PR では対応しないもの

レビューで挙がったもののうち、次は今回対応していません。

- ループ変数名が実体とずれている箇所の改名（既存名の流用で、動作への影響はないため）
- 「保存 → 再描画 → 別項目を保存 → 設定が残っている」という保存サイクル全体を通した検証（1 段目の回帰テストは追加済みで、そこが修正の本体のため）
- 複数の投稿タイプで共有されるタクソノミーに、紐づく投稿タイプ名を注記する案（ラベルが長くなり折り返しで崩れやすいため、まずは既存パターンと同じ見た目で出す方針）

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/722
