### PR TITLE
[ 不具合修正 ][ HTMLサイトマップ ] 他プラグインが同梱する古い共通ファイルが優先され、設定画面が致命的エラーになる不具合を修正

### DIFF
--- a/inc/template-tags/template-tags-config.php
+++ b/inc/template-tags/template-tags-config.php
@@ -18,10 +18,10 @@
  * package/template-tags.php 内の全関数は個別に function_exists() ガードされているため、常に
  * require_once しても関数の再宣言エラーは起きない。よってファイル単位のガードは外し、常に読み込む。
  *
- * @package Vk_All_In_One_Expansion_Unit
+ * @package VK All in One Expansion Unit
  * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1450
  */
 
-require_once 'package/template-tags.php';
-require_once 'package/template-tags-veu.php';
-require_once 'package/template-tags-veu-old.php';
+require_once __DIR__ . '/package/template-tags.php';
+require_once __DIR__ . '/package/template-tags-veu.php';
+require_once __DIR__ . '/package/template-tags-veu-old.php';

--- a/inc/template-tags/template-tags-config.php
+++ b/inc/template-tags/template-tags-config.php
@@ -1,7 +1,27 @@
 <?php
-// if ( ! function_exists( 'vk_is_template_tags_exist' ) ) {
-if ( ! function_exists( 'vk_get_post_type' ) ) {
-	require_once 'package/template-tags.php';
-}
+/**
+ * Load the shared template tag packages used by ExUnit.
+ * ExUnit が使用する共有パッケージを読み込む。
+ *
+ * When another plugin (e.g. VK Post Author Display) bundles the same shared package
+ * (package/template-tags.php) and loads it first, vk_get_post_type() becomes already defined.
+ * The old file-level guard below then skipped loading ExUnit's own package/template-tags.php
+ * entirely, leaving newer functions not present in the other plugin's older copy (e.g.
+ * vk_the_taxonomy_check_list()) undefined and causing a fatal error. Every function inside
+ * package/template-tags.php is individually guarded with function_exists(), so requiring it
+ * unconditionally cannot trigger a redeclaration error. The file-level guard is therefore
+ * removed and the file is always required.
+ * 他プラグイン（VK Post Author Display 等）が同梱する同名の共有パッケージ（package/template-tags.php）が
+ * 先に読み込まれ、vk_get_post_type() が定義済みになっていると、このファイル単位のガードにより
+ * ExUnit 側の package/template-tags.php が丸ごと読み込まれず、他プラグインの古いコピーに存在しない
+ * 新しい関数（例: vk_the_taxonomy_check_list()）が未定義のまま致命的エラーになる不具合があった。
+ * package/template-tags.php 内の全関数は個別に function_exists() ガードされているため、常に
+ * require_once しても関数の再宣言エラーは起きない。よってファイル単位のガードは外し、常に読み込む。
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1450
+ */
+
+require_once 'package/template-tags.php';
 require_once 'package/template-tags-veu.php';
 require_once 'package/template-tags-veu-old.php';

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ e.g.
 
 == Changelog ==
 
-* [ Bug Fix ][ HTML Sitemap ] Fixed a fatal error on the HTML Sitemap settings screen when used together with plugins that bundle an older copy of the shared template tag package (e.g. VK Post Author Display).
+[ Bug Fix ][ HTML Sitemap ] Fixed a fatal error on the HTML Sitemap settings screen when used together with plugins that bundle an older copy of the shared template tag package (e.g. VK Post Author Display).
 
 = 9.121.0 =
 [ New Feature ][ HTML Sitemap ] Added an option to exclude specific taxonomies from the HTML sitemap, in addition to the existing post type exclusion.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ e.g.
 
 == Changelog ==
 
