### PR TITLE
[ セキュリティ修正 ][ CTA ] CTA の保存処理と管理画面出力に多層防御を追加

### DIFF
--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -205,10 +205,18 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 				// This value is a scalar string submitted from a single <select>. Guard with isset to avoid an "Undefined array key" warning when it is missing, and sanitize the unslashed value with map_deep() ( map_deep applies the callback to scalars as well ).
 				$data = isset( $_POST['vkexunit_cta_each_option'] ) ? map_deep( wp_unslash( $_POST['vkexunit_cta_each_option'] ), 'sanitize_text_field' ) : '';
 
+				// add_post_meta()/update_post_meta() は内部で必ず wp_unslash() するため（expected_slashed）、
+				// 上ですでに wp_unslash() 済みの $data をそのまま渡すと二重に unslash される。
+				// 実データ（投稿ID / 'random' / 'disable'）にバックスラッシュは含まれないため実害は無いが、
+				// 下の cta_content 分岐と揃えるため wp_slash() で相殺しておく。
+				// add_post_meta()/update_post_meta() always run wp_unslash() internally ( expected_slashed ),
+				// so passing the already wp_unslash()'d $data as is would unslash it twice. Real values
+				// ( a post ID / 'random' / 'disable' ) never contain backslashes so there is no real-world
+				// impact, but wp_slash() it here to keep this consistent with the cta_content branch below.
 				if ( get_post_meta( $post_id, 'vkexunit_cta_each_option' ) == '' ) {
-					add_post_meta( $post_id, 'vkexunit_cta_each_option', $data, true );
+					add_post_meta( $post_id, 'vkexunit_cta_each_option', wp_slash( $data ), true );
 				} elseif ( get_post_meta( $post_id, 'vkexunit_cta_each_option', true ) !== $data ) {
-					update_post_meta( $post_id, 'vkexunit_cta_each_option', $data );
+					update_post_meta( $post_id, 'vkexunit_cta_each_option', wp_slash( $data ) );
 				} elseif ( ! $data ) {
 					delete_post_meta( $post_id, 'vkexunit_cta_each_option', get_post_meta( $post_id, 'vkexunit_cta_each_option', true ) );
 				}
