### PR TITLE
[ 仕様変更 ][ SNSシェアボタン ] Facebook・X・Bluesky・はてなブックマーク・LINE のアイコンの出力方式を Threads・Copy と揃え、インライン SVG に統一

### DIFF
--- a/inc/sns/assets/_scss/_sns.scss
+++ b/inc/sns/assets/_scss/_sns.scss
@@ -31,13 +31,12 @@
     }
     .sb_icon {
         .sb_icon_inner {
-            // アイコン（自前フォント合字 / インライン SVG）とテキストの縦位置合わせを、フォントの行ボックス
-            // （strut）基準ではなく flex の cross-axis 整列で行う。strut 基準だとフォント合字と SVG とで
-            // 実際の高さがわずかに変わってしまうため、.icon_sns（下記）も同じ理由で inline-flex にする。
-            // Vertically align the icon ( in-house web font ligature / inline SVG ) and text via flex
-            // cross-axis alignment instead of the font's line-box ( strut ), which would otherwise render
-            // a slightly different height for the web-font ligature vs. the SVG. .icon_sns below is
-            // inline-flex for the same reason.
+            // アイコン（インライン SVG。7つとも issue #1462 で SVG に統一済み）とテキストの縦位置合わせを、
+            // フォントの行ボックス（strut）基準ではなく flex の cross-axis 整列で行う。.icon_sns（下記）も
+            // 同じ理由で inline-flex にする。
+            // Vertically align the icon ( inline SVG — all 7 icons were unified to SVG in issue #1462 )
+            // and text via flex cross-axis alignment instead of the font's line-box ( strut ). .icon_sns
+            // below is inline-flex for the same reason.
             display: flex;
             align-items: center;
             overflow: hidden;
@@ -74,10 +73,10 @@
                 display: inline-flex;
                 align-items: center;
             }
-            // Threads・Copy のインライン SVG は他の自前フォント（vk_sns）アイコンと視覚サイズを揃えるため 1em 四方にする。
+            // 7つのシェアボタンアイコン（インライン SVG）はすべて 1em 四方で視覚サイズを揃える。
             // 中央寄せは親の .icon_sns（inline-flex）側で行う（詳細な検証根拠は PR 本文を参照）。
-            // Size the inline SVG ( Threads / Copy ) to 1em square to match the other in-house web font
-            // ( vk_sns ) icons. Centering is handled by the parent .icon_sns ( inline-flex; see the PR body for details ).
+            // Size all 7 share button icons ( inline SVG ) to 1em square for a consistent visual size.
+            // Centering is handled by the parent .icon_sns ( inline-flex; see the PR body for details ).
             .sb_svg_icon {
                 width: 1em;
                 height: 1em;

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -347,6 +347,95 @@ function veu_sns_icon_css( $options ) {
 }
 
 /**
+ * Facebook シェアボタンのアイコン SVG
+ * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_fb` で字形を出力していたが、
+ * Threads・Copy と出力方式が割れており（issue #1462）、7つのシェアボタンでアイコンの出力方式を
+ * インライン SVG に統一する。
+ * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は、Lightning のスキンプラグイン（hover 時の
+ * アイコン色上書きに `.vk_icon_w_r_sns_*` セレクタを使用）やユーザーのカスタム CSS からの参照が
+ * ありうるため削除せず残す。このマークアップだけがインライン SVG の出力に切り替わる。
+ * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の facebook.svg。
+ * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
+ * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、Facebook ロゴ自体の商標権は
+ * Meta Platforms, Inc. に帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
+ * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_fb`. Since
+ * this diverged from how Threads / Copy render their icons ( issue #1462 ), all 7 share buttons now
+ * use inline SVG for a consistent icon output method.
+ * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( not removed ), since the Lightning
+ * skin plugins override the hover icon color via `.vk_icon_w_r_sns_*` selectors, and user custom CSS
+ * may reference them too. Only this markup switches to inline SVG.
+ * Source: Simple Icons ( https://simpleicons.org/ ) facebook.svg.
+ * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
+ * This license covers the SVG ( the traced artwork ) copyright notice only; the Facebook logo itself
+ * remains a trademark of Meta Platforms, Inc. Used single-color, unmodified in shape, and only as a
+ * share link icon.
+ * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
+ * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
+ * Explicit width / height prevent the default replaced-element sizing rules from rendering an
+ * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
+ *
+ * @return string SVG markup.
+ */
+function veu_sns_icon_svg_facebook() {
+	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z"/></svg>';
+}
+
+/**
+ * X（旧 Twitter）シェアボタンのアイコン SVG
+ * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_x_twitter` で字形を出力していたが、
+ * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
+ * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の x.svg。
+ * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
+ * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、X ロゴ自体の商標権は
+ * X Corp. に帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
+ * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_x_twitter`.
+ * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
+ * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * Source: Simple Icons ( https://simpleicons.org/ ) x.svg.
+ * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
+ * This license covers the SVG ( the traced artwork ) copyright notice only; the X logo itself
+ * remains a trademark of X Corp. Used single-color, unmodified in shape, and only as a share link icon.
+ * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
+ * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
+ * Explicit width / height prevent the default replaced-element sizing rules from rendering an
+ * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
+ *
+ * @return string SVG markup.
+ */
+function veu_sns_icon_svg_x() {
+	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z"/></svg>';
+}
+
+/**
+ * Bluesky シェアボタンのアイコン SVG
+ * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_bluesky` で字形を出力していたが、
+ * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
+ * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の bluesky.svg。
+ * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
+ * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、Bluesky ロゴ自体の商標権は
+ * Bluesky Social PBC に帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
+ * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_bluesky`.
+ * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
+ * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * Source: Simple Icons ( https://simpleicons.org/ ) bluesky.svg.
+ * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
+ * This license covers the SVG ( the traced artwork ) copyright notice only; the Bluesky logo itself
+ * remains a trademark of Bluesky Social PBC. Used single-color, unmodified in shape, and only as a
+ * share link icon.
+ * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
+ * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
+ * Explicit width / height prevent the default replaced-element sizing rules from rendering an
+ * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
+ *
+ * @return string SVG markup.
+ */
+function veu_sns_icon_svg_bluesky() {
+	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"/></svg>';
+}
+
+/**
  * Threads シェアボタンのアイコン SVG
  * 自前フォント vk_sns に字形がないため Font Awesome の fa-brands fa-threads を使っていたが、
  * 本プラグインは Font Awesome を読み込んでおらず、テーマ側の読み込みに依存していたため、
@@ -374,6 +463,63 @@ function veu_sns_icon_css( $options ) {
  */
 function veu_sns_icon_svg_threads() {
 	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M18.263 11.097c-.03-3.486-1.92-5.586-5.111-5.586-2.13 0-3.922.963-4.863 2.499l2.062 1.438c.535-.843 1.272-1.543 2.628-1.543 1.528 0 2.318.85 2.544 2.431a15 15 0 0 0-2.236-.173c-4.125 0-6.068 1.867-6.068 4.336s1.943 3.99 4.804 3.99c3.139 0 5.013-2.115 5.781-4.735.798.361 1.348 1.204 1.348 2.47 0 3.387-3.907 5.232-7.22 5.232-4.885 0-8.077-3.207-8.077-8.424 0-6.392 4.223-10.487 9.9-10.487 3.808 0 5.69 1.671 6.97 3.914l2.108-1.475C21.44 2.078 18.331 0 13.663 0 6.227 0 1.168 5.277 1.168 12.934c0 7 4.953 11.066 10.856 11.066 4.878 0 9.809-2.846 9.809-7.716 0-2.545-1.46-4.231-3.569-5.187m-6.33 4.855c-1.077 0-2.026-.512-2.026-1.453 0-1.483 1.822-1.934 3.606-1.934.678 0 1.34.045 1.927.173-.422 1.927-1.671 3.215-3.508 3.214Z"/></svg>';
+}
+
+/**
+ * はてなブックマーク シェアボタンのアイコン SVG
+ * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_hatena` で字形を出力していたが、
+ * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
+ * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の hatenabookmark.svg。
+ * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
+ * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、はてなブックマークのロゴ自体の
+ * 商標権は株式会社はてなに帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
+ * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_hatena`.
+ * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
+ * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * Source: Simple Icons ( https://simpleicons.org/ ) hatenabookmark.svg.
+ * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
+ * This license covers the SVG ( the traced artwork ) copyright notice only; the Hatena Bookmark logo
+ * itself remains a trademark of Hatena Co., Ltd. Used single-color, unmodified in shape, and only as
+ * a share link icon.
+ * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
+ * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
+ * Explicit width / height prevent the default replaced-element sizing rules from rendering an
+ * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
+ *
+ * @return string SVG markup.
+ */
+function veu_sns_icon_svg_hatena() {
+	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M20.47 0C22.42 0 24 1.58 24 3.53v16.94c0 1.95-1.58 3.53-3.53 3.53H3.53C1.58 24 0 22.42 0 20.47V3.53C0 1.58 1.58 0 3.53 0h16.94zm-3.705 14.47c-.78 0-1.41.63-1.41 1.41s.63 1.414 1.41 1.414 1.41-.645 1.41-1.425-.63-1.41-1.41-1.41zM8.61 17.247c1.2 0 2.056-.042 2.58-.12.526-.084.976-.222 1.32-.412.45-.232.78-.564 1.02-.99s.36-.915.36-1.48c0-.78-.21-1.403-.63-1.87-.42-.48-.99-.734-1.74-.794.66-.18 1.156-.45 1.456-.81.315-.344.465-.824.465-1.424 0-.48-.103-.885-.3-1.26-.21-.36-.493-.645-.883-.87-.345-.195-.735-.315-1.215-.405-.464-.074-1.29-.12-2.474-.12H5.654v10.486H8.61zm.736-4.185c.705 0 1.185.088 1.44.262.27.18.39.495.39.93 0 .405-.135.69-.42.855-.27.18-.765.254-1.44.254H8.31v-2.297h1.05zm8.656.706v-7.06h-2.46v7.06H18zM8.925 9.08c.71 0 1.185.08 1.432.24.245.16.367.435.367.83 0 .38-.13.646-.39.804-.265.154-.747.232-1.452.232h-.57V9.08h.615z"/></svg>';
+}
+
+/**
+ * LINE シェアボタンのアイコン SVG
+ * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_line` で字形を出力していたが、
+ * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
+ * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の line.svg。
+ * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
+ * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、LINE ロゴ自体の商標権は
+ * LINEヤフー株式会社（LY Corporation）に帰属したまま。単色・形状非改変・シェア導線としての用途に
+ * 限定して使用している。
+ * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_line`.
+ * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
+ * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * Source: Simple Icons ( https://simpleicons.org/ ) line.svg.
+ * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
+ * This license covers the SVG ( the traced artwork ) copyright notice only; the LINE logo itself
+ * remains a trademark of LY Corporation. Used single-color, unmodified in shape, and only as a share
+ * link icon.
+ * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
+ * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
+ * Explicit width / height prevent the default replaced-element sizing rules from rendering an
+ * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
+ *
+ * @return string SVG markup.
+ */
+function veu_sns_icon_svg_line() {
+	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>';
 }
 
 /**
@@ -445,12 +591,16 @@ function veu_get_sns_btns( $attr = array() ) {
 
 		$social_btns = '<div class="veu_socialSet' . $auto_class . esc_attr( $classes ) . ' veu_contentAddSection"><script>window.twttr=(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return t;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));</script><ul>';
 		// facebook.
+		// アイコンは Font Awesome 非依存のインライン SVG（ veu_sns_icon_svg_facebook() ）を使用する。
+		// Use a Font Awesome independent inline SVG ( veu_sns_icon_svg_facebook() ) for the icon.
 		if ( ! empty( $options['useFacebook'] ) ) {
 			$social_btns .= '<li class="sb_facebook sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_url( '//www.facebook.com/sharer.php?src=bm&u=' . $link_url . '&t=' . $page_title ) . '" target="_blank" ' . $outer_css . 'onclick="window.open(this.href,\'FBwindow\',\'width=650,height=450,menubar=no,toolbar=no,scrollbars=yes\');return false;">';
-			// 字形を CSS 疑似要素で描く自前 web フォント（vk_sns）アイコン。隣に可視ラベル（.sns_txt "Facebook"）があるため装飾扱いで読み上げから除外する。
-			// In-house web font ( vk_sns ) icon whose glyph is drawn via a CSS pseudo-element. The visible label ( .sns_txt "Facebook" ) sits next to it, so it is decorative and hidden from screen readers.
-			$social_btns .= '<span class="vk_icon_w_r_sns_fb icon_sns" aria-hidden="true"' . $icon_css . '></span>';
+			// 隣に可視ラベル（.sns_txt "Facebook"）があるためアイコンは装飾。読み上げから除外する。
+			// 他の SNS アイコンに揃え、aria-hidden は外側の span に統一する。
+			// The visible label ( .sns_txt "Facebook" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			// aria-hidden is placed on the outer span to match the other SNS icons.
+			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_facebook() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Facebook</span>';
 			$social_btns .= '<span class="veu_count_sns_fb"' . $icon_css . '></span>';
 			$social_btns .= '</a>';
@@ -458,12 +608,16 @@ function veu_get_sns_btns( $attr = array() ) {
 		}
 
 		// X.
+		// アイコンは Font Awesome 非依存のインライン SVG（ veu_sns_icon_svg_x() ）を使用する。
+		// Use a Font Awesome independent inline SVG ( veu_sns_icon_svg_x() ) for the icon.
 		if ( ! empty( $options['useTwitter'] ) ) {
 			$social_btns .= '<li class="sb_x_twitter sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_url( '//twitter.com/intent/tweet?url=' . $link_url . '&text=' . $page_title ) . '" target="_blank" ' . $outer_css . '>';
-			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "X"）があるため装飾扱いで読み上げから除外する。
-			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "X" ) sits next to it, so it is decorative and hidden from screen readers.
-			$social_btns .= '<span class="vk_icon_w_r_sns_x_twitter icon_sns" aria-hidden="true"' . $icon_css . '></span>';
+			// 隣に可視ラベル（.sns_txt "X"）があるためアイコンは装飾。読み上げから除外する。
+			// 他の SNS アイコンに揃え、aria-hidden は外側の span に統一する。
+			// The visible label ( .sns_txt "X" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			// aria-hidden is placed on the outer span to match the other SNS icons.
+			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_x() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>X</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';
@@ -474,12 +628,16 @@ function veu_get_sns_btns( $attr = array() ) {
 		// rawurlencode() 済みの構成要素を esc_attr() で属性エスケープする（Threads も同様）
 		// esc_url() strips the %0A of "title + line break (%0A) + URL", so escape the
 		// rawurlencode()-ed parts with esc_attr() for the attribute instead ( same for Threads ).
+		// アイコンは Font Awesome 非依存のインライン SVG（ veu_sns_icon_svg_bluesky() ）を使用する。
+		// Use a Font Awesome independent inline SVG ( veu_sns_icon_svg_bluesky() ) for the icon.
 		if ( ! empty( $options['useBluesky'] ) ) {
 			$social_btns .= '<li class="sb_bluesky sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_attr( 'https://bsky.app/intent/compose?text=' . $page_title . '%0A' . $link_url ) . '" target="_blank" ' . $outer_css . '>';
-			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "Bluesky"）があるため装飾扱いで読み上げから除外する。
-			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "Bluesky" ) sits next to it, so it is decorative and hidden from screen readers.
-			$social_btns .= '<span class="vk_icon_w_r_sns_bluesky icon_sns" aria-hidden="true"' . $icon_css . '></span>';
+			// 隣に可視ラベル（.sns_txt "Bluesky"）があるためアイコンは装飾。読み上げから除外する。
+			// 他の SNS アイコンに揃え、aria-hidden は外側の span に統一する。
+			// The visible label ( .sns_txt "Bluesky" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			// aria-hidden is placed on the outer span to match the other SNS icons.
+			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_bluesky() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Bluesky</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';
@@ -494,9 +652,9 @@ function veu_get_sns_btns( $attr = array() ) {
 			$social_btns .= '<li class="sb_threads sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_attr( 'https://www.threads.net/intent/post?text=' . $page_title . '%0A' . $link_url ) . '" target="_blank" ' . $outer_css . '>';
 			// 隣に可視ラベル（.sns_txt "threads"）があるためアイコンは装飾。読み上げから除外する。
-			// 他5つの SNS アイコンに揃え、aria-hidden は外側の span に統一する。
+			// 他の SNS アイコンに揃え、aria-hidden は外側の span に統一する。
 			// The visible label ( .sns_txt "threads" ) sits next to it, so the icon is decorative and hidden from screen readers.
-			// aria-hidden is placed on the outer span to match the other 5 SNS icons.
+			// aria-hidden is placed on the outer span to match the other SNS icons.
 			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_threads() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>threads</span>';
 			$social_btns .= '</a>';
@@ -504,12 +662,16 @@ function veu_get_sns_btns( $attr = array() ) {
 		}
 
 		// hatena.
+		// アイコンは Font Awesome 非依存のインライン SVG（ veu_sns_icon_svg_hatena() ）を使用する。
+		// Use a Font Awesome independent inline SVG ( veu_sns_icon_svg_hatena() ) for the icon.
 		if ( ! empty( $options['useHatena'] ) ) {
 			$social_btns .= '<li class="sb_hatena sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner" href="' . esc_url( '//b.hatena.ne.jp/add?mode=confirm&url=' . $link_url . '&title=' . $page_title ) . '" target="_blank" ' . $outer_css . ' onclick="window.open(this.href,\'Hatenawindow\',\'width=650,height=450,menubar=no,toolbar=no,scrollbars=yes\');return false;">';
-			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "Hatena"）があるため装飾扱いで読み上げから除外する。
-			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "Hatena" ) sits next to it, so it is decorative and hidden from screen readers.
-			$social_btns .= '<span class="vk_icon_w_r_sns_hatena icon_sns" aria-hidden="true"' . $icon_css . '></span>';
+			// 隣に可視ラベル（.sns_txt "Hatena"）があるためアイコンは装飾。読み上げから除外する。
+			// 他の SNS アイコンに揃え、aria-hidden は外側の span に統一する。
+			// The visible label ( .sns_txt "Hatena" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			// aria-hidden is placed on the outer span to match the other SNS icons.
+			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_hatena() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Hatena</span>';
 			$social_btns .= '<span class="veu_count_sns_hb"' . $icon_css . '></span>';
 			$social_btns .= '</a>';
@@ -520,12 +682,16 @@ function veu_get_sns_btns( $attr = array() ) {
 		// line: は esc_url() のデフォルト許可プロトコル外で空文字になるため、許可プロトコルを明示する
 		// The line: scheme is not in esc_url()'s default allowed protocols ( the URL would become
 		// an empty string ), so pass the allowed protocol explicitly.
+		// アイコンは Font Awesome 非依存のインライン SVG（ veu_sns_icon_svg_line() ）を使用する。
+		// Use a Font Awesome independent inline SVG ( veu_sns_icon_svg_line() ) for the icon.
 		if ( wp_is_mobile() && ! empty( $options['useLine'] ) ) :
 			$social_btns .= '<li class="sb_line sb_icon">';
 			$social_btns .= '<a class="sb_icon_inner"  href="' . esc_url( 'line://msg/text/' . $page_title . ' ' . $link_url, array( 'line' ) ) . '" ' . $outer_css . '>';
-			// 自前 web フォント（vk_sns）のアイコン。隣に可視ラベル（.sns_txt "LINE"）があるため装飾扱いで読み上げから除外する。
-			// In-house web font ( vk_sns ) icon. The visible label ( .sns_txt "LINE" ) sits next to it, so it is decorative and hidden from screen readers.
-			$social_btns .= '<span class="vk_icon_w_r_sns_line icon_sns" aria-hidden="true"' . $icon_css . '></span>';
+			// 隣に可視ラベル（.sns_txt "LINE"）があるためアイコンは装飾。読み上げから除外する。
+			// 他の SNS アイコンに揃え、aria-hidden は外側の span に統一する。
+			// The visible label ( .sns_txt "LINE" ) sits next to it, so the icon is decorative and hidden from screen readers.
+			// aria-hidden is placed on the outer span to match the other SNS icons.
+			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_line() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>LINE</span>';
 			$social_btns .= '</a>';
 			$social_btns .= '</li>';
@@ -537,9 +703,9 @@ function veu_get_sns_btns( $attr = array() ) {
 			$social_btns .= '<li class="sb_copy sb_icon">';
 			$social_btns .= '<button class="copy-button sb_icon_inner"' . $outer_css . 'data-clipboard-text="' . esc_attr( urldecode( $page_title ) ) . ' ' . esc_attr( urldecode( $link_url ) ) . '">';
 			// 隣に可視ラベル（.sns_txt "Copy"）があるためアイコンは装飾。読み上げから除外する。
-			// 他5つの SNS アイコンに揃え、aria-hidden は外側の span に統一する。
+			// 他の SNS アイコンに揃え、aria-hidden は外側の span に統一する。
 			// The visible label ( .sns_txt "Copy" ) sits next to it, so the icon is decorative and hidden from screen readers.
-			// aria-hidden is placed on the outer span to match the other 5 SNS icons.
+			// aria-hidden is placed on the outer span to match the other SNS icons.
 			$social_btns .= '<span class="icon_sns" aria-hidden="true"' . $icon_css . '>' . veu_sns_icon_svg_copy() . '</span>';
 			$social_btns .= '<span class="sns_txt"' . $icon_css . '>Copy</span>';
 			$social_btns .= '</button>';

--- a/inc/sns/function-sns-btns.php
+++ b/inc/sns/function-sns-btns.php
@@ -347,100 +347,124 @@ function veu_sns_icon_css( $options ) {
 }
 
 /**
- * Facebook シェアボタンのアイコン SVG
- * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_fb` で字形を出力していたが、
- * Threads・Copy と出力方式が割れており（issue #1462）、7つのシェアボタンでアイコンの出力方式を
- * インライン SVG に統一する。
- * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は、Lightning のスキンプラグイン（hover 時の
- * アイコン色上書きに `.vk_icon_w_r_sns_*` セレクタを使用）やユーザーのカスタム CSS からの参照が
- * ありうるため削除せず残す。このマークアップだけがインライン SVG の出力に切り替わる。
+ * シェアボタンのアイコン SVG の共通のガワ（svg 要素の属性 ＋ path 要素）を組み立てる
+ * 7つのシェアボタンアイコン（Facebook / X / Bluesky / Threads / Hatena / LINE / Copy）は出典や
+ * パスデータだけが異なり、svg 要素の属性（class / width / height / viewBox / fill / aria-hidden /
+ * focusable / xmlns の8つ）は全て同一のため、ここに一本化する。以前は各アイコン関数へ同じ8属性・
+ * 同じ理由説明が7回コピーされており、直す時に1箇所直して直し忘れる壊れ方をしていた（issue #1462）。
+ *
+ * 従来は自前 web フォント（vk_sns）の合字（`.vk_icon_w_r_sns_*` クラスの空 span ＋ CSS の ::before
+ * で描く字形）でアイコンを出力していたが、7つのシェアボタンでアイコンの出力方式をインライン SVG に
+ * 統一する。自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は、このプラグイン以外の VK 製品や、
+ * サイト運営者が独自に書いたカスタム HTML / CSS がこのクラスを直接参照している可能性があるため
+ * 削除せず残す（この変更で切り替わるのは、このプラグイン自身が出力するマークアップだけ）。
+ *
+ * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
+ * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
+ *
+ * Assemble the shared SVG shell ( the <svg> element's attributes and its <path> elements ) for the
+ * share button icons. All 7 share button icons ( Facebook / X / Bluesky / Threads / Hatena / LINE /
+ * Copy ) only differ in source and path data — the 8 <svg> attributes ( class / width / height /
+ * viewBox / fill / aria-hidden / focusable / xmlns ) are identical — so this is factored out here.
+ * Previously the same 8 attributes and the same rationale were copy-pasted into each of the 7 icon
+ * functions, which broke in the way where fixing it in one place left the other 6 unfixed ( issue #1462 ).
+ *
+ * Previously rendered via the in-house web font ( vk_sns ) ligature ( an empty span with the
+ * `.vk_icon_w_r_sns_*` class, styled via a CSS ::before glyph ). Unified to inline SVG across all 7
+ * share buttons. The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( not removed ), since
+ * other VK products, or custom HTML / CSS written by site owners, may reference the class directly.
+ * Only this plugin's own markup switches to inline SVG.
+ *
+ * Explicit width / height prevent the default replaced-element sizing rules from rendering an
+ * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
+ *
+ * @param string|string[] $paths One or more SVG <path> "d" attribute values ( a single string, or an
+ *                                array when the icon needs multiple <path> elements, e.g. Copy ).
+ *                                SVG の <path> 要素の d 属性値。1つの文字列、または複数の <path> が
+ *                                必要なアイコン（ Copy など ）の場合は配列で渡す.
+ * @return string SVG markup.
+ */
+function veu_sns_icon_svg_wrap( $paths ) {
+	// 単一パスのアイコンは文字列で渡ってくるため、配列に揃えてループできるようにする.
+	// Single-path icons pass a plain string, so normalize to an array for the loop below.
+	$paths = (array) $paths;
+
+	$svg = '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">';
+	foreach ( $paths as $path ) {
+		$svg .= '<path d="' . $path . '"/>';
+	}
+	$svg .= '</svg>';
+
+	return $svg;
+}
+
+/**
+ * Facebook シェアボタンのアイコン SVG（パスデータ）
+ * SVG の共通のガワ（svg 要素の8属性・width / height を明示する理由・自前フォント / CSS を
+ * 削除しない理由）は veu_sns_icon_svg_wrap() を参照。
  * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の facebook.svg。
  * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
  * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、Facebook ロゴ自体の商標権は
  * Meta Platforms, Inc. に帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
- * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_fb`. Since
- * this diverged from how Threads / Copy render their icons ( issue #1462 ), all 7 share buttons now
- * use inline SVG for a consistent icon output method.
- * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( not removed ), since the Lightning
- * skin plugins override the hover icon color via `.vk_icon_w_r_sns_*` selectors, and user custom CSS
- * may reference them too. Only this markup switches to inline SVG.
+ * For the shared SVG shell ( the 8 <svg> attributes, why width / height are explicit, and why the
+ * in-house font / CSS are not removed ), see veu_sns_icon_svg_wrap().
  * Source: Simple Icons ( https://simpleicons.org/ ) facebook.svg.
  * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
  * This license covers the SVG ( the traced artwork ) copyright notice only; the Facebook logo itself
  * remains a trademark of Meta Platforms, Inc. Used single-color, unmodified in shape, and only as a
  * share link icon.
- * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
- * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
- * Explicit width / height prevent the default replaced-element sizing rules from rendering an
- * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
  *
  * @return string SVG markup.
  */
 function veu_sns_icon_svg_facebook() {
-	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z"/></svg>';
+	return veu_sns_icon_svg_wrap( 'M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z' );
 }
 
 /**
- * X（旧 Twitter）シェアボタンのアイコン SVG
- * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_x_twitter` で字形を出力していたが、
- * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
- * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * X（旧 Twitter）シェアボタンのアイコン SVG（パスデータ）
+ * SVG の共通のガワは veu_sns_icon_svg_wrap() を参照。
  * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の x.svg。
  * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
  * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、X ロゴ自体の商標権は
  * X Corp. に帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
- * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_x_twitter`.
- * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
- * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * For the shared SVG shell, see veu_sns_icon_svg_wrap().
  * Source: Simple Icons ( https://simpleicons.org/ ) x.svg.
  * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
  * This license covers the SVG ( the traced artwork ) copyright notice only; the X logo itself
  * remains a trademark of X Corp. Used single-color, unmodified in shape, and only as a share link icon.
- * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
- * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
- * Explicit width / height prevent the default replaced-element sizing rules from rendering an
- * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
  *
  * @return string SVG markup.
  */
 function veu_sns_icon_svg_x() {
-	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z"/></svg>';
+	return veu_sns_icon_svg_wrap( 'M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z' );
 }
 
 /**
- * Bluesky シェアボタンのアイコン SVG
- * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_bluesky` で字形を出力していたが、
- * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
- * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * Bluesky シェアボタンのアイコン SVG（パスデータ）
+ * SVG の共通のガワは veu_sns_icon_svg_wrap() を参照。
  * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の bluesky.svg。
  * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
  * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、Bluesky ロゴ自体の商標権は
  * Bluesky Social PBC に帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
- * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_bluesky`.
- * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
- * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * For the shared SVG shell, see veu_sns_icon_svg_wrap().
  * Source: Simple Icons ( https://simpleicons.org/ ) bluesky.svg.
  * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
  * This license covers the SVG ( the traced artwork ) copyright notice only; the Bluesky logo itself
  * remains a trademark of Bluesky Social PBC. Used single-color, unmodified in shape, and only as a
  * share link icon.
- * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
- * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
- * Explicit width / height prevent the default replaced-element sizing rules from rendering an
- * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
  *
  * @return string SVG markup.
  */
 function veu_sns_icon_svg_bluesky() {
-	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"/></svg>';
+	return veu_sns_icon_svg_wrap( 'M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026' );
 }
 
 /**
- * Threads シェアボタンのアイコン SVG
+ * Threads シェアボタンのアイコン SVG（パスデータ）
  * 自前フォント vk_sns に字形がないため Font Awesome の fa-brands fa-threads を使っていたが、
  * 本プラグインは Font Awesome を読み込んでおらず、テーマ側の読み込みに依存していたため、
  * Font Awesome 未読み込みのテーマ（Twenty Twenty-Five など）でアイコンが表示されない不具合があった。
- * Font Awesome に依存しないよう、インライン SVG に置き換える。
+ * Font Awesome に依存しないよう、インライン SVG に置き換える。SVG の共通のガワは veu_sns_icon_svg_wrap() を参照。
  * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の threads.svg。
  * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
  * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、Threads ロゴ自体の商標権は
@@ -449,100 +473,85 @@ function veu_sns_icon_svg_bluesky() {
  * fa-brands fa-threads was used. This plugin does not load Font Awesome itself and relied on
  * the theme loading it, so the icon did not render on themes that do not load Font Awesome
  * ( e.g. Twenty Twenty-Five ). Replace it with an inline SVG so it no longer depends on Font Awesome.
+ * For the shared SVG shell, see veu_sns_icon_svg_wrap().
  * Source: Simple Icons ( https://simpleicons.org/ ) threads.svg.
  * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
  * This license covers the SVG ( the traced artwork ) copyright notice only; the Threads logo
  * itself remains a trademark of Meta. Used single-color, unmodified in shape, and only as a
  * share link icon.
- * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
- * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
- * Explicit width / height prevent the default replaced-element sizing rules from rendering an
- * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
  *
  * @return string SVG markup.
  */
 function veu_sns_icon_svg_threads() {
-	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M18.263 11.097c-.03-3.486-1.92-5.586-5.111-5.586-2.13 0-3.922.963-4.863 2.499l2.062 1.438c.535-.843 1.272-1.543 2.628-1.543 1.528 0 2.318.85 2.544 2.431a15 15 0 0 0-2.236-.173c-4.125 0-6.068 1.867-6.068 4.336s1.943 3.99 4.804 3.99c3.139 0 5.013-2.115 5.781-4.735.798.361 1.348 1.204 1.348 2.47 0 3.387-3.907 5.232-7.22 5.232-4.885 0-8.077-3.207-8.077-8.424 0-6.392 4.223-10.487 9.9-10.487 3.808 0 5.69 1.671 6.97 3.914l2.108-1.475C21.44 2.078 18.331 0 13.663 0 6.227 0 1.168 5.277 1.168 12.934c0 7 4.953 11.066 10.856 11.066 4.878 0 9.809-2.846 9.809-7.716 0-2.545-1.46-4.231-3.569-5.187m-6.33 4.855c-1.077 0-2.026-.512-2.026-1.453 0-1.483 1.822-1.934 3.606-1.934.678 0 1.34.045 1.927.173-.422 1.927-1.671 3.215-3.508 3.214Z"/></svg>';
+	return veu_sns_icon_svg_wrap( 'M18.263 11.097c-.03-3.486-1.92-5.586-5.111-5.586-2.13 0-3.922.963-4.863 2.499l2.062 1.438c.535-.843 1.272-1.543 2.628-1.543 1.528 0 2.318.85 2.544 2.431a15 15 0 0 0-2.236-.173c-4.125 0-6.068 1.867-6.068 4.336s1.943 3.99 4.804 3.99c3.139 0 5.013-2.115 5.781-4.735.798.361 1.348 1.204 1.348 2.47 0 3.387-3.907 5.232-7.22 5.232-4.885 0-8.077-3.207-8.077-8.424 0-6.392 4.223-10.487 9.9-10.487 3.808 0 5.69 1.671 6.97 3.914l2.108-1.475C21.44 2.078 18.331 0 13.663 0 6.227 0 1.168 5.277 1.168 12.934c0 7 4.953 11.066 10.856 11.066 4.878 0 9.809-2.846 9.809-7.716 0-2.545-1.46-4.231-3.569-5.187m-6.33 4.855c-1.077 0-2.026-.512-2.026-1.453 0-1.483 1.822-1.934 3.606-1.934.678 0 1.34.045 1.927.173-.422 1.927-1.671 3.215-3.508 3.214Z' );
 }
 
 /**
- * はてなブックマーク シェアボタンのアイコン SVG
- * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_hatena` で字形を出力していたが、
- * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
- * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * はてなブックマーク シェアボタンのアイコン SVG（パスデータ）
+ * SVG の共通のガワは veu_sns_icon_svg_wrap() を参照。
  * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の hatenabookmark.svg。
  * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
  * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、はてなブックマークのロゴ自体の
  * 商標権は株式会社はてなに帰属したまま。単色・形状非改変・シェア導線としての用途に限定して使用している。
- * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_hatena`.
- * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
- * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * For the shared SVG shell, see veu_sns_icon_svg_wrap().
  * Source: Simple Icons ( https://simpleicons.org/ ) hatenabookmark.svg.
  * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
  * This license covers the SVG ( the traced artwork ) copyright notice only; the Hatena Bookmark logo
  * itself remains a trademark of Hatena Co., Ltd. Used single-color, unmodified in shape, and only as
  * a share link icon.
- * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
- * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
- * Explicit width / height prevent the default replaced-element sizing rules from rendering an
- * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
  *
  * @return string SVG markup.
  */
 function veu_sns_icon_svg_hatena() {
-	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M20.47 0C22.42 0 24 1.58 24 3.53v16.94c0 1.95-1.58 3.53-3.53 3.53H3.53C1.58 24 0 22.42 0 20.47V3.53C0 1.58 1.58 0 3.53 0h16.94zm-3.705 14.47c-.78 0-1.41.63-1.41 1.41s.63 1.414 1.41 1.414 1.41-.645 1.41-1.425-.63-1.41-1.41-1.41zM8.61 17.247c1.2 0 2.056-.042 2.58-.12.526-.084.976-.222 1.32-.412.45-.232.78-.564 1.02-.99s.36-.915.36-1.48c0-.78-.21-1.403-.63-1.87-.42-.48-.99-.734-1.74-.794.66-.18 1.156-.45 1.456-.81.315-.344.465-.824.465-1.424 0-.48-.103-.885-.3-1.26-.21-.36-.493-.645-.883-.87-.345-.195-.735-.315-1.215-.405-.464-.074-1.29-.12-2.474-.12H5.654v10.486H8.61zm.736-4.185c.705 0 1.185.088 1.44.262.27.18.39.495.39.93 0 .405-.135.69-.42.855-.27.18-.765.254-1.44.254H8.31v-2.297h1.05zm8.656.706v-7.06h-2.46v7.06H18zM8.925 9.08c.71 0 1.185.08 1.432.24.245.16.367.435.367.83 0 .38-.13.646-.39.804-.265.154-.747.232-1.452.232h-.57V9.08h.615z"/></svg>';
+	return veu_sns_icon_svg_wrap( 'M20.47 0C22.42 0 24 1.58 24 3.53v16.94c0 1.95-1.58 3.53-3.53 3.53H3.53C1.58 24 0 22.42 0 20.47V3.53C0 1.58 1.58 0 3.53 0h16.94zm-3.705 14.47c-.78 0-1.41.63-1.41 1.41s.63 1.414 1.41 1.414 1.41-.645 1.41-1.425-.63-1.41-1.41-1.41zM8.61 17.247c1.2 0 2.056-.042 2.58-.12.526-.084.976-.222 1.32-.412.45-.232.78-.564 1.02-.99s.36-.915.36-1.48c0-.78-.21-1.403-.63-1.87-.42-.48-.99-.734-1.74-.794.66-.18 1.156-.45 1.456-.81.315-.344.465-.824.465-1.424 0-.48-.103-.885-.3-1.26-.21-.36-.493-.645-.883-.87-.345-.195-.735-.315-1.215-.405-.464-.074-1.29-.12-2.474-.12H5.654v10.486H8.61zm.736-4.185c.705 0 1.185.088 1.44.262.27.18.39.495.39.93 0 .405-.135.69-.42.855-.27.18-.765.254-1.44.254H8.31v-2.297h1.05zm8.656.706v-7.06h-2.46v7.06H18zM8.925 9.08c.71 0 1.185.08 1.432.24.245.16.367.435.367.83 0 .38-.13.646-.39.804-.265.154-.747.232-1.452.232h-.57V9.08h.615z' );
 }
 
 /**
- * LINE シェアボタンのアイコン SVG
- * 従来は自前 web フォント（vk_sns）の合字 `.vk_icon_w_r_sns_line` で字形を出力していたが、
- * Facebook 同様の理由（issue #1462）でインライン SVG に統一する。
- * 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS は削除せず残す（理由は veu_sns_icon_svg_facebook() を参照）。
+ * LINE シェアボタンのアイコン SVG（パスデータ）
+ * SVG の共通のガワは veu_sns_icon_svg_wrap() を参照。
  * 素材の出典: Simple Icons（ https://simpleicons.org/ ）の line.svg。
  * ライセンス: CC0 1.0 Universal（ https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ）。
  * このライセンスは SVG（トレース成果物）の著作権表示に関するもので、LINE ロゴ自体の商標権は
  * LINEヤフー株式会社（LY Corporation）に帰属したまま。単色・形状非改変・シェア導線としての用途に
  * 限定して使用している。
- * Previously rendered via the in-house web font ( vk_sns ) ligature `.vk_icon_w_r_sns_line`.
- * Unified to inline SVG for the same reason as Facebook ( issue #1462 ).
- * The web font itself and the `.vk_icon_w_r_sns_*` CSS are kept ( see veu_sns_icon_svg_facebook() for why ).
+ * For the shared SVG shell, see veu_sns_icon_svg_wrap().
  * Source: Simple Icons ( https://simpleicons.org/ ) line.svg.
  * License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
  * This license covers the SVG ( the traced artwork ) copyright notice only; the LINE logo itself
  * remains a trademark of LY Corporation. Used single-color, unmodified in shape, and only as a share
  * link icon.
- * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
- * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
- * Explicit width / height prevent the default replaced-element sizing rules from rendering an
- * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
  *
  * @return string SVG markup.
  */
 function veu_sns_icon_svg_line() {
-	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>';
+	return veu_sns_icon_svg_wrap( 'M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314' );
 }
 
 /**
- * Copy（コピー）シェアボタンのアイコン SVG
+ * Copy（コピー）シェアボタンのアイコン SVG（パスデータ）
  * 自前フォント vk_sns に字形がなく、Font Awesome の fas fa-copy に実質依存していたため、
  * Threads と同様に Font Awesome 未読み込みのテーマでアイコンが表示されない不具合があった。
- * Font Awesome に依存しないよう、インライン SVG に置き換える。
+ * Font Awesome に依存しないよう、インライン SVG に置き換える。SVG の共通のガワは veu_sns_icon_svg_wrap() を参照。
  * 素材の出典: Heroicons（ https://heroicons.com/ ）の square-2-stack（ solid ）。
  * ライセンス: MIT License（ https://github.com/tailwindlabs/heroicons/blob/master/LICENSE ）。
  * The in-house web font ( vk_sns ) has no glyph for this either, and it effectively depended on
  * the Font Awesome fas fa-copy icon, so it had the same missing-icon issue as Threads on themes
  * that do not load Font Awesome. Replace it with an inline SVG so it no longer depends on Font Awesome.
+ * For the shared SVG shell, see veu_sns_icon_svg_wrap().
  * Source: Heroicons ( https://heroicons.com/ ) square-2-stack ( solid ).
  * License: MIT License ( https://github.com/tailwindlabs/heroicons/blob/master/LICENSE ).
- * width / height を明示するのは、CSS が当たらない経路（RSS フィード・CSS ツリーシェイキング等）で
- * 置換要素の既定サイズ規則により正方形が大きく肥大表示されるのを防ぐため。
- * Explicit width / height prevent the default replaced-element sizing rules from rendering an
- * oversized square when CSS does not apply ( e.g. RSS feeds, CSS tree-shaking ).
+ * このアイコンだけ <path> が2つある（本体を欠けなく描くのに2パス必要な square-2-stack の構成による）。
+ * This is the only icon with 2 <path> elements ( inherent to how square-2-stack draws its shape ).
  *
  * @return string SVG markup.
  */
 function veu_sns_icon_svg_copy() {
-	return '<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M16.5 6a3 3 0 0 0-3-3H6a3 3 0 0 0-3 3v7.5a3 3 0 0 0 3 3v-6A4.5 4.5 0 0 1 10.5 6h6Z"/><path d="M18 7.5a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3h-7.5a3 3 0 0 1-3-3v-7.5a3 3 0 0 1 3-3H18Z"/></svg>';
+	return veu_sns_icon_svg_wrap(
+		array(
+			'M16.5 6a3 3 0 0 0-3-3H6a3 3 0 0 0-3 3v7.5a3 3 0 0 0 3 3v-6A4.5 4.5 0 0 1 10.5 6h6Z',
+			'M18 7.5a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3h-7.5a3 3 0 0 1-3-3v-7.5a3 3 0 0 1 3-3H18Z',
+		)
+	);
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,35 @@ e.g.
 1. Feature can be stopped individually.
 2. This is an example of SNS cooperation setting screen.
 
+== Credits ==
+
+This plugin's share button icons (Facebook, X, Bluesky, Threads, Hatena Bookmark, LINE, Copy) are inline SVG traced from the following third-party icon sets. The SVG license below covers the traced artwork only; each service's logo remains a trademark of its respective owner and is used here single-color, unmodified in shape, and only as a share link icon.
+
+* Facebook, X, Bluesky, Threads, Hatena Bookmark and LINE icons: Simple Icons ( https://simpleicons.org/ ), licensed under CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
+* Copy icon: Heroicons ( https://heroicons.com/ ), square-2-stack (solid), licensed under the MIT License ( https://github.com/tailwindlabs/heroicons/blob/master/LICENSE ). Full text below, as required by the MIT License:
+
+MIT License
+
+Copyright (c) Tailwind Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 == Changelog ==
 
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ e.g.
 == Changelog ==
 
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.
-[ Spec Change ][ SNS Share Button ] Unified the Facebook, X, Bluesky, Hatena Bookmark and LINE icons to inline SVG to match Threads and Copy. The markup no longer uses the ".vk_icon_w_r_sns_*" web font classes; the classes and the font itself are kept for backward compatibility (e.g. custom CSS, Lightning skins).
+[ Spec Change ][ SNS Share Button ] Unified the Facebook, X, Bluesky, Hatena Bookmark and LINE icons to inline SVG to match Threads and Copy. The markup no longer uses the ".vk_icon_w_r_sns_*" web font classes; the classes and the font itself are kept for backward compatibility.
 [ Bug Fix ][ Block ] Fixed the Share Button, HTML Sitemap and other blocks showing "This block has encountered an error and cannot be previewed" in the editor when the post contains a cross-origin iframe embed.
 [ Bug Fix ][ Share Button ] Fixed the share button block always showing in the editor even when excluded from the front end, hiding the mismatch while editing. The editor now explains why it will not display.
 [ Bug Fix ][ SNS Share Button ] Fixed the Threads and Copy icons not being displayed on themes that do not load Font Awesome (e.g. Twenty Twenty-Five), by replacing them with inline SVG.

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ e.g.
 == Changelog ==
 
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.
+[ Spec Change ][ SNS Share Button ] Unified the Facebook, X, Bluesky, Hatena Bookmark and LINE icons to inline SVG to match Threads and Copy. The markup no longer uses the ".vk_icon_w_r_sns_*" web font classes; the classes and the font itself are kept for backward compatibility (e.g. custom CSS, Lightning skins).
 [ Bug Fix ][ Block ] Fixed the Share Button, HTML Sitemap and other blocks showing "This block has encountered an error and cannot be previewed" in the editor when the post contains a cross-origin iframe embed.
 [ Bug Fix ][ Share Button ] Fixed the share button block always showing in the editor even when excluded from the front end, hiding the mismatch while editing. The editor now explains why it will not display.
 [ Bug Fix ][ SNS Share Button ] Fixed the Threads and Copy icons not being displayed on themes that do not load Font Awesome (e.g. Twenty Twenty-Five), by replacing them with inline SVG.

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -399,16 +399,48 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			delete_option( 'vkExUnit_sns_options' );
 		}
 
-		// 装飾アイコン（Threads / Copy）の SVG 自体にも aria-hidden="true" と focusable="false" が付き、
-		// 読み上げやタブフォーカスの対象から除外される事のテスト（外側の span への統一は下の $webfont_cases 側で確認する）。
-		// Test that the SVG itself ( for the decorative icons Threads / Copy ) also gets aria-hidden="true"
-		// and focusable="false", so it is excluded from screen readers and tab focus. The outer span
-		// aria-hidden is unified with the other icons and checked in $webfont_cases below.
+		// 装飾アイコン（7つ全て）の SVG 自体にも aria-hidden="true" と focusable="false" が付き、
+		// 読み上げやタブフォーカスの対象から除外される事のテスト（外側の span への統一は下の $icon_wrap_cases 側で確認する）。
+		// issue #1462 で Facebook / X / Bluesky / Hatena / LINE も Threads / Copy と同じインライン SVG に
+		// 統一されたため、7つ全てを同じ回帰ガードで検証する。
+		// Test that the SVG itself ( for all 7 decorative icons ) also gets aria-hidden="true" and
+		// focusable="false", so it is excluded from screen readers and tab focus. The outer span
+		// aria-hidden is unified with the other icons and checked in $icon_wrap_cases below.
+		// Facebook / X / Bluesky / Hatena / LINE were unified to the same inline SVG approach as
+		// Threads / Copy in issue #1462, so all 7 are verified with the same regression guards here.
 		$svg_aria_cases = array(
+			array(
+				'test_condition_name' => 'useFacebook が true の場合 => Facebook の svg に aria-hidden="true" focusable="false" が付く',
+				'options'             => array( 'useFacebook' => true ),
+				'expected'            => veu_sns_icon_svg_facebook(),
+			),
+			array(
+				'test_condition_name' => 'useTwitter が true の場合 => X の svg に aria-hidden="true" focusable="false" が付く',
+				'options'             => array( 'useTwitter' => true ),
+				'expected'            => veu_sns_icon_svg_x(),
+			),
+			array(
+				'test_condition_name' => 'useBluesky が true の場合 => Bluesky の svg に aria-hidden="true" focusable="false" が付く',
+				'options'             => array( 'useBluesky' => true ),
+				'expected'            => veu_sns_icon_svg_bluesky(),
+			),
 			array(
 				'test_condition_name' => 'useThreads が true の場合 => Threads の svg に aria-hidden="true" focusable="false" が付く',
 				'options'             => array( 'useThreads' => true ),
 				'expected'            => veu_sns_icon_svg_threads(),
+			),
+			array(
+				'test_condition_name' => 'useHatena が true の場合 => Hatena の svg に aria-hidden="true" focusable="false" が付く',
+				'options'             => array( 'useHatena' => true ),
+				'expected'            => veu_sns_icon_svg_hatena(),
+			),
+			array(
+				// LINE はモバイル UA で wp_is_mobile() を true にした時のみ出力されるため、このケースだけ 'mobile' => true を渡す。
+				// LINE is only output when wp_is_mobile() is true via a mobile UA, so only this case passes 'mobile' => true.
+				'test_condition_name' => 'useLine が true かつモバイルの場合 => LINE の svg に aria-hidden="true" focusable="false" が付く',
+				'options'             => array( 'useLine' => true ),
+				'expected'            => veu_sns_icon_svg_line(),
+				'mobile'              => true,
 			),
 			array(
 				'test_condition_name' => 'useCopy が true の場合 => Copy の svg に aria-hidden="true" focusable="false" が付く',
@@ -417,52 +449,77 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			),
 		);
 
-		foreach ( $svg_aria_cases as $case ) {
-			// SVG 自体が aria-hidden="true" と focusable="false" を明示している事を確認
-			// Check the SVG markup itself declares aria-hidden="true" and focusable="false".
-			$this->assertStringContainsString( 'aria-hidden="true"', $case['expected'], $case['test_condition_name'] );
-			$this->assertStringContainsString( 'focusable="false"', $case['expected'], $case['test_condition_name'] );
-			// 一部の支援技術は aria-hidden があっても読み上げてしまうため、title / desc は含めない事を確認
-			// Some assistive technologies read out <title> / <desc> even with aria-hidden, so check they are not included.
-			$this->assertStringNotContainsString( '<title', $case['expected'], $case['test_condition_name'] );
-			$this->assertStringNotContainsString( '<desc', $case['expected'], $case['test_condition_name'] );
-			// サイズを決めている class="sb_svg_icon" が付いている事を確認（消えたり改名されると
-			// .sb_svg_icon の CSS が当たらなくなり、置換要素の既定サイズ規則で肥大表示される）。
-			// Check class="sb_svg_icon" is present ( the class that drives sizing ). If it disappears
-			// or gets renamed, the .sb_svg_icon CSS no longer applies and the default replaced-element
-			// sizing rules would render an oversized icon.
-			$this->assertStringContainsString( 'class="sb_svg_icon"', $case['expected'], $case['test_condition_name'] );
-			// 将来アイコンを追加する人への回帰ガードとして、危険なトークンが含まれない事を確認。
-			// HTML パーサは大文字小文字を区別しない（例: <foreignObject> は <foreignobject> とも書ける）ため、
-			// 単純な文字列一致ではなく大小無視の正規表現で判定する。
-			// Regression guard for future icon additions: check no dangerous tokens are included.
-			// HTML parsing is case-insensitive ( e.g. <foreignObject> can also be written <foreignobject> ),
-			// so use a case-insensitive regular expression instead of a plain string match.
-			$this->assertDoesNotMatchRegularExpression(
-				'/<(script|foreignobject|use|image)\b|xlink|href=/i',
-				$case['expected'],
-				$case['test_condition_name']
-			);
-			// アイコン色が snsBtn_color オプションで切り替えられるよう fill="currentColor" が明示されている事を確認
-			// Check fill="currentColor" is declared so the icon color follows the snsBtn_color option.
-			$this->assertStringContainsString( 'fill="currentColor"', $case['expected'], $case['test_condition_name'] );
-			// width:1em; height:1em; という 1:1 前提と矛盾しないよう viewBox も正方形（1:1）である事を確認
-			// Check the viewBox is also square ( 1:1 ), consistent with the width:1em; height:1em; 1:1 premise.
-			preg_match( '/viewBox="0 0 (\d+) (\d+)"/', $case['expected'], $viewbox_matches );
-			$this->assertNotEmpty( $viewbox_matches, $case['test_condition_name'] );
-			$this->assertSame( $viewbox_matches[1], $viewbox_matches[2], $case['test_condition_name'] );
+		// LINE のケースのみモバイル UA を必要とするため、ループ実行前に元の UA を保持し try/finally で復元する。
+		// Only the LINE case needs a mobile UA, so preserve the original UA before the loop and restore it in finally.
+		$svg_aria_original_ua = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
+		// iPhone の UA。文字列に "Mobile" を含むため wp_is_mobile() が true を返す。
+		// iPhone UA. It contains "Mobile", so wp_is_mobile() returns true.
+		$svg_aria_mobile_ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 
-			// オプション値を設定 / Set option value.
-			update_option( 'vkExUnit_sns_options', $case['options'] );
+		try {
+			foreach ( $svg_aria_cases as $case ) {
+				// SVG 自体が aria-hidden="true" と focusable="false" を明示している事を確認
+				// Check the SVG markup itself declares aria-hidden="true" and focusable="false".
+				$this->assertStringContainsString( 'aria-hidden="true"', $case['expected'], $case['test_condition_name'] );
+				$this->assertStringContainsString( 'focusable="false"', $case['expected'], $case['test_condition_name'] );
+				// 一部の支援技術は aria-hidden があっても読み上げてしまうため、title / desc は含めない事を確認
+				// Some assistive technologies read out <title> / <desc> even with aria-hidden, so check they are not included.
+				$this->assertStringNotContainsString( '<title', $case['expected'], $case['test_condition_name'] );
+				$this->assertStringNotContainsString( '<desc', $case['expected'], $case['test_condition_name'] );
+				// サイズを決めている class="sb_svg_icon" が付いている事を確認（消えたり改名されると
+				// .sb_svg_icon の CSS が当たらなくなり、置換要素の既定サイズ規則で肥大表示される）。
+				// Check class="sb_svg_icon" is present ( the class that drives sizing ). If it disappears
+				// or gets renamed, the .sb_svg_icon CSS no longer applies and the default replaced-element
+				// sizing rules would render an oversized icon.
+				$this->assertStringContainsString( 'class="sb_svg_icon"', $case['expected'], $case['test_condition_name'] );
+				// 将来アイコンを追加する人への回帰ガードとして、危険なトークンが含まれない事を確認。
+				// HTML パーサは大文字小文字を区別しない（例: <foreignObject> は <foreignobject> とも書ける）ため、
+				// 単純な文字列一致ではなく大小無視の正規表現で判定する。
+				// Regression guard for future icon additions: check no dangerous tokens are included.
+				// HTML parsing is case-insensitive ( e.g. <foreignObject> can also be written <foreignobject> ),
+				// so use a case-insensitive regular expression instead of a plain string match.
+				$this->assertDoesNotMatchRegularExpression(
+					'/<(script|foreignobject|use|image)\b|xlink|href=/i',
+					$case['expected'],
+					$case['test_condition_name']
+				);
+				// アイコン色が snsBtn_color オプションで切り替えられるよう fill="currentColor" が明示されている事を確認
+				// Check fill="currentColor" is declared so the icon color follows the snsBtn_color option.
+				$this->assertStringContainsString( 'fill="currentColor"', $case['expected'], $case['test_condition_name'] );
+				// width:1em; height:1em; という 1:1 前提と矛盾しないよう viewBox も正方形（1:1）である事を確認
+				// Check the viewBox is also square ( 1:1 ), consistent with the width:1em; height:1em; 1:1 premise.
+				preg_match( '/viewBox="0 0 (\d+) (\d+)"/', $case['expected'], $viewbox_matches );
+				$this->assertNotEmpty( $viewbox_matches, $case['test_condition_name'] );
+				$this->assertSame( $viewbox_matches[1], $viewbox_matches[2], $case['test_condition_name'] );
 
-			// シェアボタンの HTML を取得 / Get the share button HTML.
-			$actual = veu_get_sns_btns();
+				// LINE のケースのみモバイル UA を設定する（wp_is_mobile() を true にするため）。
+				// Set the mobile UA only for the LINE case ( to make wp_is_mobile() return true ).
+				if ( ! empty( $case['mobile'] ) ) {
+					$_SERVER['HTTP_USER_AGENT'] = $svg_aria_mobile_ua;
+				} else {
+					unset( $_SERVER['HTTP_USER_AGENT'] );
+				}
 
-			// 装飾アイコンの SVG が出力に含まれる事を確認 / Check the decorative icon's SVG is included in the output.
-			$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
+				// オプション値を設定 / Set option value.
+				update_option( 'vkExUnit_sns_options', $case['options'] );
 
-			// オプション値をクリーンアップ / Clean up the option value.
-			delete_option( 'vkExUnit_sns_options' );
+				// シェアボタンの HTML を取得 / Get the share button HTML.
+				$actual = veu_get_sns_btns();
+
+				// 装飾アイコンの SVG が出力に含まれる事を確認 / Check the decorative icon's SVG is included in the output.
+				$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
+
+				// オプション値をクリーンアップ / Clean up the option value.
+				delete_option( 'vkExUnit_sns_options' );
+			}
+		} finally {
+			// テスト後は $_SERVER['HTTP_USER_AGENT'] を必ず元に戻す（未設定だったら unset）。
+			// Always restore $_SERVER['HTTP_USER_AGENT'] after the test ( unset if it was not set ).
+			if ( null === $svg_aria_original_ua ) {
+				unset( $_SERVER['HTTP_USER_AGENT'] );
+			} else {
+				$_SERVER['HTTP_USER_AGENT'] = $svg_aria_original_ua;
+			}
 		}
 
 		// アイコンへの配色経路が「フォント色（vk_sns glyph）→ color」から「fill="currentColor"」に変わった事の
@@ -488,13 +545,19 @@ class SnsBtnsTest extends WP_UnitTestCase {
 		);
 		delete_option( 'vkExUnit_sns_options' );
 
-		// 各 SNS アイコンの外側 span（icon_sns）に aria-hidden="true" が付き読み上げから除外される事のテスト
-		// （ fb / x / bluesky / hatena / line は自前 web フォント（vk_sns）の空 span、Threads / Copy はインライン SVG を包む span ）。
-		// SVG 化を機に、Threads / Copy も他の5つと同じく外側の span に aria-hidden を統一した事を確認する。
-		// Test that the outer span ( icon_sns ) of each SNS icon gets aria-hidden="true" and is hidden from screen
-		// readers ( fb / x / bluesky / hatena / line are empty in-house web font ( vk_sns ) spans, Threads / Copy
-		// are spans wrapping an inline SVG ). Confirm that, following the move to SVG, Threads / Copy now also
-		// place aria-hidden on the outer span like the other 5 icons.
+		// 各 SNS アイコンの外側 span（icon_sns）に aria-hidden="true" が付き読み上げから除外される事のテスト。
+		// issue #1462 で fb / x / bluesky / hatena / line も、従来の自前 web フォント（vk_sns）の空 span
+		// （`.vk_icon_w_r_sns_*` クラス）から Threads / Copy と同じインライン SVG を包む span に統一された
+		// ため、7つとも同じマークアップ（`<span class="icon_sns" aria-hidden="true">` + SVG）で検証する。
+		// 自前フォント本体・`.vk_icon_w_r_sns_*` の CSS 自体は後方互換のため削除していないが、この出力
+		// （マークアップ）ではもう使われない事を、クラスが含まれない事の確認で担保する。
+		// Test that the outer span ( icon_sns ) of each SNS icon gets aria-hidden="true" and is hidden from
+		// screen readers. In issue #1462, fb / x / bluesky / hatena / line were unified from the old
+		// in-house web font ( vk_sns ) empty spans ( `.vk_icon_w_r_sns_*` classes ) to the same inline-SVG
+		// wrapping span as Threads / Copy, so all 7 are now verified with the same markup
+		// ( `<span class="icon_sns" aria-hidden="true">` + SVG ). The web font itself and the
+		// `.vk_icon_w_r_sns_*` CSS are kept for backward compatibility ( not removed ), but checking the
+		// class is absent from this output confirms the markup no longer uses it.
 		// class 直後・$icon_css の前に aria-hidden が入る実出力に合わせてリテラルで検証する。
 		// Verify against the literal output where aria-hidden comes right after class and before $icon_css.
 		// LINE はモバイル環境（wp_is_mobile() が true）かつ useLine が有効な時のみ出力されるため、ケースごとに user_agent を設定して分岐を通す。
@@ -503,50 +566,57 @@ class SnsBtnsTest extends WP_UnitTestCase {
 		// iPhone UA. It contains "Mobile", so wp_is_mobile() returns true.
 		$mobile_ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 
-		$webfont_cases = array(
+		$icon_wrap_cases = array(
 			array(
-				'test_condition_name' => 'useFacebook が true の場合 => Facebook の web フォント span に aria-hidden="true" が付く',
+				'test_condition_name' => 'useFacebook が true の場合 => Facebook の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useFacebook' => true ),
 				'user_agent'          => null,
-				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_fb icon_sns" aria-hidden="true"' ),
+				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_facebook() . '</span>' ),
+				'not_expected'        => 'vk_icon_w_r_sns_fb',
 			),
 			array(
-				'test_condition_name' => 'useTwitter が true の場合 => X の web フォント span に aria-hidden="true" が付く',
+				'test_condition_name' => 'useTwitter が true の場合 => X の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useTwitter' => true ),
 				'user_agent'          => null,
-				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_x_twitter icon_sns" aria-hidden="true"' ),
+				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_x() . '</span>' ),
+				'not_expected'        => 'vk_icon_w_r_sns_x_twitter',
 			),
 			array(
-				'test_condition_name' => 'useBluesky が true の場合 => Bluesky の web フォント span に aria-hidden="true" が付く',
+				'test_condition_name' => 'useBluesky が true の場合 => Bluesky の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useBluesky' => true ),
 				'user_agent'          => null,
-				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_bluesky icon_sns" aria-hidden="true"' ),
+				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_bluesky() . '</span>' ),
+				'not_expected'        => 'vk_icon_w_r_sns_bluesky',
 			),
 			array(
-				'test_condition_name' => 'useHatena が true の場合 => Hatena の web フォント span に aria-hidden="true" が付く',
+				'test_condition_name' => 'useHatena が true の場合 => Hatena の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useHatena' => true ),
 				'user_agent'          => null,
-				'expected_contains'   => array( '<span class="vk_icon_w_r_sns_hatena icon_sns" aria-hidden="true"' ),
+				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_hatena() . '</span>' ),
+				'not_expected'        => 'vk_icon_w_r_sns_hatena',
 			),
 			array(
 				// LINE はモバイル UA で wp_is_mobile() を true にした時のみ出力される。sb_line が含まれる事＝モバイル分岐を実際に通った裏取り（他に出力経路が無い）。
 				// LINE is only output when wp_is_mobile() is true via the mobile UA. Containing sb_line proves the mobile branch was actually taken ( no other output path ).
-				'test_condition_name' => 'useLine が true かつモバイルの場合 => LINE ボタンが出力され LINE の web フォント span に aria-hidden="true" が付く',
+				'test_condition_name' => 'useLine が true かつモバイルの場合 => LINE ボタンが出力され SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useLine' => true ),
 				'user_agent'          => $mobile_ua,
