### PR TITLE
[ その他 ][ SNSシェアボタン ] 同梱アイコンのライセンス全文を LICENSE-THIRD-PARTY.txt へ分離し、readme.txt の Credits を簡潔化

### DIFF
--- a/LICENSE-THIRD-PARTY.txt
+++ b/LICENSE-THIRD-PARTY.txt
@@ -1,0 +1,43 @@
+Third-Party Licenses
+=====================
+
+This plugin's share button icons (Facebook, X, Bluesky, Threads, Hatena Bookmark, LINE, Copy) are inline SVG traced from the following third-party icon sets. The SVG license below covers the traced artwork only; each service's logo remains a trademark of its respective owner and is used here single-color, unmodified in shape, and only as a share link icon.
+
+Heroicons (Copy icon)
+----------------------
+
+Source: https://heroicons.com/
+Icon: square-2-stack (solid)
+License: MIT License ( https://github.com/tailwindlabs/heroicons/blob/master/LICENSE )
+
+Full text below, as required by the MIT License:
+
+MIT License
+
+Copyright (c) Tailwind Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Simple Icons (Facebook, X, Bluesky, Threads, Hatena Bookmark, LINE icons)
+---------------------------------------------------------------------------
+
+Source: https://simpleicons.org/
+License: CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md )
+
+CC0 1.0 Universal is a public domain dedication and carries no attribution requirement, so no license text is reproduced here. See the license URL above for the full terms.

--- a/readme.txt
+++ b/readme.txt
@@ -81,32 +81,12 @@ e.g.
 
 == Credits ==
 
-This plugin's share button icons (Facebook, X, Bluesky, Threads, Hatena Bookmark, LINE, Copy) are inline SVG traced from the following third-party icon sets. The SVG license below covers the traced artwork only; each service's logo remains a trademark of its respective owner and is used here single-color, unmodified in shape, and only as a share link icon.
+This plugin's share button icons (Facebook, X, Bluesky, Threads, Hatena Bookmark, LINE, Copy) are inline SVG traced from the following third-party icon sets:
 
-* Facebook, X, Bluesky, Threads, Hatena Bookmark and LINE icons: Simple Icons ( https://simpleicons.org/ ), licensed under CC0 1.0 Universal ( https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md ).
-* Copy icon: Heroicons ( https://heroicons.com/ ), square-2-stack (solid), licensed under the MIT License ( https://github.com/tailwindlabs/heroicons/blob/master/LICENSE ). Full text below, as required by the MIT License:
+* Facebook, X, Bluesky, Threads, Hatena Bookmark and LINE icons: Simple Icons ( https://simpleicons.org/ ), licensed under CC0 1.0 Universal.
+* Copy icon: Heroicons ( https://heroicons.com/ ), square-2-stack (solid), licensed under the MIT License.
 
-MIT License
-
-Copyright (c) Tailwind Labs, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this plugin.
 
 == Changelog ==
 


### PR DESCRIPTION
@coderabbitai ignore

PR #1466 のフォローアップです。対応する issue はありません（レビューでの指摘を受けた追従対応のため）。

## 概要

PR #1466 で `readme.txt` に `== Credits ==` セクションを追加しましたが、Heroicons の MIT ライセンス全文をそのまま載せたため、セクションが20行以上になっていました。`readme.txt` は WordPress.org のプラグインページとして表示されるものなので、ここにライセンス全文が並ぶのは読み手にとって適切ではありません。

ライセンス全文を `LICENSE-THIRD-PARTY.txt` へ移し、`readme.txt` 側は「どのアイコンセットを、どのライセンスで使っているか」が分かる5行だけにしました。

## なぜ削除ではなく移設なのか

**MIT ライセンスは「著作権表示と許諾表示を、ソフトウェアの全体または重要な部分の複製に含めること」を条件にしています。** ライセンス名と URL を書くだけでは条件を満たさないため、全文そのものを配布物に同梱する必要があります。

`LICENSE-THIRD-PARTY.txt` はプラグイン直下に置いており、`.distignore`・`.svnignore` のどちらにも除外指定が無いことを確認済みです。配布物（配布用 zip / WordPress.org）に含まれるため、移設後も条件を満たします。

Simple Icons 側は CC0 1.0 Universal（著作権を放棄した扱い）で**帰属表示の義務が無い**ため、全文は載せず、出典とライセンス名の記載に留めています。

## 変更内容

- `LICENSE-THIRD-PARTY.txt`（新規）
  - Heroicons（Copy アイコン）: 出典・`square-2-stack (solid)` である旨・**MIT ライセンス全文**
  - Simple Icons（Facebook / X / Bluesky / Threads / はてなブックマーク / LINE）: 出典・CC0 1.0 Universal である旨と、帰属義務が無いため全文を載せていない旨
  - SVG のライセンスと各社ロゴの商標権が別物である旨
- `readme.txt`
  - `== Credits ==` を5行に短縮し、ライセンス全文は `LICENSE-THIRD-PARTY.txt` にある旨の案内を追加

MIT ライセンス本文は、移設前後で `diff` により一字一句同一であることを確認しています。

## changelog を追記していない理由

ライセンス表記の置き場所を変えただけで、エンドユーザーの動作・表示には影響しないためです。PR #1466 の changelog エントリ（アイコンの SVG 統一）は未リリース領域にそのまま残っています。

## 確認手順

1. `readme.txt` を開き、`== Credits ==` セクションを見る
   → アイコンセット名とライセンス名が並んだ5行程度になっており、ライセンス全文が含まれていない
   → 末尾に `LICENSE-THIRD-PARTY.txt` を参照する旨の案内がある
2. プラグイン直下の `LICENSE-THIRD-PARTY.txt` を開く
   → Heroicons の MIT ライセンス全文（`Copyright (c) Tailwind Labs, Inc.` から始まり、免責条項まで）が含まれている
   → Simple Icons の出典と CC0 である旨が含まれている
3. 配布物に含まれることの確認（任意）
   → `.distignore` / `.svnignore` のどちらにも `LICENSE-THIRD-PARTY.txt` を除外する記述が無い

表示・動作に関わる変更は含まないため、スクリーンショットは省略しています。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