@@ -218,7 +226,13 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 				// カスタムフィールドの設定.
 				$custom_fields = array(
 					'vkExUnit_cta_use_type'           => array(
-						'escape_type' => '',
+						// REST 経路 ( inc/block-editor-panels/enqueue.php ) は同じメタキーに sanitize_text_field を
+						// 掛けているため、クラシック保存経路でも揃えて防御レベルを一致させる。
+						// 値は 'veu_cta_normal' か空のみのため挙動は変わらない。
+						// The REST path ( inc/block-editor-panels/enqueue.php ) runs sanitize_text_field on the
+						// same meta key, so apply it here too to keep the defense level consistent across paths.
+						// The value is only 'veu_cta_normal' or empty, so behavior is unchanged.
+						'escape_type' => 'sanitize_text_field',
 					),
 					'vkExUnit_cta_img'                => array(
 						// 画像フィールドはアタッチメントIDを保持するため、整数化した上で文字列にキャストして保存する。
@@ -263,7 +277,9 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						'escape_type' => 'esc_url',
 					),
 					'vkExUnit_cta_url_blank'          => array(
-						'escape_type' => '',
+						// 上の vkExUnit_cta_use_type と同じ理由で sanitize_text_field を掛ける.
+						// Same reason as vkExUnit_cta_use_type above: run sanitize_text_field.
+						'escape_type' => 'sanitize_text_field',
 					),
 					'vkExUnit_cta_text'               => array(
 						// stripslashes は wp_unslash() と役割が重複するため付けない ( 上の vkExUnit_cta_button_text と同じ理由 ).
@@ -276,6 +292,15 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 				foreach ( $custom_fields as $custom_field_name => $custom_field_options ) {
 					$data = '';
 					if ( isset( $_POST[ $custom_field_name ] ) ) {
+						// 配列などスカラー以外が送信された場合、esc_url() 等のエスケープ関数へ渡すと
+						// TypeError で致命的エラーになる ( sanitize_image_position() と同じ発想のガード )。
+						// このフィールドの保存だけをスキップし、他のフィールドの保存は継続する。
+						// If a non-scalar value ( e.g. an array ) is submitted, passing it to escaping
+						// functions like esc_url() would throw a fatal TypeError ( same guard idea as
+						// sanitize_image_position() ). Skip saving only this field; other fields still save.
+						if ( ! is_scalar( $_POST[ $custom_field_name ] ) ) {
+							continue;
+						}
 						if ( ! empty( $custom_field_options['escape_type'] ) ) {
 							if ( is_array( $custom_field_options['escape_type'] ) ) {
 								// エスケープ処理が複数ある場合
@@ -422,13 +447,8 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 	<td>
 			<?php
 			$target_blank = get_post_meta( get_the_id(), 'vkExUnit_cta_use_type', true );
-			if ( 'veu_cta_normal' === $target_blank ) {
-				$checked = ' checked';
-			} else {
-				$checked = '';
-			}
 			?>
-	<input type="checkbox" id="vkExUnit_cta_use_type" name="vkExUnit_cta_use_type" value="veu_cta_normal"<?php echo esc_attr( $checked ); ?> />
+	<input type="checkbox" id="vkExUnit_cta_use_type" name="vkExUnit_cta_use_type" value="veu_cta_normal"<?php checked( $target_blank, 'veu_cta_normal' ); ?> />
 	<label for="vkExUnit_cta_use_type"><?php _e( 'Use following data (Do not use content data)', 'vk-all-in-one-expansion-unit' ); ?></label>
 	</td>
 	</tr>
@@ -457,7 +477,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 	</td></tr>
 	<tr><th>
 	<label for="vkExUnit_cta_button_text"><?php _e( 'Button text', 'vk-all-in-one-expansion-unit' ); ?></label></th><td>
-	<input type="text" name="vkExUnit_cta_button_text" id="vkExUnit_cta_button_text" value="<?php echo esc_html( get_post_meta( get_the_id(), 'vkExUnit_cta_button_text', true ) ); ?>" />
+	<input type="text" name="vkExUnit_cta_button_text" id="vkExUnit_cta_button_text" value="<?php echo esc_attr( get_post_meta( get_the_id(), 'vkExUnit_cta_button_text', true ) ); ?>" />
 	</td></tr>
 	<tr><th>
 	<label for="vkExUnit_cta_button_icon"><?php _e( 'Button icon', 'vk-all-in-one-expansion-unit' ); ?></label></th>
@@ -490,14 +510,9 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 
 			<?php
 			$target_blank = get_post_meta( get_the_id(), 'vkExUnit_cta_url_blank', true );
-			if ( $target_blank == 'window_self' ) {
-				$checked = ' checked';
-			} else {
-				$checked = '';
-			}
 			?>
 	<label for="vkExUnit_cta_url_blank"><?php _e( 'Target window', 'vk-all-in-one-expansion-unit' ); ?></label></th><td>
-<input type="checkbox" id="vkExUnit_cta_url_blank" name="vkExUnit_cta_url_blank" value="window_self"<?php echo esc_attr( $checked ); ?> />
+<input type="checkbox" id="vkExUnit_cta_url_blank" name="vkExUnit_cta_url_blank" value="window_self"<?php checked( $target_blank, 'window_self' ); ?> />
 <label for="vkExUnit_cta_url_blank"><?php _e( 'Open in a self window', 'vk-all-in-one-expansion-unit' ); ?></label>
 </td></tr>
 <tr><th><label for="vkExUnit_cta_text"><?php _e( 'Text message', 'vk-all-in-one-expansion-unit' ); ?>

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -191,6 +191,14 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 				return $post_id;
 			}
 
+			// nonce 検証だけでは CSRF は防げても権限の無いユーザーによる保存は防げないため、
+			// 投稿の編集権限があるかどうかを確認する（多層防御）。
+			// nonce verification alone does not prevent a user without edit permission from saving,
+			// so also confirm the current user can edit this post ( defense in depth ).
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				return $post_id;
+			}
+
 			if ( 'cta_number' === $_POST['_vkExUnit_cta_switch'] ) {
 				// この値は単一 select から送信されるスカラー文字列。未送信時の Undefined array key 警告を防ぐため isset で判定し、
 				// map_deep() で wp_unslash 後の値をサニタイズする（map_deep はスカラーにもコールバックを適用する）。
@@ -235,7 +243,12 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						},
 					),
 					'vkExUnit_cta_button_text'        => array(
-						'escape_type' => array( 'stripslashes', 'wp_kses_post' ),
+						// stripslashes は wp_unslash() と役割が重複するため付けない
+						// ( 保存ループ側で $_POST の値に wp_unslash() を適用済み。二重にスラッシュ除去すると
+						// 意図したバックスラッシュまで消えてしまう ).
+						// Do not add stripslashes here; it duplicates wp_unslash() ( already applied to the
+						// $_POST value in the save loop ). Running both would strip backslashes twice.
+						'escape_type' => 'wp_kses_post',
 					),
 					'vkExUnit_cta_button_icon'        => array(
 						'escape_type' => 'wp_kses_post',
@@ -253,7 +266,9 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						'escape_type' => '',
 					),
 					'vkExUnit_cta_text'               => array(
-						'escape_type' => array( 'stripslashes', 'wp_kses_post' ),
+						// stripslashes は wp_unslash() と役割が重複するため付けない ( 上の vkExUnit_cta_button_text と同じ理由 ).
+						// Do not add stripslashes here; it duplicates wp_unslash() ( same reason as vkExUnit_cta_button_text above ).
+						'escape_type' => 'wp_kses_post',
 					),
 				);
 
@@ -264,26 +279,44 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 						if ( ! empty( $custom_field_options['escape_type'] ) ) {
 							if ( is_array( $custom_field_options['escape_type'] ) ) {
 								// エスケープ処理が複数ある場合
-								$data = $_POST[ $custom_field_name ];
+								// WordPress は magic quotes 互換のため $_POST の値にスラッシュを付加して渡してくるので、
+								// エスケープ処理へ渡す前に wp_unslash() で除去する.
+								// WordPress adds slashes to $_POST values for magic-quotes compatibility,
+								// so strip them with wp_unslash() before passing the value to the escape callbacks.
+								$data = wp_unslash( $_POST[ $custom_field_name ] );
 								foreach ( $custom_field_options['escape_type'] as $escape ) {
 									$data = call_user_func( $escape, $data );
 								}
 							} else {
 								// エスケープ処理が一つの場合
-								$data = call_user_func( $custom_field_options['escape_type'], $_POST[ $custom_field_name ] );
+								// 同上の理由で wp_unslash() を通してからエスケープする.
+								// Same reason as above: unslash before escaping.
+								$data = call_user_func( $custom_field_options['escape_type'], wp_unslash( $_POST[ $custom_field_name ] ) );
 							}
 						} else {
 							// エスケープ処理が無い場合
-							$data = $_POST[ $custom_field_name ];
+							// エスケープ関数を通さないフィールドも、保存前に wp_unslash() で余分なスラッシュを除去する.
+							// Fields without an escape callback also need wp_unslash() to remove the extra slashes before saving.
+							$data = wp_unslash( $_POST[ $custom_field_name ] );
 						}
 					}
 
 					if ( get_post_meta( $post_id, $custom_field_name ) == '' ) {
 						// データが今までなかったらカスタムフィールドに新規保存
-						add_post_meta( $post_id, $custom_field_name, $data, true );
+						// add_post_meta()/update_post_meta() は「スラッシュ付きの値を受け取り、内部で wp_unslash() する」仕様
+						// ( expected_slashed ) のため、上で既にサニタイズ済みの $data をそのまま渡すと
+						// ここでもう一度スラッシュが除去され、値に含まれる本物のバックスラッシュが消えてしまう。
+						// そのため保存直前に wp_slash() で相殺し、$data の中身がそのまま保存されるようにする。
+						// add_post_meta()/update_post_meta() expect a slashed value and call wp_unslash() on it
+						// internally ( expected_slashed ). Passing the already-sanitized $data as is would strip
+						// slashes a second time and corrupt genuine backslashes in the value, so wp_slash() it
+						// right before saving to cancel that out and store $data unchanged.
+						add_post_meta( $post_id, $custom_field_name, wp_slash( $data ), true );
 					} elseif ( $data != get_post_meta( $post_id, $custom_field_name, true ) ) {
 						// 保存されてたデータと送信されてきたデータが違ったら更新
-						update_post_meta( $post_id, $custom_field_name, $data );
+						// 上記と同じ理由で wp_slash() を通してから渡す.
+						// Same reason as above: wp_slash() before passing it in.
+						update_post_meta( $post_id, $custom_field_name, wp_slash( $data ) );
 					} elseif ( ! $data ) {
 						// データが送信されてこなかった（空のデータが送られてきた）らフィールドの値を削除
 						delete_post_meta( $post_id, $custom_field_name, get_post_meta( $post_id, $custom_field_name, true ) );
@@ -320,7 +353,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 
 		public static function render_meta_box_cta() {
 
-			echo '<input type="hidden" name="_nonce_vkExUnit_custom_cta" id="_nonce_vkExUnit__custom_field_metaKeyword" value="' . wp_create_nonce( plugin_basename( __FILE__ ) ) . '" />';
+			echo '<input type="hidden" name="_nonce_vkExUnit_custom_cta" id="_nonce_vkExUnit__custom_field_metaKeyword" value="' . esc_attr( wp_create_nonce( plugin_basename( __FILE__ ) ) ) . '" />';
 			$imgid          = get_post_meta( get_the_id(), 'vkExUnit_cta_img', true );
 			$cta_image      = wp_get_attachment_image_src( $imgid, 'large' );
 			$image_position = get_post_meta( get_the_id(), 'vkExUnit_cta_img_position', true );
@@ -404,7 +437,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 	<th><?php esc_html_e( 'CTA image', 'vk-all-in-one-expansion-unit' ); ?></th>
 	<td>
 		<div id="cta-thumbnail_box" >
-		<img id="cta-thumbnail_image" src="<?php echo ( $cta_image ) ? $cta_image[0] : ''; ?>" class="<?php echo ( $cta_image ) ? '' : 'noimage'; ?>" />
+		<img id="cta-thumbnail_image" src="<?php echo esc_url( ( $cta_image ) ? $cta_image[0] : '' ); ?>" class="<?php echo ( $cta_image ) ? '' : 'noimage'; ?>" />
 		</div>
 		<div id="cta-thumbnail_control" class="<?php echo ( $cta_image ) ? 'change' : 'add'; ?>">
 		<button id="media_thumb_url_add" class="cta-media_btn button button-default"><?php _e( 'Add image', 'vk-all-in-one-expansion-unit' ); ?></button>
@@ -443,7 +476,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 
 			<?php
 			if ( class_exists( 'Vk_Font_Awesome_Versions' ) ) {
-				echo Vk_Font_Awesome_Versions::ex_and_link();
+				echo wp_kses_post( Vk_Font_Awesome_Versions::ex_and_link() );
 			}
 			?>
 
@@ -464,7 +497,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			}
 			?>
 	<label for="vkExUnit_cta_url_blank"><?php _e( 'Target window', 'vk-all-in-one-expansion-unit' ); ?></label></th><td>
-<input type="checkbox" id="vkExUnit_cta_url_blank" name="vkExUnit_cta_url_blank" value="window_self"<?php echo $checked; ?> />
+<input type="checkbox" id="vkExUnit_cta_url_blank" name="vkExUnit_cta_url_blank" value="window_self"<?php echo esc_attr( $checked ); ?> />
 <label for="vkExUnit_cta_url_blank"><?php _e( 'Open in a self window', 'vk-all-in-one-expansion-unit' ); ?></label>
 </td></tr>
 <tr><th><label for="vkExUnit_cta_text"><?php _e( 'Text message', 'vk-all-in-one-expansion-unit' ); ?>
@@ -473,7 +506,7 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 <textarea name="vkExUnit_cta_text" id="vkExUnit_cta_text" rows="10em" cols="50em"><?php echo wp_kses_post( get_post_meta( get_the_id(), 'vkExUnit_cta_text', true ) ); ?></textarea>
 </td></tr>
 </table>
-<a href="<?php echo admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ); ?>" class="button button-default" target="_blank"><?php _e( 'CTA setting', 'vk-all-in-one-expansion-unit' ); ?></a>
+<a href="<?php echo esc_url( admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ) ); ?>" class="button button-default" target="_blank"><?php _e( 'CTA setting', 'vk-all-in-one-expansion-unit' ); ?></a>
 			<?php
 		}
 
@@ -847,24 +880,6 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			// 文字のハイライトによる mark タグへの style 属性やグループブロックの背景画像指定の style 属性が削除されるため wp_kses は通していない
 			// https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1172
 			return $content;
-		}
-
-		public static function allow_custom_iframes( $tags, $context ) {
-			if ( $context ) {
-				$tags['iframe'] = array(
-					'src'             => true,
-					'width'           => true,
-					'height'          => true,
-					'style'           => true,
-					'allowfullscreen' => true,
-					'loading'         => true,
-					'sandbox'         => true,
-				);
-				$tags['style']  = array(
-					'type' => true,
-				);
-			}
-			return $tags;
 		}
 	}
 