-				'expected_contains'   => array( 'sb_line', '<span class="vk_icon_w_r_sns_line icon_sns" aria-hidden="true"' ),
+				'expected_contains'   => array( 'sb_line', '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_line() . '</span>' ),
+				'not_expected'        => 'vk_icon_w_r_sns_line',
 			),
 			array(
-				'test_condition_name' => 'useThreads が true の場合 => Threads の SVG を包む span に aria-hidden="true" が付く（他5つの icon_sns と統一）',
+				'test_condition_name' => 'useThreads が true の場合 => Threads の SVG を包む span に aria-hidden="true" が付く（他の icon_sns と統一）',
 				'options'             => array( 'useThreads' => true ),
 				'user_agent'          => null,
-				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true"' ),
+				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_threads() . '</span>' ),
+				'not_expected'        => null,
 			),
 			array(
-				'test_condition_name' => 'useCopy が true の場合 => Copy の SVG を包む span に aria-hidden="true" が付く（他5つの icon_sns と統一）',
+				'test_condition_name' => 'useCopy が true の場合 => Copy の SVG を包む span に aria-hidden="true" が付く（他の icon_sns と統一）',
 				'options'             => array( 'useCopy' => true ),
 				'user_agent'          => null,
-				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true"' ),
+				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_copy() . '</span>' ),
+				'not_expected'        => null,
 			),
 		);
 