+* [ Bug Fix ][ HTML Sitemap ] Fixed a fatal error on the HTML Sitemap settings screen when used together with plugins that bundle an older copy of the shared template tag package (e.g. VK Post Author Display).
+
 = 9.121.0 =
 [ New Feature ][ HTML Sitemap ] Added an option to exclude specific taxonomies from the HTML sitemap, in addition to the existing post type exclusion.
 

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -809,32 +809,22 @@ class TemplateTagsTest extends WP_UnitTestCase {
 	 * Regression test for the include guard in inc/template-tags/template-tags-config.php.
 	 * template-tags-config.php の読み込みガードに関する回帰テスト。
 	 *
-	 * VK Post Author Display 等、同じ共有パッケージ（package/template-tags.php）の
-	 * 古いコピーを同梱する他プラグインが ExUnit より先に読み込まれると、
-	 * vk_get_post_type() が既に定義済みになる。かつてはそれをファイル単位のガード
-	 * （`if ( ! function_exists( 'vk_get_post_type' ) )`）に使っていたため、
-	 * package/template-tags.php 自体が丸ごと読み込まれず、他プラグインの古いコピーに
-	 * 存在しない新しい関数（vk_the_taxonomy_check_list() 等）が未定義のまま
-	 * 致命的エラーになっていた（Issue #1450）。
+	 * 背景・経緯の詳細は読み込み元である template-tags-config.php 側の docblock を正とする。
+	 * The background and rationale are documented in the docblock of
+	 * template-tags-config.php, which is the source of truth.
 	 *
-	 * このテストは、テストプロセス内では ExUnit の全関数が既に定義済みで
-	 * 「まだ何も読み込まれていない状態」を作れないため、事前に関数定義を注入した
-	 * 独立した PHP プロセスで template-tags-config.php を読み込ませて検証する。
-	 *
-	 * When another plugin (e.g. VK Post Author Display) bundling an older copy of the same
-	 * shared package (package/template-tags.php) loads before ExUnit, vk_get_post_type()
-	 * becomes already defined. The old file-level guard
-	 * (`if ( ! function_exists( 'vk_get_post_type' ) )`) then skipped loading ExUnit's own
-	 * package/template-tags.php entirely, leaving newer functions absent from the other
-	 * plugin's older copy (e.g. vk_the_taxonomy_check_list()) undefined and causing a fatal
-	 * error (Issue #1450).
-	 *
-	 * Because every function in ExUnit is already defined inside the test process, there is
-	 * no way to reproduce a "nothing loaded yet" state there. This test instead loads
-	 * template-tags-config.php in an isolated PHP process with pre-defined stub functions,
-	 * to reproduce the third-party load order.
+	 * @see inc/template-tags/template-tags-config.php
+	 * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1450
 	 */
 	public function test_template_tags_config_include_guard() {
+
+		// exec() が disable_functions 等で無効な実行環境（phpdbg 経由の実行を含む）では
+		// このテストの前提が成立しないため、失敗ではなくスキップとして扱う。
+		// On environments where exec() is disabled (e.g. via disable_functions, or when
+		// running under phpdbg), the premise of this test cannot hold, so skip rather than fail.
+		if ( ! function_exists( 'exec' ) ) {
+			$this->markTestSkipped( 'exec() が無効なためスキップ' );
+		}
 
 		$config_path = VEU_DIRECTORY_PATH . '/inc/template-tags/template-tags-config.php';
 
@@ -873,23 +863,35 @@ class TemplateTagsTest extends WP_UnitTestCase {
 			// and system calls (which exists to protect production request handling) is
 			// intentionally bypassed here.
 			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_export, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec, WordPress.WP.AlternativeFunctions.unlink_unlink
+
+			// 子プロセス側は "[RESULT:YES]" / "[RESULT:NO]" のマーカー付きで結果を出力する。
+			// 警告・Deprecated 等が標準エラーに1行でも混ざると完全一致比較は容易に壊れるため、
+			// 親側は完全一致ではなくこのマーカーの包含判定で結果を見る。
+			// The child process emits its result wrapped in a "[RESULT:YES]" / "[RESULT:NO]"
+			// marker. Since even a single warning/deprecated notice on stderr would break an
+			// exact-match comparison, the parent checks for this marker's presence instead.
 			$script  = '<?php' . PHP_EOL;
 			$script .= $case['prelude'] . PHP_EOL;
 			$script .= 'require ' . var_export( $config_path, true ) . ';' . PHP_EOL;
-			$script .= 'echo function_exists( "vk_the_taxonomy_check_list" ) ? "YES" : "NO";' . PHP_EOL;
+			$script .= 'echo "[RESULT:" . ( function_exists( "vk_the_taxonomy_check_list" ) ? "YES" : "NO" ) . "]";' . PHP_EOL;
 
 			$script_path = tempnam( sys_get_temp_dir(), 'veu-template-tags-config-' );
-			file_put_contents( $script_path, $script );
+			$this->assertNotFalse( $script_path, $case['test_condition_name'] . ' / tempnam() が一時ファイルパスの発行に失敗しました' );
 
-			$output    = array();
-			$exit_code = 0;
-			exec( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $script_path ) . ' 2>&1', $output, $exit_code );
+			$write_result = file_put_contents( $script_path, $script );
+			$this->assertNotFalse( $write_result, $case['test_condition_name'] . ' / file_put_contents() が一時スクリプトの書き込みに失敗しました' );
 
-			unlink( $script_path );
+			try {
+				$output    = array();
+				$exit_code = 0;
+				exec( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $script_path ) . ' 2>&1', $output, $exit_code );
+
+				$this->assertSame( 0, $exit_code, $case['test_condition_name'] . ' / stderr: ' . implode( PHP_EOL, $output ) );
+				$this->assertStringContainsString( '[RESULT:YES]', implode( PHP_EOL, $output ), $case['test_condition_name'] );
+			} finally {
+				unlink( $script_path );
+			}
 			// phpcs:enable
-
-			$this->assertSame( 0, $exit_code, $case['test_condition_name'] . ' / stderr: ' . implode( PHP_EOL, $output ) );
-			$this->assertSame( 'YES', implode( '', $output ), $case['test_condition_name'] );
 		}
 	}
 }

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -804,4 +804,92 @@ class TemplateTagsTest extends WP_UnitTestCase {
 		$this->assertTrue( $taxonomy->hierarchical );
 		$this->assertTrue( $taxonomy->show_in_rest );
 	}