--- a/inc/call-to-action/package/widget-call-to-action.php
+++ b/inc/call-to-action/package/widget-call-to-action.php
@@ -84,18 +84,18 @@ class Widget_CTA extends \WP_Widget {
 		);
 		?>
 <input type="hidden" name="_vkExUnit_cta_switch" value="cta_number" />
-<select name="<?php echo $this->get_field_name( 'id' ); ?>" style="width: 100%" >
+<select name="<?php echo esc_attr( $this->get_field_name( 'id' ) ); ?>" style="width: 100%" >
 <option value="">[ <?php _e( 'Please select', $vk_call_to_action_textdomain ); ?> ]</option>
 		<?php foreach ( $ctas as $cta ) : ?>
-	<option value="<?php echo $cta['key']; ?>" <?php echo( $value == $cta['key'] ) ? 'selected' : ''; ?> ><?php echo $cta['label']; ?></option>
+	<option value="<?php echo esc_attr( $cta['key'] ); ?>" <?php echo( $value == $cta['key'] ) ? 'selected' : ''; ?> ><?php echo esc_html( $cta['label'] ); ?></option>
 <?php endforeach; ?>
 </select>
 </div>
 <div style="padding-bottom: 1em;">
-<a href="<?php echo admin_url( 'edit.php?post_type=cta' ); ?>" class="button button-default" target="_blank">
+<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=cta' ) ); ?>" class="button button-default" target="_blank">
 		<?php _e( 'Show CTA index page', $vk_call_to_action_textdomain ); ?>
 </a>