@@ -555,7 +625,7 @@ class SnsBtnsTest extends WP_UnitTestCase {
 		$original_ua = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
 
 		try {
-			foreach ( $webfont_cases as $case ) {
+			foreach ( $icon_wrap_cases as $case ) {
 				// ケースごとに UA を設定（null なら未設定にする）。LINE はモバイル UA で分岐を通す。
 				// Set the UA per case ( unset if null ). LINE goes through the branch with the mobile UA.
 				if ( null === $case['user_agent'] ) {
@@ -573,6 +643,12 @@ class SnsBtnsTest extends WP_UnitTestCase {
 				// 期待する文字列が全て含まれる事を確認（装飾アイコン span の aria-hidden 等）/ Check that all expected strings are included ( aria-hidden on the decorative span icon, etc. ).
 				foreach ( $case['expected_contains'] as $expected ) {
 					$this->assertStringContainsString( $expected, $actual, $case['test_condition_name'] );
+				}
+
+				// 旧・自前 web フォントのクラスがマークアップに残っていない事を確認（issue #1462 での移行確認）。
+				// Check the old in-house web font class is no longer present in the markup ( confirms the migration in issue #1462 ).
+				if ( null !== $case['not_expected'] ) {
+					$this->assertStringNotContainsString( $case['not_expected'], $actual, $case['test_condition_name'] );
 				}
 
 				// オプション値をクリーンアップ / Clean up the option value.

--- a/tests/test-sns-btns.php
+++ b/tests/test-sns-btns.php
@@ -399,127 +399,65 @@ class SnsBtnsTest extends WP_UnitTestCase {
 			delete_option( 'vkExUnit_sns_options' );
 		}
 
-		// 装飾アイコン（7つ全て）の SVG 自体にも aria-hidden="true" と focusable="false" が付き、
-		// 読み上げやタブフォーカスの対象から除外される事のテスト（外側の span への統一は下の $icon_wrap_cases 側で確認する）。
+		// 装飾アイコン（7つ全て）の SVG 自体が、想定した構造以外の何物でもない事を確認するテスト
+		// （外側の span への統一・実際の出力への混入確認は下の $icon_wrap_cases 側で行う）。
 		// issue #1462 で Facebook / X / Bluesky / Hatena / LINE も Threads / Copy と同じインライン SVG に
 		// 統一されたため、7つ全てを同じ回帰ガードで検証する。
-		// Test that the SVG itself ( for all 7 decorative icons ) also gets aria-hidden="true" and
-		// focusable="false", so it is excluded from screen readers and tab focus. The outer span
-		// aria-hidden is unified with the other icons and checked in $icon_wrap_cases below.
-		// Facebook / X / Bluesky / Hatena / LINE were unified to the same inline SVG approach as
-		// Threads / Copy in issue #1462, so all 7 are verified with the same regression guards here.
-		$svg_aria_cases = array(
-			array(
-				'test_condition_name' => 'useFacebook が true の場合 => Facebook の svg に aria-hidden="true" focusable="false" が付く',
-				'options'             => array( 'useFacebook' => true ),
-				'expected'            => veu_sns_icon_svg_facebook(),
-			),
-			array(
-				'test_condition_name' => 'useTwitter が true の場合 => X の svg に aria-hidden="true" focusable="false" が付く',
-				'options'             => array( 'useTwitter' => true ),
-				'expected'            => veu_sns_icon_svg_x(),
-			),
-			array(
-				'test_condition_name' => 'useBluesky が true の場合 => Bluesky の svg に aria-hidden="true" focusable="false" が付く',
-				'options'             => array( 'useBluesky' => true ),
-				'expected'            => veu_sns_icon_svg_bluesky(),
-			),
-			array(
-				'test_condition_name' => 'useThreads が true の場合 => Threads の svg に aria-hidden="true" focusable="false" が付く',
-				'options'             => array( 'useThreads' => true ),
-				'expected'            => veu_sns_icon_svg_threads(),
-			),
-			array(
-				'test_condition_name' => 'useHatena が true の場合 => Hatena の svg に aria-hidden="true" focusable="false" が付く',
-				'options'             => array( 'useHatena' => true ),
-				'expected'            => veu_sns_icon_svg_hatena(),
-			),
-			array(
-				// LINE はモバイル UA で wp_is_mobile() を true にした時のみ出力されるため、このケースだけ 'mobile' => true を渡す。
-				// LINE is only output when wp_is_mobile() is true via a mobile UA, so only this case passes 'mobile' => true.
-				'test_condition_name' => 'useLine が true かつモバイルの場合 => LINE の svg に aria-hidden="true" focusable="false" が付く',
-				'options'             => array( 'useLine' => true ),
-				'expected'            => veu_sns_icon_svg_line(),
-				'mobile'              => true,
-			),
-			array(
-				'test_condition_name' => 'useCopy が true の場合 => Copy の svg に aria-hidden="true" focusable="false" が付く',
-				'options'             => array( 'useCopy' => true ),
-				'expected'            => veu_sns_icon_svg_copy(),
-			),
+		// このループは7つの関数の戻り値だけを検査する純粋なテストで、WP の option 設定や
+		// veu_get_sns_btns() の呼び出し、UA の差し替えは行わない（実際の出力への混入は
+		// $icon_wrap_cases 側の完全一致検証で確認済みのため、ここで重複させない）。
+		// Test that the SVG itself ( for all 7 decorative icons ) is nothing other than the expected
+		// shape ( the outer span's aria-hidden and its presence in the actual output are checked in
+		// $icon_wrap_cases below ). Facebook / X / Bluesky / Hatena / LINE were unified to the same
+		// inline SVG approach as Threads / Copy in issue #1462, so all 7 are verified with the same
+		// regression guard here. This loop only inspects each function's return value — no WP option
+		// setup, no veu_get_sns_btns() call, and no UA switching ( that integration is already covered
+		// by the exact-match assertions in $icon_wrap_cases, so it is not duplicated here ).
+		$svg_cases = array(
+			'Facebook' => veu_sns_icon_svg_facebook(),
+			'X'        => veu_sns_icon_svg_x(),
+			'Bluesky'  => veu_sns_icon_svg_bluesky(),
+			'Threads'  => veu_sns_icon_svg_threads(),
+			'Hatena'   => veu_sns_icon_svg_hatena(),
+			'LINE'     => veu_sns_icon_svg_line(),
+			'Copy'     => veu_sns_icon_svg_copy(),
 		);
 
-		// LINE のケースのみモバイル UA を必要とするため、ループ実行前に元の UA を保持し try/finally で復元する。
-		// Only the LINE case needs a mobile UA, so preserve the original UA before the loop and restore it in finally.
-		$svg_aria_original_ua = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
-		// iPhone の UA。文字列に "Mobile" を含むため wp_is_mobile() が true を返す。
-		// iPhone UA. It contains "Mobile", so wp_is_mobile() returns true.
-		$svg_aria_mobile_ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+		// 「危険なトークンを列挙して弾く」denylist 方式（旧 assertDoesNotMatchRegularExpression）は、
+		// <svg onload=...> のようなイベントハンドラ属性や javascript: スキーム、<style>、SMIL アニメーション
+		// （<animate>/<set> の attributeName="href" + to="javascript:..."。属性値が href" であって
+		// href= ではないため denylist の /href=/ に掛からない）を素通りさせてしまう。
+		// 許可する構造そのものを固定する allowlist 方式に変更し、想定した svg 要素の8属性と
+		// path 要素の d 属性（パスデータの文字だけ）以外を一切許さない事で、未知の危険要素も
+		// 自動的に弾けるようにする。
+		// The denylist approach ( enumerating "dangerous tokens" to reject; the old
+		// assertDoesNotMatchRegularExpression ) lets through inline event handler attributes like
+		// <svg onload=...>, the javascript: scheme, <style>, and SMIL animation ( <animate>/<set> with
+		// attributeName="href" + to="javascript:..." — the attribute value is href" rather than href=,
+		// so it does not match the denylist's /href=/ ). Switch to an allowlist that pins down exactly
+		// which structure is permitted — the expected 8 <svg> attributes and <path> elements whose "d"
+		// attribute contains only path-data characters — so unknown dangerous elements are rejected
+		// automatically too.
+		$allowed_svg_pattern = '#^<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 \d+ \d+" fill="currentColor" aria-hidden="true" focusable="false" xmlns="http://www\.w3\.org/2000/svg">(?:<path d="[MmLlHhVvCcSsQqTtAaZz0-9eE.,\-\s]+"/>)+</svg>$#';
 
-		try {
-			foreach ( $svg_aria_cases as $case ) {
-				// SVG 自体が aria-hidden="true" と focusable="false" を明示している事を確認
-				// Check the SVG markup itself declares aria-hidden="true" and focusable="false".
-				$this->assertStringContainsString( 'aria-hidden="true"', $case['expected'], $case['test_condition_name'] );
-				$this->assertStringContainsString( 'focusable="false"', $case['expected'], $case['test_condition_name'] );
-				// 一部の支援技術は aria-hidden があっても読み上げてしまうため、title / desc は含めない事を確認
-				// Some assistive technologies read out <title> / <desc> even with aria-hidden, so check they are not included.
-				$this->assertStringNotContainsString( '<title', $case['expected'], $case['test_condition_name'] );
-				$this->assertStringNotContainsString( '<desc', $case['expected'], $case['test_condition_name'] );
-				// サイズを決めている class="sb_svg_icon" が付いている事を確認（消えたり改名されると
-				// .sb_svg_icon の CSS が当たらなくなり、置換要素の既定サイズ規則で肥大表示される）。
-				// Check class="sb_svg_icon" is present ( the class that drives sizing ). If it disappears
-				// or gets renamed, the .sb_svg_icon CSS no longer applies and the default replaced-element
-				// sizing rules would render an oversized icon.
-				$this->assertStringContainsString( 'class="sb_svg_icon"', $case['expected'], $case['test_condition_name'] );
-				// 将来アイコンを追加する人への回帰ガードとして、危険なトークンが含まれない事を確認。
-				// HTML パーサは大文字小文字を区別しない（例: <foreignObject> は <foreignobject> とも書ける）ため、
-				// 単純な文字列一致ではなく大小無視の正規表現で判定する。
-				// Regression guard for future icon additions: check no dangerous tokens are included.
-				// HTML parsing is case-insensitive ( e.g. <foreignObject> can also be written <foreignobject> ),
-				// so use a case-insensitive regular expression instead of a plain string match.
-				$this->assertDoesNotMatchRegularExpression(
-					'/<(script|foreignobject|use|image)\b|xlink|href=/i',
-					$case['expected'],
-					$case['test_condition_name']
-				);
-				// アイコン色が snsBtn_color オプションで切り替えられるよう fill="currentColor" が明示されている事を確認
-				// Check fill="currentColor" is declared so the icon color follows the snsBtn_color option.
-				$this->assertStringContainsString( 'fill="currentColor"', $case['expected'], $case['test_condition_name'] );
-				// width:1em; height:1em; という 1:1 前提と矛盾しないよう viewBox も正方形（1:1）である事を確認
-				// Check the viewBox is also square ( 1:1 ), consistent with the width:1em; height:1em; 1:1 premise.
-				preg_match( '/viewBox="0 0 (\d+) (\d+)"/', $case['expected'], $viewbox_matches );
-				$this->assertNotEmpty( $viewbox_matches, $case['test_condition_name'] );
-				$this->assertSame( $viewbox_matches[1], $viewbox_matches[2], $case['test_condition_name'] );
+		foreach ( $svg_cases as $icon_name => $svg ) {
+			$test_condition_name = $icon_name . ' の svg が、想定した構造（8属性の svg 要素 + path 要素のみ）から外れない事';
 
-				// LINE のケースのみモバイル UA を設定する（wp_is_mobile() を true にするため）。
-				// Set the mobile UA only for the LINE case ( to make wp_is_mobile() return true ).
-				if ( ! empty( $case['mobile'] ) ) {
-					$_SERVER['HTTP_USER_AGENT'] = $svg_aria_mobile_ua;
-				} else {
-					unset( $_SERVER['HTTP_USER_AGENT'] );
-				}
+			// allowlist で全体を厳密一致させる。aria-hidden="true" / focusable="false" / class="sb_svg_icon" /
+			// fill="currentColor" の存在、<title>/<desc>/<script>/<style> 等が無い事を1本でまとめて担保する。
+			// Match the whole string against the allowlist. This single assertion covers the presence of
+			// aria-hidden="true" / focusable="false" / class="sb_svg_icon" / fill="currentColor", and the
+			// absence of <title>/<desc>/<script>/<style> and any other unexpected element, all at once.
+			$this->assertMatchesRegularExpression( $allowed_svg_pattern, $svg, $test_condition_name );
 
-				// オプション値を設定 / Set option value.
-				update_option( 'vkExUnit_sns_options', $case['options'] );
-
-				// シェアボタンの HTML を取得 / Get the share button HTML.
-				$actual = veu_get_sns_btns();
-
-				// 装飾アイコンの SVG が出力に含まれる事を確認 / Check the decorative icon's SVG is included in the output.
-				$this->assertStringContainsString( $case['expected'], $actual, $case['test_condition_name'] );
-
-				// オプション値をクリーンアップ / Clean up the option value.
-				delete_option( 'vkExUnit_sns_options' );
-			}
-		} finally {
-			// テスト後は $_SERVER['HTTP_USER_AGENT'] を必ず元に戻す（未設定だったら unset）。
-			// Always restore $_SERVER['HTTP_USER_AGENT'] after the test ( unset if it was not set ).
-			if ( null === $svg_aria_original_ua ) {
-				unset( $_SERVER['HTTP_USER_AGENT'] );
-			} else {
-				$_SERVER['HTTP_USER_AGENT'] = $svg_aria_original_ua;
-			}
+			// width:1em; height:1em; という 1:1 前提と矛盾しないよう viewBox も正方形（1:1）である事を確認
+			// （allowlist の \d+ \d+ は2つの数値が別々でも通るため、等しいかはここで別途確認する）。
+			// Check the viewBox is also square ( 1:1 ), consistent with the width:1em; height:1em; 1:1
+			// premise ( the allowlist's \d+ \d+ matches even if the two numbers differ, so equality is
+			// verified separately here ).
+			preg_match( '/viewBox="0 0 (\d+) (\d+)"/', $svg, $viewbox_matches );
+			$this->assertNotEmpty( $viewbox_matches, $test_condition_name );
+			$this->assertSame( $viewbox_matches[1], $viewbox_matches[2], $test_condition_name );
 		}
 
 		// アイコンへの配色経路が「フォント色（vk_sns glyph）→ color」から「fill="currentColor"」に変わった事の
@@ -566,34 +504,40 @@ class SnsBtnsTest extends WP_UnitTestCase {
 		// iPhone UA. It contains "Mobile", so wp_is_mobile() returns true.
 		$mobile_ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 
+		// not_expected は7ケース全て 'vk_icon_w_r_sns' というプレフィックス一致にしている（各アイコン専用の
+		// 完全名にすると、例えば `_x_twitter` が `_twitter` に退行しても検出できない上、Threads / Copy は
+		// 元々 web フォントクラス自体を持たないため対象外になっていた。プレフィックスに揃える事で、7ケース
+		// 全てを同じ強さで「vk_icon_w_r_sns から始まる旧クラスが一切出力されない」形で守れる）。
+		// not_expected uses the single prefix 'vk_icon_w_r_sns' for all 7 cases ( a full per-icon class
+		// name would miss a regression such as `_x_twitter` degrading to `_twitter`, and Threads / Copy
+		// never had a web font class to begin with, so they were excluded. Unifying on the prefix lets
+		// all 7 cases be guarded equally strongly: no class starting with vk_icon_w_r_sns is output at all ).
+		$legacy_class_prefix = 'vk_icon_w_r_sns';
+
 		$icon_wrap_cases = array(
 			array(
 				'test_condition_name' => 'useFacebook が true の場合 => Facebook の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useFacebook' => true ),
 				'user_agent'          => null,
 				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_facebook() . '</span>' ),
-				'not_expected'        => 'vk_icon_w_r_sns_fb',
 			),
 			array(
 				'test_condition_name' => 'useTwitter が true の場合 => X の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useTwitter' => true ),
 				'user_agent'          => null,
 				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_x() . '</span>' ),
-				'not_expected'        => 'vk_icon_w_r_sns_x_twitter',
 			),
 			array(
 				'test_condition_name' => 'useBluesky が true の場合 => Bluesky の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useBluesky' => true ),
 				'user_agent'          => null,
 				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_bluesky() . '</span>' ),
-				'not_expected'        => 'vk_icon_w_r_sns_bluesky',
 			),
 			array(
 				'test_condition_name' => 'useHatena が true の場合 => Hatena の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない',
 				'options'             => array( 'useHatena' => true ),
 				'user_agent'          => null,
 				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_hatena() . '</span>' ),
-				'not_expected'        => 'vk_icon_w_r_sns_hatena',
 			),
 			array(
 				// LINE はモバイル UA で wp_is_mobile() を true にした時のみ出力される。sb_line が含まれる事＝モバイル分岐を実際に通った裏取り（他に出力経路が無い）。
@@ -602,21 +546,18 @@ class SnsBtnsTest extends WP_UnitTestCase {
 				'options'             => array( 'useLine' => true ),
 				'user_agent'          => $mobile_ua,
 				'expected_contains'   => array( 'sb_line', '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_line() . '</span>' ),
-				'not_expected'        => 'vk_icon_w_r_sns_line',
 			),
 			array(
-				'test_condition_name' => 'useThreads が true の場合 => Threads の SVG を包む span に aria-hidden="true" が付く（他の icon_sns と統一）',
+				'test_condition_name' => 'useThreads が true の場合 => Threads の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない（他の icon_sns と統一）',
 				'options'             => array( 'useThreads' => true ),
 				'user_agent'          => null,
 				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_threads() . '</span>' ),
-				'not_expected'        => null,
 			),
 			array(
-				'test_condition_name' => 'useCopy が true の場合 => Copy の SVG を包む span に aria-hidden="true" が付く（他の icon_sns と統一）',
+				'test_condition_name' => 'useCopy が true の場合 => Copy の SVG を包む span に aria-hidden="true" が付き、旧 web フォントクラスは出力されない（他の icon_sns と統一）',
 				'options'             => array( 'useCopy' => true ),
 				'user_agent'          => null,
 				'expected_contains'   => array( '<span class="icon_sns" aria-hidden="true">' . veu_sns_icon_svg_copy() . '</span>' ),
-				'not_expected'        => null,
 			),
 		);
 
@@ -645,11 +586,12 @@ class SnsBtnsTest extends WP_UnitTestCase {
 					$this->assertStringContainsString( $expected, $actual, $case['test_condition_name'] );
 				}
 
-				// 旧・自前 web フォントのクラスがマークアップに残っていない事を確認（issue #1462 での移行確認）。
-				// Check the old in-house web font class is no longer present in the markup ( confirms the migration in issue #1462 ).
-				if ( null !== $case['not_expected'] ) {
-					$this->assertStringNotContainsString( $case['not_expected'], $actual, $case['test_condition_name'] );
-				}
+				// 旧・自前 web フォントのクラス（vk_icon_w_r_sns で始まるもの全て）がマークアップに
+				// 残っていない事を確認（issue #1462 での移行確認。7ケース共通のプレフィックスで検証）。
+				// Check no old in-house web font class ( anything starting with vk_icon_w_r_sns ) remains
+				// in the markup ( confirms the migration in issue #1462. Verified with the shared prefix
+				// across all 7 cases ).
+				$this->assertStringNotContainsString( $legacy_class_prefix, $actual, $case['test_condition_name'] );
 
 				// オプション値をクリーンアップ / Clean up the option value.
 				delete_option( 'vkExUnit_sns_options' );


### PR DESCRIPTION
Closes #1462

@coderabbitai ignore

## 概要

SNS シェアボタンのアイコンの出し方が2通りに割れていたので、インライン SVG（HTML の中に SVG の図形データを直接書き込む方式）に統一しました。

これまでは7つのボタンのうち、

- **Facebook / X / Bluesky / はてなブックマーク / LINE の5つ** — このプラグイン独自の web フォント `vk_sns` を読み込み、空の `<span>` に CSS の `::before` で字形を描く方式
- **Threads / Copy の2つ** — インライン SVG（#1457 の対応で導入）

と分かれていました。今回、前者の5つも後者と同じインライン SVG に置き換え、7つとも同じ形で出力されるようにしています。

出力方式が2系統あると、web フォントの字形と SVG とで行の高さの扱いが違うため、CSS 側で無理やり揃える配慮が必要でした。7つとも SVG になったことで土俵が揃い、テーマ側のフォント読み込みへの依存も残らなくなります。

## 変更内容

### アイコンの SVG 化

- `veu_sns_icon_svg_facebook()` / `_x()` / `_bluesky()` / `_hatena()` / `_line()` を追加。図形データは [Simple Icons](https://simpleicons.org/)（ライセンス CC0 1.0 Universal = 著作権を放棄した扱いで自由に利用できる）から取得しています。Copy はブランドロゴではない操作アイコンで Simple Icons の対象外のため、従来どおり Heroicons（MIT ライセンス）のままです。
- 商標については、各社のロゴの商標権は各社に帰属したままである点、単色・形状非改変・シェア導線の用途に限定して使用している点を、既存の Threads と同じ水準で各関数のコメントに記載しています。
- マークアップは7つとも `<span class="icon_sns" aria-hidden="true">` で SVG を包む形に統一しました。

### SVG のガワの共通化

- SVG の外枠（`<svg class="sb_svg_icon" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" xmlns="...">` の8属性）が7回コピーされる形になるため、`veu_sns_icon_svg_wrap()` に一本化しました。各アイコン関数は図形データと、そのアイコン固有の情報（出典・ライセンス・商標）だけを持ちます。既存の Threads / Copy も同じヘルパーを使う形に揃えています。
- **出力される HTML は1文字も変わっていません。** 両方のコミットからアイコン関数の定義だけを抜き出して実際に PHP で実行し、7つともバイト単位で一致することを確認済みです（Copy の2つのパスの連結順・区切りも含む）。

### 後方互換のため残したもの

- `vk_sns` フォントの読み込み宣言（`@font-face`）と `.vk_icon_w_r_sns_*` クラスの CSS は**削除していません**。他の VK 製品や、サイト運営者が独自に書いたカスタム HTML / CSS がこのクラスを直接参照している可能性があるためです。
- 今回はマークアップ側でこれらのクラスを使うのをやめるだけで、CSS とフォント本体の削除は、周知期間を置いた別対応とします。
- なお、クラスに一致する要素がページから消えるため、ブラウザは `vk_sns` フォントファイル（woff 3.2KB）を取得しなくなります（`@font-face` は宣言されていても、使う要素が無ければ読み込まれないため）。

### テスト

- `tests/test-sns-btns.php` の「危険な要素が混入していないか」の検証を、**禁止したいものを列挙する方式（denylist）から、許可する構造そのものを固定する方式（allowlist）へ変更**しました。旧方式は `<svg onload=...>` のようなイベントハンドラ属性や、SMIL アニメーション経由の形（`<set attributeName="href" to="javascript:...">`。属性値が `href"` であって `href=` ではないため旧正規表現に掛からない）を素通りさせていました。
- 新方式は実アイコン7種すべてを通し、危険・退行パターン25種すべてを拒否することを確認済みです。列挙し忘れが原理的に発生しない形になっています。
- 旧クラスが出力に残っていないことの検証を、SNS ごとの完全名から共通のプレフィックス `vk_icon_w_r_sns` に統一し、7ケース全部に適用しました。
- PHPUnit フルスイート PASS（138 tests / 1037 assertions）。

## 確認手順

### 前提

- ExUnit の SNS 設定（管理画面 > ExUnit > SNS）で、シェアボタンの各サービス（Facebook / X / Bluesky / Threads / はてなブックマーク / LINE / Copy）を有効にしておく
- 投稿を1件用意し、フロント側でシェアボタンが表示される状態にしておく

### 1. アイコンが7つとも表示されるか

1. 用意した投稿をフロント側で開く
2. シェアボタンの並びを見る
   → **7つとも**アイコンが表示される（アイコンが欠けて文字だけになっているボタンが無い）
3. **Font Awesome を読み込まないテーマ**（Twenty Twenty-Five など）に切り替えて、同じ投稿を開く
   → 同じく7つともアイコンが表示される

### 2. アイコンの見え方が揃っているか（要目視）

1. 7つのボタンを並べた状態で、アイコンの大きさ・上下位置を見比べる
   → 極端に大きい・小さい・上下にずれているアイコンが無い
2. 特に **Copy アイコンが他の6つ（特に Facebook / はてなブックマーク / LINE）と比べて小さく浮いて見えないか**を確認する
   → 気になる差が無ければ OK

> 補足: 7つとも `viewBox` と表示サイズ（`1em`）は揃えていますが、素材ごとにキャンバスをどれだけ使って描かれているかが違います。Facebook・はてなブックマーク・LINE はほぼ全面を使う一方、Copy は上下左右に約25%の余白がある意匠のため、この項目だけは数値の統一では担保できず目視確認が必要です。

### 3. マウスを乗せたときの色（Lightning + pale / charm スキン）

1. Lightning テーマ ＋ `lightning-skin-pale` または `lightning-skin-charm` を有効にする
2. 同じ投稿をフロント側で開き、シェアボタンにマウスを乗せる
   → アイコンの色が従来どおり白に変わる

> 補足: これらのスキンは `.vk_icon_w_r_sns_*` セレクタでマウスを乗せたときのアイコン色を上書きしていましたが、マークアップからクラスが消えたためこのルールは効かなくなります。ただし同じ `a:hover` のブロックに文字色の指定が併記されており、SVG は `fill="currentColor"`（親要素の文字色をそのまま塗り色に使う指定）でそれを継承するため、表示は変わらない想定です。想定どおりか確認する項目です。

### 4. モバイルでの LINE ボタン

1. ブラウザの開発者ツールでモバイル端末をエミュレートするか、実機のスマートフォンで同じ投稿を開く
   → LINE ボタンが表示され、アイコンも表示される

### 5. デグレ確認

1. 各ボタンをクリックする
   → 従来どおり、それぞれの共有画面が開く（Copy はクリップボードにコピーされる）
2. Facebook / はてなブックマークのシェア数表示を有効にしている場合、数字が従来どおり表示される
3. ブロックエディタでシェアボタンブロックを配置し、プレビューを確認する
   → アイコンが表示される

## スクリーンショット

UI テスト担当（麗美）による実機確認の結果です。テーマは Twenty Twenty-Five（Font Awesome を読み込まないテーマ）で確認しています。

**デスクトップ表示**（Facebook / X / Bluesky / Threads / はてなブックマーク / Copy。LINE はモバイル限定のため非表示）

<img src="https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1466/after-desktop-share-buttons.png?raw=true" width="600" alt="デスクトップ表示のシェアボタン">

**モバイル表示**（LINE を含む7つ）

<img src="https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1466/after-mobile-share-buttons.png?raw=true" width="400" alt="モバイル表示のシェアボタン">

**ブロックエディタでのプレビュー**

<img src="https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1466/after-block-editor-preview.png?raw=true" width="600" alt="ブロックエディタでのシェアボタンブロックのプレビュー">

補足:

- 7つのアイコンの表示サイズを実測したところ、**7つとも `19.578125px × 19.578125px` で完全に一致**していました。上下位置（垂直中央）も揃っています。
- Copy アイコンは意匠上の余白が多いぶん、塗りつぶしのロゴ（Facebook / はてなブックマーク / LINE）より軽く見えますが、極端に小さく浮くほどではないと判断しました。
- `vk_sns` フォントファイルへのネットワークリクエストが **0件**であることも実測で確認しています。
- Before / After の比較は、変更前の環境を別途構築する必要があり今回は見送りました（After のみ）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