+
+	/**
+	 * Regression test for the include guard in inc/template-tags/template-tags-config.php.
+	 * template-tags-config.php の読み込みガードに関する回帰テスト。
+	 *
+	 * VK Post Author Display 等、同じ共有パッケージ（package/template-tags.php）の
+	 * 古いコピーを同梱する他プラグインが ExUnit より先に読み込まれると、
+	 * vk_get_post_type() が既に定義済みになる。かつてはそれをファイル単位のガード
+	 * （`if ( ! function_exists( 'vk_get_post_type' ) )`）に使っていたため、
+	 * package/template-tags.php 自体が丸ごと読み込まれず、他プラグインの古いコピーに
+	 * 存在しない新しい関数（vk_the_taxonomy_check_list() 等）が未定義のまま
+	 * 致命的エラーになっていた（Issue #1450）。
+	 *
+	 * このテストは、テストプロセス内では ExUnit の全関数が既に定義済みで
+	 * 「まだ何も読み込まれていない状態」を作れないため、事前に関数定義を注入した
+	 * 独立した PHP プロセスで template-tags-config.php を読み込ませて検証する。
+	 *
+	 * When another plugin (e.g. VK Post Author Display) bundling an older copy of the same
+	 * shared package (package/template-tags.php) loads before ExUnit, vk_get_post_type()
+	 * becomes already defined. The old file-level guard
+	 * (`if ( ! function_exists( 'vk_get_post_type' ) )`) then skipped loading ExUnit's own
+	 * package/template-tags.php entirely, leaving newer functions absent from the other
+	 * plugin's older copy (e.g. vk_the_taxonomy_check_list()) undefined and causing a fatal
+	 * error (Issue #1450).
+	 *
+	 * Because every function in ExUnit is already defined inside the test process, there is
+	 * no way to reproduce a "nothing loaded yet" state there. This test instead loads
+	 * template-tags-config.php in an isolated PHP process with pre-defined stub functions,
+	 * to reproduce the third-party load order.
+	 */
+	public function test_template_tags_config_include_guard() {
+
+		$config_path = VEU_DIRECTORY_PATH . '/inc/template-tags/template-tags-config.php';
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '何も事前定義されていない通常の読み込み => vk_the_taxonomy_check_list() が定義される（正常系）',
+				'prelude'             => '',
+			),
+			array(
+				'test_condition_name' => 'ExUnit 自身の関数が既に全て定義済みの二重読み込み => 再宣言エラーにならず vk_the_taxonomy_check_list() が定義されたまま（正常系）',
+				// var_export() はデバッグ出力ではなく、生成する一時 PHP スクリプト内に埋め込むための
+				// リテラルなファイルパス文字列を組み立てるために使用している。
+				// var_export() here is not debug output; it builds a literal file path string to
+				// embed inside the generated temporary PHP script.
+				'prelude'             => 'require ' . var_export( VEU_DIRECTORY_PATH . '/inc/template-tags/package/template-tags.php', true ) . ';', // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			),
+			array(
+				'test_condition_name' => '他プラグイン同梱の共有パッケージの古いコピー相当（vk_get_post_type() のみ先に定義）が読み込まれた場合 => vk_the_taxonomy_check_list() が定義される（Issue #1450 の境界値）',
+				'prelude'             => 'function vk_get_post_type() { return array( "slug" => "stub" ); }',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			// 各ケースを独立した PHP プロセスで実行し、テストプロセス側で既に定義済みの
+			// 関数群の影響を受けずに「まだ何も読み込まれていない状態」を再現する。
+			// Run each case in an isolated PHP process so it is unaffected by functions
+			// already defined in the test process, reproducing a "nothing loaded yet" state.
+			//
+			// このブロックはテスト実行用の一時 PHP スクリプトをローカルファイルシステムに
+			// 書き出して CLI 実行するためのもので、WordPress のリクエスト処理経路では
+			// 使われないため、WP_Filesystem や wp_delete_file() 等の代替を必須にする
+			// WordPress 標準の直接ファイル操作／システムコール制限を意図的に無視する。
+			// This block writes a temporary PHP script to the local filesystem and runs it
+			// via CLI purely for test isolation; it is never reached through a WordPress
+			// request, so the WordPress-standard restriction against direct file operations
+			// and system calls (which exists to protect production request handling) is
+			// intentionally bypassed here.
+			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_export, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec, WordPress.WP.AlternativeFunctions.unlink_unlink
+			$script  = '<?php' . PHP_EOL;
+			$script .= $case['prelude'] . PHP_EOL;
+			$script .= 'require ' . var_export( $config_path, true ) . ';' . PHP_EOL;
+			$script .= 'echo function_exists( "vk_the_taxonomy_check_list" ) ? "YES" : "NO";' . PHP_EOL;
+
+			$script_path = tempnam( sys_get_temp_dir(), 'veu-template-tags-config-' );
+			file_put_contents( $script_path, $script );
+
+			$output    = array();
+			$exit_code = 0;
+			exec( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $script_path ) . ' 2>&1', $output, $exit_code );
+
+			unlink( $script_path );
+			// phpcs:enable
+
+			$this->assertSame( 0, $exit_code, $case['test_condition_name'] . ' / stderr: ' . implode( PHP_EOL, $output ) );
+			$this->assertSame( 'YES', implode( '', $output ), $case['test_condition_name'] );
+		}
+	}
 }