-<a href="<?php echo admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ); ?>" class="button button-default" target="_blank">
+<a href="<?php echo esc_url( admin_url( 'admin.php?page=vkExUnit_main_setting#vkExUnit_cta_settings' ) ); ?>" class="button button-default" target="_blank">
 		<?php _e( 'CTA setting', $vk_call_to_action_textdomain ); ?>
 </a>
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ e.g.
 == Changelog ==
 
 [ Bug Fix ][ Block ] Fixed the Share Button, HTML Sitemap and other blocks showing "This block has encountered an error and cannot be previewed" in the editor when the post contains a cross-origin iframe embed.
+[ Security Fix ][ CTA ] Added a permission check on save and strengthened output escaping on the classic edit screen as defense-in-depth hardening.
 
 = 9.121.1 =
 [ Bug Fix ][ HTML Sitemap ] Fixed a fatal error on the HTML Sitemap settings screen when used together with plugins that bundle an older copy of the shared template tag package (e.g. VK Post Author Display).

--- a/tests/test-cta-output-escaping.php
+++ b/tests/test-cta-output-escaping.php
@@ -337,6 +337,17 @@ class CTAOutputEscapingTest extends WP_UnitTestCase {
 	public function test_save_custom_field() {
 		$cta_id = $this->create_classic_cta();
 
+		// save_custom_field() は edit_post 権限を要求するため、管理者としてログインする
+		// ( issue #1437 で追加された多層防御チェック ).
+		// wp_create_nonce() はログイン中のユーザーIDに紐づくため、必ず nonce を発行する前に
+		// ログインを済ませておく（順序を逆にすると nonce が別ユーザー扱いになり検証に失敗する）.
+		// save_custom_field() requires edit_post capability, so log in as an administrator
+		// ( the defense-in-depth check added in issue #1437 ). wp_create_nonce() ties the nonce
+		// to the currently logged-in user, so the login must happen before the nonce is created
+		// ( doing it in the other order makes the nonce belong to a different user and fail verification ).
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
 		// save_custom_field() が要求する nonce を作成する。
 		// Create the nonce required by save_custom_field().
 		$reflection = new ReflectionClass( 'Vk_Call_To_Action' );

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -16,6 +16,9 @@ class CTATest extends WP_UnitTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		$_POST = array();
+		// テストごとにログインユーザー状態をリセットする（未ログイン状態に戻す）.
+		// Reset the logged-in user state after each test ( back to logged out ).
+		wp_set_current_user( 0 );
 	}
 
 	/**
@@ -81,6 +84,21 @@ class CTATest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Create an administrator user and switch the current user to it.
+	 * save_custom_field() が要求する edit_post 権限を満たすため、管理者ユーザーを作成しログイン状態にする.
+	 *
+	 * Creates an administrator and makes them the current user, so save_custom_field()'s
+	 * current_user_can( 'edit_post', $post_id ) check passes.
+	 *
+	 * @return int 作成した管理者ユーザーのID / Created administrator user ID.
+	 */
+	private function login_as_editor() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		return $admin_id;
+	}
+
+	/**
 	 * save_custom_field() should bail when CTA switch isn't provided.
 	 */
 	public function test_save_custom_field_requires_switch() {
@@ -115,6 +133,9 @@ class CTATest extends WP_UnitTestCase {
 				'post_content' => 'content',
 			)
 		);
+		// save_custom_field() は edit_post 権限を要求するため、管理者としてログインする.
+		// save_custom_field() requires edit_post capability, so log in as an administrator.
+		$this->login_as_editor();
 
 		$_POST = array(
 			'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
@@ -155,6 +176,9 @@ class CTATest extends WP_UnitTestCase {
 				'post_content' => 'content',
 			)
 		);
