### PR TITLE
[ 不具合修正 ][ CTA ] ExUnit の設定保存時、未保存の CTA 設定に初期値が入らず PHP の非推奨警告が表示され、保存に失敗したように見える不具合を修正

### DIFF
--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -721,10 +721,16 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 
 		/**
 		 * CTA のメイン設定（投稿タイプごとの表示 CTA ID 等）をサニタイズして返す.
-		 * `admin.php?page=vkexunit_cta_option` の保存処理から呼ばれる.
+		 * `admin.php?page=vkExUnit_main_setting` 内の CTA セクションの保存処理
+		 * ( `admin/admin-main-setting-page.php` の `veu_main_sanitaize_and_update()` ) から、
+		 * `option_init()` で `vkExUnit_register_setting()` に登録したサニタイズコールバック
+		 * として呼ばれる.
 		 *
 		 * Sanitize and return the CTA main settings ( the display CTA ID per post type, etc. ).
-		 * Called from the save handler of `admin.php?page=vkexunit_cta_option`.
+		 * Called as the sanitize callback registered via `vkExUnit_register_setting()` in
+		 * `option_init()`, from the save handler of the CTA section on
+		 * `admin.php?page=vkExUnit_main_setting`
+		 * ( `veu_main_sanitaize_and_update()` in `admin/admin-main-setting-page.php` ).
 		 *
 		 * @param mixed $input 保存対象の入力値（$_POST 由来の連想配列を想定）. / The submitted input ( expected to be an associative array from $_POST ).
 		 * @return array サニタイズ済みの設定配列（投稿タイプ => CTA ID または '0' / 'random'）. / The sanitized settings array ( post type => CTA ID, or '0' / 'random' ).

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -735,7 +735,16 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			);
 			$option    = get_option( 'vkExUnit_cta_settings' );
 			if ( ! $option ) {
-				$current_option = self::get_default_option();
+				// 未保存時（get_option() が false を返す場合）は、初期値で $option を上書きする.
+				// この代入先が $current_option という未使用変数になっていたため、$option は false のまま
+				// 後続のループで配列アクセスされ、PHP 8.1 以降で「false から array への暗黙変換」の
+				// deprecated 警告が出て、保存に失敗したように見えていた ( issue #1461 ).
+				// When unsaved ( get_option() returns false ), overwrite $option with the default value.
+				// The assignment target used to be the unused variable $current_option, leaving $option
+				// as false and causing an array-access on false in the loop below. On PHP 8.1+ this
+				// triggered an "Automatic conversion of false to array is deprecated" warning, which
+				// looked like the save had failed ( issue #1461 ).
+				$option = self::get_default_option();
 			}
 			if ( is_array( $input ) ) {
 				foreach ( $input as $key => $value ) {

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -719,6 +719,16 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 		}
 
 
+		/**
+		 * CTA のメイン設定（投稿タイプごとの表示 CTA ID 等）をサニタイズして返す.
+		 * `admin.php?page=vkexunit_cta_option` の保存処理から呼ばれる.
+		 *
+		 * Sanitize and return the CTA main settings ( the display CTA ID per post type, etc. ).
+		 * Called from the save handler of `admin.php?page=vkexunit_cta_option`.
+		 *
+		 * @param mixed $input 保存対象の入力値（$_POST 由来の連想配列を想定）. / The submitted input ( expected to be an associative array from $_POST ).
+		 * @return array サニタイズ済みの設定配列（投稿タイプ => CTA ID または '0' / 'random'）. / The sanitized settings array ( post type => CTA ID, or '0' / 'random' ).
+		 */
 		public static function sanitize_config( $input ) {
 			$posttypes = array_merge(
 				array(
@@ -734,12 +744,20 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 				)
 			);
 			$option    = get_option( 'vkExUnit_cta_settings' );
-			if ( ! $option ) {
-				// 未保存時（get_option() が false を返す場合）は、初期値で $option を上書きする.
+			if ( ! $option || ! is_array( $option ) ) {
+				// 未保存時（get_option() が false を返す場合）に加え、他プラグインの
+				// option_vkExUnit_cta_settings フィルタや壊れた DB 値により配列以外の
+				// truthy な値が返るケースも初期値へ倒す。ここを is_array() だけの判定に
+				// すると、正当な空配列（array()）まで弾いてしまうため ! $option との
+				// 組み合わせを維持する（get_option() の判定と同じ形に揃えている）。
 				// この代入先が $current_option という未使用変数になっていたため、$option は false のまま
 				// 後続のループで配列アクセスされ、PHP 8.1 以降で「false から array への暗黙変換」の
 				// deprecated 警告が出て、保存に失敗したように見えていた ( issue #1461 ).
-				// When unsaved ( get_option() returns false ), overwrite $option with the default value.
+				// Unsaved ( get_option() returns false ), and also cases where a non-array truthy
+				// value is returned ( e.g. via another plugin's option_vkExUnit_cta_settings filter,
+				// or a corrupted DB value ) both fall back to the default value here. Checking
+				// ! is_array() alone would incorrectly reject a legitimate empty array ( array() ),
+				// so it is combined with ! $option ( matching the same check used in get_option() ).
 				// The assignment target used to be the unused variable $current_option, leaving $option
 				// as false and causing an array-access on false in the loop below. On PHP 8.1+ this
 				// triggered an "Automatic conversion of false to array is deprecated" warning, which

--- a/inc/call-to-action/package/class-vk-call-to-action.php
+++ b/inc/call-to-action/package/class-vk-call-to-action.php
@@ -751,23 +751,14 @@ if ( ! class_exists( 'Vk_Call_To_Action' ) ) {
 			);
 			$option    = get_option( 'vkExUnit_cta_settings' );
 			if ( ! $option || ! is_array( $option ) ) {
-				// 未保存時（get_option() が false を返す場合）に加え、他プラグインの
-				// option_vkExUnit_cta_settings フィルタや壊れた DB 値により配列以外の
-				// truthy な値が返るケースも初期値へ倒す。ここを is_array() だけの判定に
-				// すると、正当な空配列（array()）まで弾いてしまうため ! $option との
-				// 組み合わせを維持する（get_option() の判定と同じ形に揃えている）。
-				// この代入先が $current_option という未使用変数になっていたため、$option は false のまま
-				// 後続のループで配列アクセスされ、PHP 8.1 以降で「false から array への暗黙変換」の
-				// deprecated 警告が出て、保存に失敗したように見えていた ( issue #1461 ).
-				// Unsaved ( get_option() returns false ), and also cases where a non-array truthy
-				// value is returned ( e.g. via another plugin's option_vkExUnit_cta_settings filter,
-				// or a corrupted DB value ) both fall back to the default value here. Checking
-				// ! is_array() alone would incorrectly reject a legitimate empty array ( array() ),
-				// so it is combined with ! $option ( matching the same check used in get_option() ).
-				// The assignment target used to be the unused variable $current_option, leaving $option
-				// as false and causing an array-access on false in the loop below. On PHP 8.1+ this
-				// triggered an "Automatic conversion of false to array is deprecated" warning, which
-				// looked like the save had failed ( issue #1461 ).
+				// ! $option … 未保存（false）と空配列（array()）を初期値へ倒す。
+				// ! is_array( $option ) … 配列以外の truthy な値（壊れた文字列など）を初期値へ倒す。
+				// どちらか一方だけでは片方のケースを取りこぼすため || で組み合わせている
+				// （get_option() の判定と同じ形。詳細は issue #1461 / 本 PR 参照）。
+				// ! $option … falls back false ( unsaved ) and an empty array ( array() ) to the default.
+				// ! is_array( $option ) … falls back a non-array truthy value ( e.g. a corrupted string )
+				// to the default. Either check alone would miss the other case, so they are combined
+				// with || ( same shape as the check in get_option(); see issue #1461 / this PR for details ).
 				$option = self::get_default_option();
 			}
 			if ( is_array( $input ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ e.g.
 [ Bug Fix ][ Block ] Fixed the Share Button, HTML Sitemap and other blocks showing "This block has encountered an error and cannot be previewed" in the editor when the post contains a cross-origin iframe embed.
 [ Bug Fix ][ Share Button ] Fixed the share button block always showing in the editor even when excluded from the front end, hiding the mismatch while editing. The editor now explains why it will not display.
 [ Bug Fix ][ SNS Share Button ] Fixed the Threads and Copy icons not being displayed on themes that do not load Font Awesome (e.g. Twenty Twenty-Five), by replacing them with inline SVG.
+[ Bug Fix ][ CTA ] Fixed a PHP deprecated warning shown on the first save of the CTA settings (which looked like the save had failed) and CTA default values not being applied.
 [ Security Fix ][ CTA ] Added a permission check on save and strengthened output escaping on the classic edit screen as defense-in-depth hardening.
 
 = 9.121.1 =

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -530,6 +530,21 @@ class CTATest extends WP_UnitTestCase {
 					'page' => '4',
 				),
 			),
+			array(
+				// 他プラグインの option_vkExUnit_cta_settings フィルタや DB の破損等で、
+				// get_option() が false ではない配列以外の truthy な値（文字列）を返すケースを再現する。
+				// ! $option だけの判定では素通りし、$option[ $key ] = ... が文字列オフセットへの
+				// 書き込みとなって PHP 8 では致命的エラーになるため、初期値へ倒れる事を検証する.
+				// Reproduce get_option() returning a non-array, non-false truthy value ( a string ) —
+				// e.g. via another plugin's option_vkExUnit_cta_settings filter, or a corrupted DB
+				// value. A ! $option -only check would let this through, and $option[ $key ] = ...
+				// would become a write to a string offset, fatal on PHP 8. Verify it falls back to
+				// the default value instead.
+				'test_condition_name' => '保存値が配列以外の truthy な値（壊れた文字列）の場合、初期値をベースに送信値が反映される ( 文字列オフセット書き込みで致命的エラーにならない )',
+				'existing_option'     => 'broken-string',
+				'input'               => array( 'post' => '7' ),
+				'expected'            => array_merge( $default_option, array( 'post' => '7' ) ),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {
@@ -579,16 +594,27 @@ class CTATest extends WP_UnitTestCase {
 				if ( E_DEPRECATED === $errno ) {
 					$deprecated_triggered = true;
 				}
-				// false を返し、ハンドラチェーンの後続処理にも委ねる.
-				// Return false so the error still propagates to any outer handler.
+				// false を返すと、この呼び出し（sanitize_config() 内で発生したエラー）については
+				// PHP 標準のエラー処理（error_reporting / display_errors 等に基づく通常処理）に
+				// 委ねられる。ここで false を返しても、直前に登録されていた PHPUnit 側のハンドラに
+				// 戻るわけではない.
+				// Returning false hands this particular error back to PHP's standard error
+				// handling ( governed by error_reporting / display_errors etc. ), not back to
+				// whatever handler ( e.g. PHPUnit's ) was registered before this one.
 				return false;
 			},
 			E_DEPRECATED
 		);
 
-		Vk_Call_To_Action::sanitize_config( array( 'post' => '1' ) );
-
-		restore_error_handler();
+		try {
+			Vk_Call_To_Action::sanitize_config( array( 'post' => '1' ) );
+		} finally {
+			// sanitize_config() が例外を投げた場合でも、このテスト専用のハンドラが
+			// 後続のテストへ漏れないよう、必ず元のハンドラへ戻す.
+			// Always restore the previous handler, even if sanitize_config() throws,
+			// so this test-local handler never leaks into subsequent tests.
+			restore_error_handler();
+		}
 
 		$this->assertFalse(
 			$deprecated_triggered,

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -545,6 +545,35 @@ class CTATest extends WP_UnitTestCase {
 				'input'               => array( 'post' => '7' ),
 				'expected'            => array_merge( $default_option, array( 'post' => '7' ) ),
 			),
+			array(
+				// admin/admin-main-setting-page.php の veu_main_sanitaize_and_update() は、
+				// その設定グループが $_POST に含まれていない場合 $before = null; としてサニタイズ
+				// コールバックへ渡す ( 実際に起こる呼び出し経路 )。未保存状態でこれが起きても、
+				// null や false ではなく初期値の配列が返る事を検証する.
+				// admin/admin-main-setting-page.php's veu_main_sanitaize_and_update() passes
+				// $before = null when the setting group is absent from $_POST ( a real call path ).
+				// Verify that even when unsaved, this returns the default array, not null or false.
+				'test_condition_name' => '入力が null（該当設定が POST に含まれない）かつ未保存の場合、初期値の配列が返る ( null / false が返らない )',
+				'existing_option'     => false,
+				'input'               => null,
+				'expected'            => $default_option,
+			),
+			array(
+				// 上記と同じ呼び出し経路を、保存済み設定がある状態で再現する。null を渡しただけで
+				// 既存の設定が消えたり上書きされたりしない事を検証する.
+				// Reproduce the same call path with a saved option already present. Verify that
+				// passing null alone does not clear or overwrite the existing settings.
+				'test_condition_name' => '入力が null（該当設定が POST に含まれない）かつ保存済み設定がある場合、既存の設定がそのまま返る',
+				'existing_option'     => array(
+					'post' => '3',
+					'page' => '4',
+				),
+				'input'               => null,
+				'expected'            => array(
+					'post' => '3',
+					'page' => '4',
+				),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {

--- a/tests/test-cta.php
+++ b/tests/test-cta.php
@@ -487,6 +487,118 @@ class CTATest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Sanitize_config() が未保存状態でも初期値をベースに動作し、保存済み設定がある場合は
+	 * 送信されたキーだけを上書きする事を検証する ( issue #1461 ).
+	 * 修正前は get_option() が false を返す未保存時に、初期値の代入先が未使用変数
+	 * $current_option になっており、$option が false のまま配列アクセスされていた.
+	 *
+	 * Verify sanitize_config() falls back to default values when unsaved, and only
+	 * overwrites the submitted keys when a saved option already exists ( issue #1461 ).
+	 * Before the fix, the default value was assigned to an unused variable
+	 * ( $current_option ) instead of $option when get_option() returned false ( unsaved ),
+	 * leaving $option as false and array-accessed as-is.
+	 */
+	public function test_sanitize_config() {
+		// 元のオプション値を退避し、テスト後に復元する.
+		// Back up the original option value to restore it after the test.
+		$original_option = get_option( 'vkExUnit_cta_settings' );
+
+		$default_option = Vk_Call_To_Action::get_default_option();
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '未保存 ( get_option が false ) の場合、初期値をベースに送信値が反映される ( false が返らない )',
+				'existing_option'     => false,
+				'input'               => array( 'post' => '5' ),
+				'expected'            => array_merge( $default_option, array( 'post' => '5' ) ),
+			),
+			array(
+				'test_condition_name' => '未保存で random 指定を送信した場合、初期値をベースに random が反映される',
+				'existing_option'     => false,
+				'input'               => array( 'post' => 'random' ),
+				'expected'            => array_merge( $default_option, array( 'post' => 'random' ) ),
+			),
+			array(
+				'test_condition_name' => '保存済み設定がある場合、送信されたキーだけが上書きされ、それ以外の既存値は維持される',
+				'existing_option'     => array(
+					'post' => '3',
+					'page' => '4',
+				),
+				'input'               => array( 'post' => '9' ),
+				'expected'            => array(
+					'post' => '9',
+					'page' => '4',
+				),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			// 保存済みオプションの有無を再現する.
+			// Reproduce the presence/absence of a saved option.
+			if ( false === $case['existing_option'] ) {
+				delete_option( 'vkExUnit_cta_settings' );
+			} else {
+				update_option( 'vkExUnit_cta_settings', $case['existing_option'] );
+			}
+
+			$actual = Vk_Call_To_Action::sanitize_config( $case['input'] );
+
+			// false のまま返らず、必ず配列で返る事を検証する ( 修正前は未保存時に false が返っていた ).
+			// Verify it always returns an array, never false ( before the fix, false was returned when unsaved ).
+			$this->assertIsArray( $actual, $case['test_condition_name'] );
+
+			foreach ( $case['expected'] as $key => $value ) {
+				$this->assertSame( $value, $actual[ $key ], $case['test_condition_name'] . ' : ' . $key );
+			}
+		}
+
+		$this->restore_cta_option( $original_option );
+	}
+
+	/**
+	 * Sanitize_config() を未保存状態から呼び出しても PHP の deprecated 警告
+	 * ( Automatic conversion of false to array is deprecated, PHP 8.1+ ) が
+	 * 発生しない事を検証する ( issue #1461 ).
+	 *
+	 * Verify calling sanitize_config() from an unsaved state does not trigger the PHP
+	 * deprecated warning ( "Automatic conversion of false to array is deprecated",
+	 * PHP 8.1+ ) ( issue #1461 ).
+	 */
+	public function test_sanitize_config_no_deprecated_warning_when_unset() {
+		$original_option = get_option( 'vkExUnit_cta_settings' );
+		delete_option( 'vkExUnit_cta_settings' );
+
+		$deprecated_triggered = false;
+
+		// E_DEPRECATED だけを捕捉する一時的なエラーハンドラを設定する。
+		// PHPUnit 側の変換設定に左右されず、確実に deprecated の発生有無を判定するため.
+		// Install a temporary error handler that catches only E_DEPRECATED, so the
+		// assertion does not depend on PHPUnit's own error-to-exception conversion settings.
+		set_error_handler(
+			function ( $errno ) use ( &$deprecated_triggered ) {
+				if ( E_DEPRECATED === $errno ) {
+					$deprecated_triggered = true;
+				}
+				// false を返し、ハンドラチェーンの後続処理にも委ねる.
+				// Return false so the error still propagates to any outer handler.
+				return false;
+			},
+			E_DEPRECATED
+		);
+
+		Vk_Call_To_Action::sanitize_config( array( 'post' => '1' ) );
+
+		restore_error_handler();
+
+		$this->assertFalse(
+			$deprecated_triggered,
+			'未保存状態から sanitize_config() を呼んでも deprecated 警告が発生しない事 / Calling sanitize_config() from an unsaved state must not trigger a deprecated warning.'
+		);
+
+		$this->restore_cta_option( $original_option );
+	}
+
+	/**
 	 * Test get_cta_post()
 	 *
 	 * @return void


### PR DESCRIPTION
Closes #1461

@coderabbitai ignore

## 概要

ExUnit の設定画面（ExUnit > メイン設定）で設定を保存すると、**1回目だけ画面に英語の警告文が出る**不具合を修正しました。保存自体は成功しているのですが、見慣れない警告が出るため、利用者は保存に失敗したと受け取ります。

出ていた警告はこれです。WordPress の通知ボックスではなく、PHP が出す警告が本文の中に直接表示されるため、見た目が唐突でした。

```
Deprecated: Automatic conversion of false to array is deprecated in .../inc/call-to-action/package/class-vk-call-to-action.php on line 745
```

### 発生条件

- CTA（Call To Action。記事の前後に差し込む告知エリア）の設定が、**まだ一度も保存されていない**こと
- その状態で ExUnit > メイン設定 から保存すること

**保存したタブは関係ありません。** メイン設定画面は ExUnit の全機能の保存処理をまとめて実行する作りのため、SNS の設定だけを変更して保存した場合でも CTA の保存処理は必ず一緒に走ります。そのため「CTA を一度も触っていないサイトで、最初に何かの設定を保存したとき」に発生していました。1回目の保存でこの設定が作られるため、2回目以降は起きません。

## 原因

`inc/call-to-action/package/class-vk-call-to-action.php` の `sanitize_config()`（保存前に値を整える処理）で、**初期値の代入先の変数名が間違っていました。**

```php
$option = get_option( 'vkExUnit_cta_settings' );   // 保存済みの設定値を読み込む
if ( ! $option ) {
    $current_option = self::get_default_option();  // ← 代入先の変数名が誤り
}
if ( is_array( $input ) ) {
    foreach ( $input as $key => $value ) {
        $option[ $key ] = ...;                     // ← $option は false のまま
    }
}
return $option;
```

`get_option()`（サイト全体で1つ保存される設定値を読み込む関数）は、その設定がまだ保存されていないとき `false` を返します。本来はその場合に `$option` へ初期値を入れ直す意図でしたが、**どこからも使われていない別の変数 `$current_option` に代入していた**ため、`$option` は `false` のまま次の処理へ進んでいました。

その直後に `false` へ配列として値を入れようとするため、PHP 8.1 以降の非推奨警告が発生していました。この警告は PHP 9 では致命的エラーになる見込みです。

## 変更内容

1. **代入先を `$option` に修正しました。** これが不具合の直接の原因です。
2. **ガードを強化しました。** 判定を `if ( ! $option )` から `if ( ! $option || ! is_array( $option ) )` に変えています。他のプラグインが `option_vkExUnit_cta_settings` フィルタで配列以外の値を返した場合や、DB の値が壊れていた場合に、文字列に対して配列として書き込もうとして PHP 8 で致命的エラーになるのを防ぎます。同じクラスの `get_option()` が既にこの判定形なので、そちらに揃えました。
3. **PHPDoc を追加しました。** `sanitize_config()` がどこから呼ばれ、何を返すのかを記載しています。
4. **PHPUnit テストを追加しました。** 詳細は下記。

### 追加したテスト（`tests/test-cta.php`）

| テスト | 検証内容 |
|---|---|
| `test_sanitize_config()` | 未保存の状態で呼ぶと初期値をベースにした配列が返ること（`false` にならないこと）／保存済み設定がある場合は送信されたキーだけが上書きされること／保存値が配列以外の値だった場合も初期値へ倒れること |
| `test_sanitize_config_no_deprecated_warning_when_unset()` | 未保存の状態から呼んでも PHP の非推奨警告が発生しないこと |

**修正前のコードに一時的に戻して、この2つのテストが両方とも FAIL することを確認済みです**（他 11 テストは green のまま）。「修正しなくても通ってしまうテスト」にはなっていません。

## 影響範囲

- **既存の保存済み設定がある場合、挙動は完全に従来どおりです。** `! $option` が成立しないため、修正した分岐に入りません。
- 変わるのは未保存時に保存される内容が「送信されたキーのみ」から「初期値＋送信されたキー」になる点だけです。読み出し側（`get_option()`）は元々欠損キーを初期値で補完していたため、公開画面の表示は変わりません。
- 保存経路の権限チェック・nonce 検証には一切手を入れていません。

## 確認手順

### 前提条件

- ExUnit を有効化した WordPress 環境
- **CTA の設定を一度も保存していない状態**（`vkExUnit_cta_settings` オプションが存在しない状態）
  - 既に保存済みの環境で試す場合は、確認前に以下でオプションを削除してください。
    ```
    wp option delete vkExUnit_cta_settings
    ```
- `wp-config.php` で `WP_DEBUG` を `true` にしておく（非推奨警告を画面に出すため）
- PHP 8.1 以上（8.0 以下では警告そのものが出ないため、この不具合を再現できません）

### 手順

#### Before（修正前の再現手順）

1. 管理画面 > ExUnit > メイン設定 を開く
2. どのタブでもよいので設定を変更する（例: SNS のタブで任意の項目を変更）
3. 「変更を保存」をクリックする
   → ✗ 画面に `Deprecated: Automatic conversion of false to array is deprecated in .../class-vk-call-to-action.php on line 745` という英語の警告文が表示される
4. もう一度「変更を保存」をクリックする
   → 警告は表示されなくなる（1回目だけ出る）

#### After（修正後）

1. `wp option delete vkExUnit_cta_settings` で CTA の設定を未保存の状態に戻す
2. 管理画面 > ExUnit > メイン設定 を開く
3. どのタブでもよいので設定を変更し、「変更を保存」をクリックする
   → ✓ 警告文が表示されない
   → ✓ 変更した設定が正しく保存されている
4. `wp option get vkExUnit_cta_settings` で保存された内容を確認する
   → ✓ `post` / `page` など、公開されている投稿タイプの一覧が初期値として入っている（送信された項目だけになっていない）
5. 管理画面 > ExUnit > CTA設定 を開く
   → ✓ 投稿タイプごとの CTA 設定が一覧に表示され、いずれも「表示しない」相当の初期値になっている
6. もう一度メイン設定から保存する
   → ✓ 警告が出ず、手順3で保存した内容が維持されている（2回目以降の挙動が従来どおり）

#### デグレ確認

1. ExUnit > CTA設定 で任意の投稿タイプに CTA を割り当てて保存する
2. メイン設定から SNS など別のタブの設定だけを変更して保存する
   → ✓ 手順1で設定した CTA の割り当てが維持されている（他タブの保存で CTA 設定が初期値に戻らない）
3. CTA を割り当てた投稿タイプの記事を公開側で表示する
   → ✓ CTA が従来どおり表示される

### 自動テスト

```
npm run phpunit
```

→ ✓ すべて PASS（実行結果: `OK (138 tests, 1021 assertions)` / 終了コード 0）

## スクリーンショット

画面のレイアウト・デザインは変更していないため省略します。見た目の変化は「保存時に出ていた PHP の警告文が出なくなる」ことのみで、上記の確認手順で再現・確認できます。

## レビュー実施状況

- **セキュリティ / コード品質レビュー（安藤）**: PASS。初回レビューで MEDIUM ×1・LOW ×2 の指摘があり、すべて対応のうえ再レビューで PASS。
- **UX レビュー（植草）**: スキップ。画面に出る要素（CSS・JavaScript・HTML・画面テンプレート）を一切変更していないため。
- **PHPUnit**: フルスイート PASS。

## 今回のスコープ外（据え置き）

同じ `sanitize_config()` 内に、以下の既存事項があります。いずれも本 PR 以前からのもので、管理者権限と有効な nonce が前提のため実リスクは低く、今回の変更趣旨（保存時の警告を止める）と混ざるため触っていません。

- 未使用の変数 `$posttypes`（投稿タイプの一覧を組み立てているが、どこからも参照されていない）
- 送信されたキーが投稿タイプの一覧で検証されていない点
- `$value == 'random'` の緩い比較
- 投稿 ID に `absint()` を使っていない点

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/769