### PR DESCRIPTION
## 概要

VK Post Author Display を有効にした状態で「ExUnit > メイン設定 > HTML サイトマップ」を開くと、画面が真っ白になり致命的エラー（重大なエラー）になる不具合を修正します。

### 何が起きていたか

このプラグインには、複数の VK 製プラグインで共通して使うテンプレートタグ（テーマやプラグインから呼び出せる表示用の関数）をまとめたファイル `inc/template-tags/package/template-tags.php` が同梱されています。**同じファイルの別バージョンのコピーが、他の VK 製プラグインにも同梱されています。**

読み込みの制御はこれまで `inc/template-tags/template-tags-config.php` が行っており、「関数 `vk_get_post_type()`（表示中のページの投稿タイプ名を返す関数）がまだ定義されていなければ読み込む」という**ファイル単位の判定**でした。つまり、他のプラグインが自分の同梱コピーを先に読み込んでいると、ExUnit 側のファイルは**丸ごと読み込まれません**。

ここで読み込み順が問題になります。

| プラグイン | 共通ファイルを読み込むタイミング |
|---|---|
| VK Post Author Display | プラグイン本体の読み込み時（即時） |
| VK All in One Expansion Unit（本プラグイン） | `after_setup_theme`（テーマ読み込み後に走る WordPress の処理タイミング）の優先度 0 |