+		// save_custom_field() は edit_post 権限を要求するため、管理者としてログインする.
+		// save_custom_field() requires edit_post capability, so log in as an administrator.
+		$this->login_as_editor();
 
 		$raw_button_text = "Click <script>alert(1)</script> O\\'Clock";
 		$raw_cta_text    = "Line 1\\nLine 2<script>alert(2)</script>";
@@ -260,6 +284,131 @@ class CTATest extends WP_UnitTestCase {
 				get_post_meta( $post_id, $case['field'], true ),
 				$case['name']
 			);
+		}
+	}
+
+	/**
+	 * Save_custom_field の edit_post 権限チェックを検証する.
+	 * 権限が無いユーザーからの保存は拒否され、権限があるユーザーからの保存のみ許可される事を確認する ( issue #1437 項目1 ).
+	 *
+	 * Verify the edit_post capability check in save_custom_field().
+	 * Saving must be rejected without the capability and allowed with it ( issue #1437 item 1 ).
+	 */
+	public function test_save_custom_field_requires_edit_post_capability() {
+		$test_cases = array(
+			array(
+				'test_condition_name' => '権限の無いユーザー（購読者）の場合 => 保存されず post_id が返る',
+				'role'                => 'subscriber',
+				'expected_saved'      => false,
+			),
+			array(
+				'test_condition_name' => '権限のあるユーザー（管理者）の場合 => 保存され post_id が返る',
+				'role'                => 'administrator',
+				'expected_saved'      => true,
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_type'    => Vk_Call_To_Action::POST_TYPE,
+					'post_status'  => 'publish',
+					'post_title'   => 'CTA Capability Test',
+					'post_content' => 'content',
+				)
+			);
+			$user_id = self::factory()->user->create( array( 'role' => $case['role'] ) );
+			wp_set_current_user( $user_id );
+
+			$_POST = array(
+				'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
+				'_vkExUnit_cta_switch'       => 'cta_content',
+				'vkExUnit_cta_button_text'   => 'Save attempt',
+			);
+
+			$return = Vk_Call_To_Action::save_custom_field( $post_id );
+
+			// 権限の有無にかかわらず post_id は返り値として返る仕様のため、まず共通で検証する.
+			// The return value is always $post_id regardless of permission, so assert that first.
+			$this->assertSame( $post_id, $return, $case['test_condition_name'] );
+
+			if ( $case['expected_saved'] ) {
+				$this->assertSame(
+					wp_kses_post( 'Save attempt' ),
+					get_post_meta( $post_id, 'vkExUnit_cta_button_text', true ),
+					$case['test_condition_name']
+				);
+			} else {
+				$this->assertEmpty(
+					get_post_meta( $post_id, 'vkExUnit_cta_button_text' ),
+					$case['test_condition_name']
+				);
+			}
+		}
+	}
+
+	/**
+	 * Save_custom_field が $_POST の値を二重にスラッシュ除去しない事を検証する ( issue #1437 項目2 ).
+	 * バックスラッシュを含む値が「escape 無し」「単一 escape」のどちらの分岐でも1回だけ除去され、
+	 * 期待どおりのバックスラッシュ数で保存される事を確認する.
+	 *
+	 * Verify that save_custom_field() does not strip slashes from a $_POST value twice
+	 * ( issue #1437 item 2 ). A value containing backslashes must be unslashed exactly once
+	 * — for both the "no escape" branch and the "single escape" branch — ending up with the
+	 * expected number of backslashes after saving.
+	 */
+	public function test_save_custom_field_does_not_double_unslash_backslash_values() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => Vk_Call_To_Action::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => 'CTA Backslash Test',
+				'post_content' => 'content',
+			)
+		);
+		$this->login_as_editor();
+
+		// WordPress の magic quotes 互換仕様では、実際の HTTP リクエストで $_POST の値に
+		// スラッシュが1段だけ付加されて渡ってくる。ここではその状態を、実際の1本のバックスラッシュを
+		// 意図した値として二重バックスラッシュ ( \\\\ は実体として2文字 ) で再現する。
+		// 1回だけ unslash されればバックスラッシュは1本残り、二重に unslash されると消えてしまう.
+		// WordPress's magic-quotes-compatible behavior slashes $_POST values by one level in a real
+		// HTTP request. Reproduce that here with a doubled backslash ( \\\\ is 2 real characters )
+		// representing one intended real backslash: it survives as one backslash if unslashed exactly
+		// once, and disappears entirely if unslashed twice.
+		$raw_value = 'Windows path C:\\\\Users\\\\test';
+
+		$field_cases = array(
+			array(
+				'test_condition_name' => 'no-escape フィールド ( vkExUnit_cta_url_blank ) はバックスラッシュが1回だけ除去される',
+				'field'               => 'vkExUnit_cta_url_blank',
+				'expected'            => stripslashes( $raw_value ),
+			),
+			array(
+				'test_condition_name' => 'single-escape フィールド ( vkExUnit_cta_button_text ) はバックスラッシュが1回だけ除去される（二重除去されない）',
+				'field'               => 'vkExUnit_cta_button_text',
+				'expected'            => wp_kses_post( stripslashes( $raw_value ) ),
+			),
+		);
+
+		foreach ( $field_cases as $case ) {
+			$_POST = array(
+				'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
+				'_vkExUnit_cta_switch'       => 'cta_content',
+				$case['field']               => $raw_value,
+			);
+
+			Vk_Call_To_Action::save_custom_field( $post_id );
+
+			$this->assertSame(
+				$case['expected'],
+				get_post_meta( $post_id, $case['field'], true ),
+				$case['test_condition_name']
+			);
+
+			// 次のケースに影響しないようメタを削除する.
+			// Delete the meta so it does not affect the next case.
+			delete_post_meta( $post_id, $case['field'] );
 		}
 	}
 

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -92,7 +92,7 @@ class CTATest extends WP_UnitTestCase {
 	 *
 	 * @return int 作成した管理者ユーザーのID / Created administrator user ID.
 	 */
-	private function login_as_editor() {
+	private function login_as_administrator() {
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
 		return $admin_id;
@@ -135,7 +135,7 @@ class CTATest extends WP_UnitTestCase {
 		);
 		// save_custom_field() は edit_post 権限を要求するため、管理者としてログインする.
 		// save_custom_field() requires edit_post capability, so log in as an administrator.
-		$this->login_as_editor();
+		$this->login_as_administrator();
 
 		$_POST = array(
 			'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
@@ -178,7 +178,7 @@ class CTATest extends WP_UnitTestCase {
 		);
 		// save_custom_field() は edit_post 権限を要求するため、管理者としてログインする.
 		// save_custom_field() requires edit_post capability, so log in as an administrator.
-		$this->login_as_editor();
+		$this->login_as_administrator();
 
 		$raw_button_text = "Click <script>alert(1)</script> O\\'Clock";
 		$raw_cta_text    = "Line 1\\nLine 2<script>alert(2)</script>";
@@ -297,14 +297,42 @@ class CTATest extends WP_UnitTestCase {
 	public function test_save_custom_field_requires_edit_post_capability() {
 		$test_cases = array(
 			array(
-				'test_condition_name' => '権限の無いユーザー（購読者）の場合 => 保存されず post_id が返る',
+				'test_condition_name' => 'cta_content 分岐 / 権限の無いユーザー（購読者）の場合 => 保存されず post_id が返る',
 				'role'                => 'subscriber',
+				'switch'              => 'cta_content',
+				'post_extra'          => array( 'vkExUnit_cta_button_text' => 'Save attempt' ),
+				'meta_key'            => 'vkExUnit_cta_button_text',
 				'expected_saved'      => false,
+				'expected_value'      => null,
 			),
 			array(
-				'test_condition_name' => '権限のあるユーザー（管理者）の場合 => 保存され post_id が返る',
+				'test_condition_name' => 'cta_content 分岐 / 権限のあるユーザー（管理者）の場合 => 保存され post_id が返る',
 				'role'                => 'administrator',
+				'switch'              => 'cta_content',
+				'post_extra'          => array( 'vkExUnit_cta_button_text' => 'Save attempt' ),
+				'meta_key'            => 'vkExUnit_cta_button_text',
 				'expected_saved'      => true,
+				'expected_value'      => wp_kses_post( 'Save attempt' ),
+			),
+			array(
+				// cta_number 分岐 ( サイドバーの表示先ごとの個別指定 ) も同じ権限チェックの対象である事を検証する.
+				// Verify the cta_number branch ( per-post display override ) is covered by the same capability check.
+				'test_condition_name' => 'cta_number 分岐 / 権限の無いユーザー（購読者）の場合 => 保存されず post_id が返る',
+				'role'                => 'subscriber',
+				'switch'              => 'cta_number',
+				'post_extra'          => array( 'vkexunit_cta_each_option' => 'disable' ),
+				'meta_key'            => 'vkexunit_cta_each_option',
+				'expected_saved'      => false,
+				'expected_value'      => null,
+			),
+			array(
+				'test_condition_name' => 'cta_number 分岐 / 権限のあるユーザー（管理者）の場合 => 保存され post_id が返る',
+				'role'                => 'administrator',
+				'switch'              => 'cta_number',
+				'post_extra'          => array( 'vkexunit_cta_each_option' => 'disable' ),
+				'meta_key'            => 'vkexunit_cta_each_option',
+				'expected_saved'      => true,
+				'expected_value'      => 'disable',
 			),
 		);
 
@@ -320,10 +348,12 @@ class CTATest extends WP_UnitTestCase {
 			$user_id = self::factory()->user->create( array( 'role' => $case['role'] ) );
 			wp_set_current_user( $user_id );
 
-			$_POST = array(
-				'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
-				'_vkExUnit_cta_switch'       => 'cta_content',
-				'vkExUnit_cta_button_text'   => 'Save attempt',
+			$_POST = array_merge(
+				array(
+					'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
+					'_vkExUnit_cta_switch'       => $case['switch'],
+				),
+				$case['post_extra']
 			);
 
 			$return = Vk_Call_To_Action::save_custom_field( $post_id );
@@ -334,13 +364,13 @@ class CTATest extends WP_UnitTestCase {
 
 			if ( $case['expected_saved'] ) {
 				$this->assertSame(
-					wp_kses_post( 'Save attempt' ),
-					get_post_meta( $post_id, 'vkExUnit_cta_button_text', true ),
+					$case['expected_value'],
+					get_post_meta( $post_id, $case['meta_key'], true ),
 					$case['test_condition_name']
 				);
 			} else {
 				$this->assertEmpty(
-					get_post_meta( $post_id, 'vkExUnit_cta_button_text' ),
+					get_post_meta( $post_id, $case['meta_key'] ),
 					$case['test_condition_name']
 				);
 			}
@@ -349,13 +379,13 @@ class CTATest extends WP_UnitTestCase {
 
 	/**
 	 * Save_custom_field が $_POST の値を二重にスラッシュ除去しない事を検証する ( issue #1437 項目2 ).
-	 * バックスラッシュを含む値が「escape 無し」「単一 escape」のどちらの分岐でも1回だけ除去され、
+	 * バックスラッシュを含む値が単一 escape の異なる複数フィールドで1回だけ除去され、
 	 * 期待どおりのバックスラッシュ数で保存される事を確認する.
 	 *
 	 * Verify that save_custom_field() does not strip slashes from a $_POST value twice
 	 * ( issue #1437 item 2 ). A value containing backslashes must be unslashed exactly once
-	 * — for both the "no escape" branch and the "single escape" branch — ending up with the
-	 * expected number of backslashes after saving.
+	 * — across multiple single-escape fields — ending up with the expected number of
+	 * backslashes after saving.
 	 */
 	public function test_save_custom_field_does_not_double_unslash_backslash_values() {
 		$post_id = self::factory()->post->create(
@@ -366,7 +396,7 @@ class CTATest extends WP_UnitTestCase {
 				'post_content' => 'content',
 			)
 		);
-		$this->login_as_editor();
+		$this->login_as_administrator();
 
 		// WordPress の magic quotes 互換仕様では、実際の HTTP リクエストで $_POST の値に
 		// スラッシュが1段だけ付加されて渡ってくる。ここではその状態を、実際の1本のバックスラッシュを
@@ -380,12 +410,12 @@ class CTATest extends WP_UnitTestCase {
 
 		$field_cases = array(
 			array(
-				'test_condition_name' => 'no-escape フィールド ( vkExUnit_cta_url_blank ) はバックスラッシュが1回だけ除去される',
+				'test_condition_name' => 'single-escape フィールド ( vkExUnit_cta_url_blank / sanitize_text_field ) はバックスラッシュが1回だけ除去される（二重除去されない）',
 				'field'               => 'vkExUnit_cta_url_blank',
-				'expected'            => stripslashes( $raw_value ),
+				'expected'            => sanitize_text_field( stripslashes( $raw_value ) ),
 			),
 			array(
-				'test_condition_name' => 'single-escape フィールド ( vkExUnit_cta_button_text ) はバックスラッシュが1回だけ除去される（二重除去されない）',
+				'test_condition_name' => 'single-escape フィールド ( vkExUnit_cta_button_text / wp_kses_post ) はバックスラッシュが1回だけ除去される（二重除去されない）',
 				'field'               => 'vkExUnit_cta_button_text',
 				'expected'            => wp_kses_post( stripslashes( $raw_value ) ),
 			),
@@ -410,6 +440,50 @@ class CTATest extends WP_UnitTestCase {
 			// Delete the meta so it does not affect the next case.
 			delete_post_meta( $post_id, $case['field'] );
 		}
+	}
+
+	/**
+	 * Save_custom_field が配列などスカラー以外の $_POST 値を渡されても致命的エラーにならず、
+	 * 該当フィールドの保存だけをスキップする事を検証する ( issue #1437 項目3 の多層防御 ).
+	 * esc_url() 等のエスケープ関数は配列を渡すと TypeError になるため、事前のスカラー検証で防ぐ.
+	 *
+	 * Verify that save_custom_field() does not fatal when a non-scalar ( e.g. array ) $_POST
+	 * value is submitted, and simply skips saving that field ( defense-in-depth from issue #1437
+	 * item 3 ). Escaping functions like esc_url() would throw a TypeError on an array, so a
+	 * scalar check up front guards against that.
+	 */
+	public function test_save_custom_field_skips_non_scalar_values() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => Vk_Call_To_Action::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => 'CTA Non-Scalar Test',
+				'post_content' => 'content',
+			)
+		);
+		$this->login_as_administrator();
+
+		$_POST = array(
+			'_nonce_vkExUnit_custom_cta' => $this->create_cta_nonce(),
+			'_vkExUnit_cta_switch'       => 'cta_content',
+			// esc_url() が想定していない配列を送信する。TypeError にならず、このフィールドの
+			// 保存だけがスキップされる事を検証する。
+			// Submit an array, which esc_url() does not expect. Verify it does not throw a
+			// TypeError and simply skips saving this field.
+			'vkExUnit_cta_url'           => array( 'https://example.com' ),
+			// 他のフィールドは通常どおり保存され続ける事もあわせて検証する.
+			// Also verify other fields keep saving normally.
+			'vkExUnit_cta_button_text'   => 'Still saved',
+		);
+
+		$return = Vk_Call_To_Action::save_custom_field( $post_id );
+
+		$this->assertSame( $post_id, $return );
+		$this->assertEmpty( get_post_meta( $post_id, 'vkExUnit_cta_url' ) );
+		$this->assertSame(
+			wp_kses_post( 'Still saved' ),
+			get_post_meta( $post_id, 'vkExUnit_cta_button_text', true )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Closes #1437

@coderabbitai ignore

## 概要

CTA（Call To Action。記事下などに表示する誘導エリア）の設定を保存する処理と、投稿編集画面に表示される設定枠（メタボックス）の出力について、防御を厚くしました。いずれも現時点で問題が起きているものではなく、多層防御としての強化です。

対象は主に `inc/call-to-action/package/class-vk-call-to-action.php` です。

## 変更内容

### 1. 保存時に投稿の編集権限を確認するようにした

設定の保存処理で、フォーム送信が正規の画面から来たことを確かめる使い捨ての値（nonce）の検証に加えて、その利用者に投稿の編集権限があるかどうかの確認（`current_user_can( 'edit_post', $post_id )`）を追加しました。

これに伴う挙動の変化が1つあります。投稿の自動保存で作られるリビジョン（変更履歴）に対しては、CTA の設定値が書き込まれなくなります。親となる投稿の保存はこれまでどおり通るため機能への影響はなく、リビジョンへの不要なデータ蓄積が止まります。

### 2. 送信された値の正規化を整理した

- 送信値に付加されるバックスラッシュを取り除く処理（`wp_unslash()`）を、保存処理の全分岐に適用しました
- 役割が重複していた `stripslashes` の指定を外し、`wp_unslash()` に一本化しました
- 「クラシックレイアウトを使う」「別ウィンドウで開く」の2項目は、これまで保存時のサニタイズ（送信値を安全な形へ整える処理）が掛かっていませんでした。ブロックエディタ側の保存経路と揃えて `sanitize_text_field` を掛けるようにしました
- 値がスカラー（文字列や数値などの単一の値）でない場合は、そのフィールドの保存だけを見送るようにしました。配列が送られた場合に致命的エラーへ至る経路を塞いでいます

なお、投稿ごとの追加データを保存する関数（`add_post_meta()` / `update_post_meta()`）は、渡された値のバックスラッシュを内部で必ず1回取り除く仕様です。そのため保存直前に `wp_slash()` で打ち消し、値がそのまま保存されるようにしています（WordPress 本体も REST API のメタ保存で同じ形を採っています）。この対応が無いと、値に含まれる本物のバックスラッシュが消えます。

### 3. 管理画面の出力にエスケープを追加した

投稿編集画面の CTA 設定枠と、CTA ウィジェットの設定画面で、未エスケープだった出力にエスケープを追加しました。

| 箇所 | 追加した処理 |
|---|---|
| 保存用の照合トークン（nonce）の出力 | `esc_attr()` |
| CTA 画像のサムネイル `src` | `esc_url()` |
| Font Awesome の説明とアイコン一覧へのリンク | `wp_kses_post()` |
| 「CTA setting」ボタンの `href` | `esc_url()` |
| ボタン文言の入力欄の `value` | `esc_html()` → `esc_attr()`（属性値に適した関数へ修正） |
| ウィジェット設定の select 名・選択肢の値とラベル・管理画面リンク | `esc_attr()` / `esc_html()` / `esc_url()` |

チェックボックスのチェック状態は、属性フラグメントを直接出力する形をやめ、WordPress 標準の `checked()` を使うようにしました。

### 4. 使われていないメソッドを削除した

`allow_custom_iframes()` は、許可タグ以外を取り除く仕組み（`wp_kses`）の許可リストに `iframe` と `style` タグを追加するメソッドですが、リポジトリ内のどこからも呼ばれておらず、フックにも登録されていませんでした（2025-02-10 のコミット `5b13c7e7` で登録が削除済み。しかもそれ以前から登録直後に解除しており実質動作していませんでした）。将来これを有効化した人が意図せず許可リストを広げてしまう罠になるため削除しました。

CTA の出力は `safe_kses_post()` が担っており、こちらは #1172（文字のハイライトやグループブロックの背景画像指定に使う `style` 属性が消える問題への対応）の経緯で `wp_kses` を通していません。今回この処理には手を入れていません。

## テスト

`tests/test-cta.php` / `tests/test-cta-output-escaping.php` に次のテストを追加しました。

- 編集権限の有無による保存の可否（`cta_content` 分岐・`cta_number` 分岐の両方）
- バックスラッシュを含む値が二重に処理されず、そのまま保存されること
- スカラー以外の値が送られたときにそのフィールドの保存を見送ること

プラグイン全体のテストは 132 tests / 957 assertions が全て通っています（変更前は 131 tests / 950 assertions）。

## 確認手順

### 前提

- 管理者でログインできる WordPress 環境
- ExUnit の CTA 機能を有効化しておく（管理画面 → ExUnit → 有効化設定 → CTA）

### A. CTA の設定が従来どおり保存・表示できること

1. 管理画面の左メニュー「CTA」→「新規追加」を開く
2. タイトルを入力し、本文下の「CTA Contents」枠で次を設定する
   - 「Use following data (Do not use content data)」にチェックを入れる
   - 「CTA image」で画像を1枚選ぶ
   - 「CTA image position」を「left」にする
   - 「Button text」に `お問い合わせ & 資料請求` と入力する（`&` を含める）
   - 「Button link url」に `https://example.com/contact/` と入力する
   - 「Open in a self window」にチェックを入れる
   - 「Text message」に任意の文章を入力する
3. 「公開」する

→ 公開後に画面が再読み込みされ、**入力した内容がすべてそのまま表示されている**こと。とくに「Button text」が `お問い合わせ & 資料請求` と表示され、`&amp;` のような表示にならないこと（この点は今回の修正で改善した箇所です。修正前は `&amp;` と表示されます）

→ 「Use following data」「Open in a self window」の2つのチェックボックスが、**チェックを入れた状態のまま**表示されていること

→ 選んだ画像のサムネイルが枠内に表示されていること

4. いったん「Open in a self window」のチェックを外して更新する

→ チェックが外れた状態で保存されること

### B. 記事下に CTA が従来どおり表示されること

1. 管理画面 → ExUnit → CTA 設定で、A で作成した CTA を全体表示に設定する
2. 任意の投稿をフロント側で表示する

→ 記事下に CTA が表示され、画像・ボタン文言・リンク先・本文が A で入力したとおりであること

→ ボタンをクリックすると `https://example.com/contact/` へ遷移すること（A の4でチェックを外した場合は同じタブで開くこと）

### C. CTA ウィジェットの設定画面が従来どおり操作できること

1. 管理画面 → 外観 → ウィジェットで「CTA」ウィジェットを任意のウィジェットエリアへ追加する
2. プルダウンから A で作成した CTA を選び、保存する

→ プルダウンに CTA のタイトルが正しく表示され、選択した状態で保存されること

→ 「Show CTA index page」「CTA setting」の2つのボタンが、それぞれ CTA 一覧・CTA 設定画面へ遷移すること

### D. 権限の無い利用者では保存されないこと

1. 購読者（Subscriber）権限のユーザーを用意する

→ 購読者は投稿編集画面へアクセスできないため、CTA の設定値が保存されないこと（PHPUnit の追加テストで自動確認済み）

### デグレ確認

- ブロックエディタのサイドバーから CTA の表示設定（この投稿で CTA を表示する / しない）を切り替えて保存できること
- 既存の CTA（この変更前に作成したもの）を開いたとき、設定内容が欠けずに表示されること

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/764