### PR TITLE
[ 不具合修正 ][ SNSシェアボタン ] Threads の表示名が正式表記と異なり先頭が大文字で表示される不具合を修正

### DIFF
--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -498,7 +498,7 @@ function veu_get_sns_btns( $attr = array() ) {
 			// The visible label ( .sns_txt "Threads" ) sits next to it, so the icon is decorative and hidden from screen readers.
 			// aria-hidden is placed on the outer span to match the other 5 SNS icons.
 			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_threads() . '</span>';
-			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Threads</span>';
+			$social_btns .= '<span class="sns_txt"' . $icon_css . '>threads</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';
 		}

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -493,9 +493,9 @@ function veu_get_sns_btns( $attr = array() ) {
 		if ( ! empty( $options['useThreads'] ) ) {
 			$social_btns .= '<li class="sb_threads sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_attr( 'https://www.threads.net/intent/post?text=' . $page_title . '%0A' . $link_url ) . '" target="_blank" ' . $outer_css . '>';
-			// 隣に可視ラベル（.sns_txt "Threads"）があるためアイコンは装飾。読み上げから除外する。
+			// 隣に可視ラベル（.sns_txt "threads"）があるためアイコンは装飾。読み上げから除外する。
 			// 他5つの SNS アイコンに揃え、aria-hidden は外側の span に統一する。
-			// The visible label ( .sns_txt "Threads" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			// The visible label ( .sns_txt "threads" ) sits next to it, so the icon is decorative and hidden from screen readers.
 			// aria-hidden is placed on the outer span to match the other 5 SNS icons.
 			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_threads() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>threads</span>';

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -170,6 +170,7 @@ if ( $options['useBluesky'] ) {
 if ( $options['useThreads'] ) {
 	echo 'checked';}
 ?>
+<?php /* translators: "threads" is the brand name of Meta's social network. Keep it lowercase and do not translate. */ ?>
 /> <?php _e( 'threads', 'vk-all-in-one-expansion-unit' ); ?></label></li>
 <li><label><input type="checkbox" name="vkExUnit_sns_options[useHatena]" value="true"
 <?php

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -170,7 +170,7 @@ if ( $options['useBluesky'] ) {
 if ( $options['useThreads'] ) {
 	echo 'checked';}
 ?>
-/> <?php _e( 'Threads', 'vk-all-in-one-expansion-unit' ); ?></label></li>
+/> <?php _e( 'threads', 'vk-all-in-one-expansion-unit' ); ?></label></li>
 <li><label><input type="checkbox" name="vkExUnit_sns_options[useHatena]" value="true"
 <?php
 if ( $options['useHatena'] ) {

--- a/inc/sns/sns_admin.php
+++ b/inc/sns/sns_admin.php
@@ -170,8 +170,7 @@ if ( $options['useBluesky'] ) {
 if ( $options['useThreads'] ) {
 	echo 'checked';}
 ?>
-<?php /* translators: "threads" is the brand name of Meta's social network. Keep it lowercase and do not translate. */ ?>
-/> <?php _e( 'threads', 'vk-all-in-one-expansion-unit' ); ?></label></li>
+/> <?php /* translators: "threads" is the brand name of Meta's social network. Keep it lowercase and do not translate. */ _e( 'threads', 'vk-all-in-one-expansion-unit' ); ?></label></li>
 <li><label><input type="checkbox" name="vkExUnit_sns_options[useHatena]" value="true"
 <?php
 if ( $options['useHatena'] ) {

--- a/inc/sns/sns_customizer.php
+++ b/inc/sns/sns_customizer.php
@@ -600,6 +600,7 @@ function veu_customize_register_sns( $wp_customize ) {
 	$wp_customize->add_control(
 		'useThreads',
 		array(
+			/* translators: "threads" is the brand name of Meta's social network. Keep it lowercase and do not translate. */
 			'label'    => __( 'threads', 'vk-all-in-one-expansion-unit' ),
 			'section'  => 'veu_sns_setting',
 			'settings' => 'vkExUnit_sns_options[useThreads]',

--- a/inc/sns/sns_customizer.php
+++ b/inc/sns/sns_customizer.php
@@ -600,7 +600,7 @@ function veu_customize_register_sns( $wp_customize ) {
 	$wp_customize->add_control(
 		'useThreads',
 		array(
-			'label'    => __( 'Threads', 'vk-all-in-one-expansion-unit' ),
+			'label'    => __( 'threads', 'vk-all-in-one-expansion-unit' ),
 			'section'  => 'veu_sns_setting',
 			'settings' => 'vkExUnit_sns_options[useThreads]',
 			'type'     => 'checkbox',

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ e.g.
 [ Bug Fix ][ Block ] Fixed the Share Button, HTML Sitemap and other blocks showing "This block has encountered an error and cannot be previewed" in the editor when the post contains a cross-origin iframe embed.
 [ Bug Fix ][ Share Button ] Fixed the share button block always showing in the editor even when excluded from the front end, hiding the mismatch while editing. The editor now explains why it will not display.
 [ Bug Fix ][ SNS Share Button ] Fixed the Threads and Copy icons not being displayed on themes that do not load Font Awesome (e.g. Twenty Twenty-Five), by replacing them with inline SVG.
+[ Bug Fix ][ SNS Share Button ] Fixed the Threads share button's label, admin checkbox and Customizer control showing "Threads" with a capital T instead of the official lowercase "threads".
 [ Security Fix ][ CTA ] Added a permission check on save and strengthened output escaping on the classic edit screen as defense-in-depth hardening.
 
 = 9.121.1 =

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -338,6 +338,9 @@ class SnsBtnsTest extends WP_UnitTestCase {
 				$this->assertStringContainsString( 'sb_threads', $actual, $case['test_condition_name'] );
 				$this->assertStringContainsString( $threads_intent, $actual, $case['test_condition_name'] );
 				$this->assertStringContainsString( veu_sns_icon_svg_threads(), $actual, $case['test_condition_name'] );
+				// 可視ラベルが正式表記の小文字「threads」で出力される事を確認（assertStringContainsString は大文字小文字を区別するため「Threads」への退行を検知できる）
+				// Confirm the visible label is output in the official lowercase "threads" ( assertStringContainsString is case-sensitive, so a regression back to "Threads" would be caught ).
+				$this->assertStringContainsString( '>threads</span>', $actual, $case['test_condition_name'] );
 			} else {
 				// Threads ボタンが含まれない事を確認（li クラス・intent URL・アイコンの全てが出力されない）
 				// Check that the Threads button is not included ( none of the li class, intent URL, or icon are output ).


### PR DESCRIPTION
Closes #1463

@coderabbitai ignore

## 概要

Threads（Meta が提供している SNS）の正式表記は、先頭が小文字の「threads」です。ExUnit ではこれまで先頭を大文字にした「Threads」で表示していたため、正式表記に合わせて小文字へ修正しました。

**画面上で表示が変わるのは次の3か所です。**

| 場所 | 変更前 | 変更後 |
|---|---|---|
| 公開画面の SNS シェアボタンのラベル | Threads | threads |
| ExUnit メイン設定 > SNS シェアボタンのチェックボックス | Threads | threads |
| カスタマイザー（管理画面から色や表示を設定する画面）のチェックボックス | Threads | threads |

**あわせて、表示の修正が後から崩れないための手当てを3点入れています。**

- **翻訳者向けの注記を追加**（`inc/sns/sns_admin.php` / `inc/sns/sns_customizer.php`）
  翻訳の元になる文字列が `Threads`（固有名詞と分かる形）から `threads`（英語の一般名詞に見える形）に変わりました。翻訳サイト（translate.wordpress.org）の翻訳者は前後の文脈なしでこの文字列を見るため、「スレッド」のような一般名詞として訳されると、今回の修正が翻訳側で打ち消されてしまいます。これを防ぐため、「これは Meta の SNS のブランド名であり、小文字のまま訳さないでほしい」という注記（`/* translators: ... */`）を翻訳関数の直前に添えました。
- **コード内コメントの表記を実装に揃えた**（`inc/sns/function-sns-btns.php`）
  コメントが `.sns_txt "Threads"` のままで、実際の出力とずれていたため合わせました。動作には影響しません。
- **表示文字列を固定するテストを追加**（`tests/test-sns-btns.php`）
  既存のテストは CSS クラス・投稿画面を開くリンク・アイコンしか検証しておらず、ラベルが将来また `Threads` に戻っても気付けませんでした。大文字小文字を区別する検証を1行足し、表記が戻ったらテストが落ちるようにしています。

## 変更しなかったもの（意図的）

次の内部的な名前は**あえて変更していません**。表記を統一する目的に対して、既存サイトを壊す代償が見合わないためです。

- **設定の保存キー `useThreads`** — 各サイトのデータベースに保存済みの設定を読み出す鍵です。変えると、これまで ON にしていた設定が読めなくなり、初期状態に戻ってしまいます
- **CSS クラス `sb_threads`** — 公開画面の HTML に出ており、ユーザーが独自に書いた CSS から指定されている可能性があります。変えるとその見た目の調整が効かなくなります。そもそも元から小文字のため、変える理由もありません
- **アイコンを出力する関数 `veu_sns_icon_svg_threads()`** — テーマや他のプラグインから呼び出せる公開された名前です

## レビュー状況

PR 作成前に以下を実施済みです。

- 安藤（リードエンジニア）セキュリティレビュー: **PASS**
- 植草（UXデザイナー）UX レビュー: **PASS**

指摘（翻訳者向け注記の追加・コメントの表記ゆれ・テスト追加）はこの PR 内で対応済みです。レビューの詳細は #1463 のコメントに記録しています。

## 確認手順

### 前提条件

- ExUnit の「SNS」機能が有効であること（管理画面 > ExUnit > 有効化設定）
- 任意の投稿が1件以上あること

### 手順

#### Before（修正前の状態）

1. `master` ブランチの状態で、管理画面 > ExUnit > メイン設定 を開く
2. 「SNS シェアボタン」のチェックボックス一覧を見る
   → ✗ 項目名が「Threads」（先頭が大文字）になっている
3. 投稿の公開ページを開き、シェアボタンの並びを見る
   → ✗ ボタンのラベルが「Threads」（先頭が大文字）になっている

#### After（このブランチ）

1. 管理画面 > ExUnit > メイン設定 を開く
2. 「SNS シェアボタン」のチェックボックス一覧を見る
   → ✓ 項目名が「threads」（すべて小文字）になっている
   → ✓ チェックの ON / OFF 状態が、変更前と同じ状態のまま保たれている（設定がリセットされていない）
3. threads のチェックを ON にして保存する
4. 投稿の公開ページを開き、シェアボタンの並びを見る
   → ✓ ボタンのラベルが「threads」（すべて小文字）になっている
   → ✓ 他のボタン（Facebook / X / Bluesky / Hatena / LINE / Copy）の表記・並び順は変わっていない
5. threads のボタンをクリックする
   → ✓ これまでどおり threads の投稿画面が開き、タイトルと URL が入力されている
6. 管理画面 > 外観 > カスタマイズ > ExUnit の SNS 設定 を開く
   → ✓ チェックボックスの項目名が「threads」（すべて小文字）になっている
7. カスタマイザーで threads のチェックを OFF にしてプレビューを見る
   → ✓ シェアボタンの並びから threads が消える（ON / OFF の切り替えがこれまでどおり動く）

#### デグレ確認

8. 投稿編集画面で「シェアボタン」ブロックを配置する
   → ✓ 編集画面のプレビューでも、ラベルが「threads」で表示される
9. テーマ側の追加 CSS で `.sb_threads` を指定している場合、その指定がこれまでどおり効いていることを確認する
   → ✓ CSS クラス名は変更していないため、見た目の調整は影響を受けない

## スクリーンショット

Before / After は e2e / UI テスト（麗美）の工程で取得し、テスト結果コメントに掲載しています。

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1464#issuecomment-5289603641

掲載しているのは次の3画面（それぞれ Before / After）です。

- 管理画面 > ExUnit > メイン設定 の SNS シェアボタン設定
- 公開ページのシェアボタンの並び
- カスタマイザーの SNS 設定

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/768