本プラグインの方が必ず後になるため、両方を有効にしていると **常に VK Post Author Display 側の古いコピーが採用されます**。その古いコピーには、9.121.0 の #1448（HTML サイトマップから特定のタクソノミーを除外する設定を追加した対応）で新しく追加した `vk_the_taxonomy_check_list()`（設定画面のタクソノミー除外チェックボックス一覧を描画する関数）が存在しません。結果として、設定画面がその未定義の関数を呼び出して致命的エラーになっていました。

### 修正内容

`inc/template-tags/template-tags-config.php` のファイル単位の判定を撤去し、共通ファイルを**常に読み込む**ようにしました。

共通ファイル内の関数はすべて個別に「同名の関数がまだ無ければ定義する」という判定（`function_exists()`）で囲まれているため、他のプラグインが先に読み込んでいても関数の再定義エラーは起きません。既に定義済みの関数はそのまま使われ、**相手側のコピーに存在しない新しい関数だけが補われます。** 併せて、読み込みパスを実行ファイルの位置起点（`__DIR__`）に統一しました。

これにより、他プラグインが同梱するコピーのバージョンに関係なく、本プラグインが必要とする関数が必ず利用できる状態になります。

### 検証済みの前提

- 共通ファイル内の関数定義15個すべてが個別判定で囲まれていること
- 同ファイルに、二重読み込みで副作用が出るトップレベル処理（フックの登録・定数定義・即時実行）が無いこと

## テスト

`tests/test-template-tags.php` に回帰テスト（`test_template_tags_config_include_guard`）を追加しました。PHPUnit のプロセス内では本プラグインの関数がすべて定義済みで「他プラグインが先に読み込んだ状態」を再現できないため、独立した PHP プロセスを起動し、`vk_get_post_type()` だけを先に定義した状態で読み込み処理を実行する形にしています。

- 修正前のコードでは、この状態で `vk_the_taxonomy_check_list()` が未定義になることを確認済み（不具合を実際に捕まえるテストです）
- PHPUnit 全体: 129 tests, 944 assertions, OK
- PHPCS: 変更・追加箇所に新規エラーなし

## 確認手順

### 前提条件

- プラグイン「VK Post Author Display」をインストールし、有効化しておく
- 本プラグイン（VK All in One Expansion Unit）も有効化しておく

### 手順

#### Before（修正前の再現手順）

1. 管理画面 > ExUnit > メイン設定 を開く
2. ページ内の「HTML サイトマップ」設定までスクロールする
   → ✗ ページが表示されず「重大なエラーが発生しました」または白い画面になる

#### After（修正後）

1. 管理画面 > ExUnit > メイン設定 を開く
   → ✓ エラーにならず、ページが最後まで表示される
2. 「HTML サイトマップ」設定の「サイトマップに出力しないタクソノミー」の項目を見る
   → ✓ タクソノミーのチェックボックス一覧（対象が無い場合は「除外できるタクソノミーがありません」の文言）が表示される
3. チェックを1つ入れて設定を保存する
   → ✓ 保存後もチェック状態が保持される
4. VK Post Author Display を停止し、同じ画面を開く
   → ✓ これまでどおり正常に表示される（デグレしていない）

## スクリーンショット

管理画面の表示に関わる変更のため、Before / After のスクリーンショットは UI テスト担当（麗美）の確認時に追記します。

Closes #1450

@coderabbitai ignore

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/754