### PR TITLE
[ セキュリティ修正 ][ カスタムCSS ] メタボックスの保存処理に権限チェックと入力値の unslash 処理を追加

### DIFF
--- a/admin/class-veu-metabox.php
+++ b/admin/class-veu-metabox.php
@@ -171,11 +171,22 @@ class VEU_Metabox {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return $post_id; }
 
-		// 設定したnonce を取得（CSRF対策）
-		$noncename__value = isset( $_POST[ 'noncename__' . $this->args['cf_name'] ] ) ? $_POST[ 'noncename__' . $this->args['cf_name'] ] : null;
+		// 設定したnonce を取得（CSRF対策）。nonce 自体の値なので wp_verify_nonce() に渡す前に
+		// wp_unslash() + sanitize_text_field() を通す。
+		// Retrieve the configured nonce ( CSRF protection ). This is the nonce value itself, so
+		// unslash and sanitize it with sanitize_text_field() before passing it to wp_verify_nonce().
+		$noncename__value = isset( $_POST[ 'noncename__' . $this->args['cf_name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ 'noncename__' . $this->args['cf_name'] ] ) ) : null;
 
 		// nonce を確認し、値が書き換えられていれば、何もしない（CSRF対策）
 		if ( ! wp_verify_nonce( $noncename__value, $this->nonce_action ) ) {
+			return $post_id;
+		}
+
+		// nonce 検証だけでは CSRF は防げても権限の無いユーザーによる保存は防げないため、
+		// 投稿の編集権限があるかどうかを確認する（多層防御）。
+		// nonce verification alone does not prevent a user without edit permission from saving,
+		// so also confirm the current user can edit this post ( defense in depth ).
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return $post_id;
 		}
 

--- a/inc/contact-section/block/index.php
+++ b/inc/contact-section/block/index.php
@@ -78,6 +78,14 @@ function veu_contact_section_block_callback( $attributes, $content ) {
 	$r = VkExUnit_Contact::render_contact_section_html( $classes, false );
 
 	if ( empty( $r ) ) {
+		// エディタでのプレビュー時にだけ「お問い合わせページ未設定」の注意書きを表示するための読み取り専用の分岐。
+		// $_GET['context'] の値そのものは使わず isset() の有無だけを見ており、保存や状態変更を一切行わないため、
+		// ノンス検証は不要と判断した（追加すると通常のプレビュー時に検証が失敗し、注意書きが出せなくなる）。
+		// Read-only branch that shows the "No Contact Page Setting" notice only while previewing in the
+		// editor. It only checks whether $_GET['context'] isset() and never reads its value, and it never
+		// saves or changes state, so nonce verification is intentionally omitted here ( adding one would
+		// fail during normal preview requests and prevent the notice from being shown ).
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only check of the render context; only isset() is used and the value itself is never read, so no state is read from or written to.
 		if ( isset( $_GET['context'] ) ) {
 			return '<div class="disabled ' . esc_attr( $classes ) . '">' . __( 'No Contact Page Setting.', 'vk-all-in-one-expansion-unit' ) . '</div>';
 		}

--- a/inc/css-customize/class-veu-metabox-css-customize.php
+++ b/inc/css-customize/class-veu-metabox-css-customize.php
@@ -45,10 +45,21 @@ class VEU_Metabox_CSS_Customize extends VEU_Metabox {
 			return $post_id;
 		}
 
-		$nonce_key   = 'noncename__' . $this->args['cf_name'];
-		$nonce_value = isset( $_POST[ $nonce_key ] ) ? $_POST[ $nonce_key ] : null;
+		$nonce_key = 'noncename__' . $this->args['cf_name'];
+		// nonce 自体の値なので wp_verify_nonce() に渡す前に wp_unslash() + sanitize_text_field() を通す。
+		// This is the nonce value itself, so unslash and sanitize it with sanitize_text_field()
+		// before passing it to wp_verify_nonce().
+		$nonce_value = isset( $_POST[ $nonce_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $nonce_key ] ) ) : null;
 
 		if ( ! wp_verify_nonce( $nonce_value, $this->nonce_action ) ) {
+			return $post_id;
+		}
+
+		// nonce 検証だけでは CSRF は防げても権限の無いユーザーによる保存は防げないため、
+		// 投稿の編集権限があるかどうかを確認する（多層防御）。
+		// nonce verification alone does not prevent a user without edit permission from saving,
+		// so also confirm the current user can edit this post ( defense in depth ).
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return $post_id;
 		}
 
@@ -58,10 +69,30 @@ class VEU_Metabox_CSS_Customize extends VEU_Metabox {
 			return $post_id;
 		}
 
-		$raw_css       = $_POST[ $this->args['cf_name'] ];
+		// WordPress は magic quotes 互換のため $_POST の値にスラッシュを付加して渡してくるので、
+		// veu_sanitize_custom_css_input() へ渡す前に wp_unslash() で除去する。サニタイズ自体は
+		// veu_sanitize_custom_css_input()（wp_strip_all_tags() 等）が行うが、phpcs の静的解析は
+		// 独自関数内のサニタイズを認識できないため、この行単体では未サニタイズと誤検知される。
+		// WordPress adds slashes to $_POST values for magic-quotes compatibility, so strip them
+		// with wp_unslash() before passing the value to veu_sanitize_custom_css_input(). The actual
+		// sanitization happens inside veu_sanitize_custom_css_input() ( via wp_strip_all_tags(), etc. ),
+		// but phpcs's static analysis cannot see sanitization performed inside a custom function, so
+		// this line alone is flagged as a false positive.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by veu_sanitize_custom_css_input() on the next line ( custom sanitizer not recognized by static analysis ).
+		$raw_css       = wp_unslash( $_POST[ $this->args['cf_name'] ] );
 		$sanitized_css = veu_sanitize_custom_css_input( $raw_css );
 		if ( '' !== $sanitized_css ) {
-			add_post_meta( $post_id, $this->args['cf_name'], $sanitized_css );
+			// add_post_meta() は「スラッシュ付きの値を受け取り、内部で wp_unslash() する」仕様
+			// ( expected_slashed ) のため、上で既に wp_unslash() 済みの $sanitized_css をそのまま渡すと
+			// ここでもう一度スラッシュが除去され、CSS に含まれる本物のバックスラッシュ（\f101 のような
+			// エスケープ記法など）が消えてしまう。そのため保存直前に wp_slash() で相殺し、
+			// $sanitized_css の中身がそのまま保存されるようにする。
+			// add_post_meta() expects a slashed value and calls wp_unslash() on it internally
+			// ( expected_slashed ). Passing the already-unslashed $sanitized_css as is would strip
+			// slashes a second time and corrupt genuine backslashes in the CSS ( e.g. \f101 escape
+			// sequences ), so wp_slash() it right before saving to cancel that out and store
+			// $sanitized_css unchanged.
+			add_post_meta( $post_id, $this->args['cf_name'], wp_slash( $sanitized_css ) );
 		}
 
 		return $post_id;

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,8 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
+[ Security Fix ][ Custom CSS ] Added a permission check on save and hardened input handling on the classic edit screen as defense-in-depth hardening.
+
 = 9.122.0 =
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.
 [ Spec Change ][ SNS Share Button ] Unified the Facebook, X, Bluesky, Hatena Bookmark and LINE icons to inline SVG to match Threads and Copy. The markup no longer uses the ".vk_icon_w_r_sns_*" web font classes; the classes and the font itself are kept for backward compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
-[ Security Fix ][ Custom CSS ] Added a permission check on save and hardened input handling on the classic edit screen as defense-in-depth hardening.
+[ Security Fix ][ Custom CSS ] Added a permission check on save and hardened input handling on the classic edit screen as defense in depth.
 
 = 9.122.0 =
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.

--- a/tests/test-css-customize-save-custom-field.php
+++ b/tests/test-css-customize-save-custom-field.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Class CssCustomizeSaveCustomFieldTest
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+/**
+ * VEU_Metabox_CSS_Customize::save_custom_field() のテスト
+ *
+ * 主に以下の動作を検証する ( issue #1471 で追加した権限チェック・unslash 処理 )：
+ * - edit_post 権限が無いユーザーからの保存は拒否されること
+ * - edit_post 権限があるユーザーからの保存は許可され、CSS がサニタイズされて保存されること
+ * - $_POST の値が二重に unslash されず、本物のバックスラッシュが 1 本だけ残ること
+ * - nonce が不正な場合は保存されないこと
+ */
+
+// VEU_Metabox_CSS_Customize は本体側で admin_menu フック内でのみ require されるため
+// （エディタ画面でのタイミング調整が理由）、admin_menu が発火しない PHPUnit 環境では
+// 未定義のままになる。親クラス VEU_Metabox は既に読み込み済みの前提で、テスト側から明示的に読み込む。
+// VEU_Metabox_CSS_Customize is only required inside the admin_menu hook in the plugin itself
+// ( for load-timing reasons on the editor screen ), so it stays undefined in the PHPUnit
+// environment where admin_menu never fires. Require it explicitly from the test, assuming the
+// parent class VEU_Metabox is already loaded.
+if ( ! class_exists( 'VEU_Metabox_CSS_Customize' ) ) {
+	require_once dirname( __DIR__ ) . '/inc/css-customize/class-veu-metabox-css-customize.php';
+}
+
+class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
+
+	/**
+	 * テストごとにログインユーザー状態をリセットする（未ログイン状態に戻す）。
+	 * Reset the logged-in user state after each test ( back to logged out ).
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		wp_set_current_user( 0 );
+		$_POST = array();
+	}
+
+	/**
+	 * テスト用投稿を作成する
+	 *
+	 * @return int 作成した投稿 ID
+	 */
+	protected function create_test_post() {
+		return wp_insert_post(
+			array(
+				'post_title'  => 'CSS Customize Test Post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+	}
+
+	/**
+	 * 管理者ユーザーを作成しログイン状態にする。
+	 * save_custom_field() は edit_post 権限を要求するため、多くのテストで必要になる。
+	 *
+	 * @return int 作成した管理者ユーザーの ID
+	 */
+	protected function login_as_administrator() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		return $admin_id;
+	}
+
+	/**
+	 * $_POST に正規の nonce と CSS 値をセットするヘルパー
+	 *
+	 * @param VEU_Metabox_CSS_Customize $metabox テスト対象のメタボックスインスタンス
+	 * @param string                    $value   保存する CSS 値
+	 */
+	protected function set_post_data( $metabox, $value ) {
+		$cf_name = $metabox->args['cf_name'];
+		// nonce_action は protected のため、VEU_Metabox::__construct() と同じ組み立てルール
+		// ( 'veu_metabox_' . cf_name ) をテスト側で再現する。
+		// nonce_action is protected, so reproduce the same construction rule used in
+		// VEU_Metabox::__construct() ( 'veu_metabox_' . cf_name ) on the test side.
+		$nonce_action = 'veu_metabox_' . $cf_name;
+		$nonce_key    = 'noncename__' . $cf_name;
+
+		$_POST[ $nonce_key ] = wp_create_nonce( $nonce_action );
+		$_POST[ $cf_name ]   = $value;
+	}
+
+	/**
+	 * test_save_custom_field_requires_edit_post_capability
+	 *
+	 * edit_post 権限の有無で保存の可否が変わることを検証する。
+	 */
+	public function test_save_custom_field_requires_edit_post_capability() {
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '権限の無いユーザー（購読者）の場合 => 保存されない',
+				'role'                => 'subscriber',
+				'expected_saved'      => false,
+			),
+			array(
+				'test_condition_name' => '権限のあるユーザー（管理者）の場合 => 保存される',
+				'role'                => 'administrator',
+				'expected_saved'      => true,
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$post_id = $this->create_test_post();
+			$metabox = new VEU_Metabox_CSS_Customize();
+
+			$user_id = self::factory()->user->create( array( 'role' => $case['role'] ) );
+			wp_set_current_user( $user_id );
+
+			$this->set_post_data( $metabox, 'div { color: red; }' );
+			$metabox->save_custom_field( $post_id );
+
+			$actual = get_post_meta( $post_id, '_veu_custom_css', true );
+
+			if ( $case['expected_saved'] ) {
+				// veu_sanitize_custom_css_input() は HTML タグ除去・trim のみを行い、
+				// 空白の圧縮は行わない（圧縮は表示側の veu_get_the_custom_css_single() の役割）。
+				// veu_sanitize_custom_css_input() only strips tags and trims; it does not
+				// collapse whitespace ( that is done by veu_get_the_custom_css_single() on output ).
+				$this->assertSame( 'div { color: red; }', $actual, $case['test_condition_name'] );
+			} else {
+				$this->assertEmpty( $actual, $case['test_condition_name'] );
+			}
+
+			delete_post_meta( $post_id, '_veu_custom_css' );
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	/**
+	 * test_save_custom_field_with_invalid_nonce
+	 *
+	 * nonce が不正な場合はカスタム CSS が保存されないことを検証する。
+	 */
+	public function test_save_custom_field_with_invalid_nonce() {
+
+		$post_id = $this->create_test_post();
+		$this->login_as_administrator();
+
+		$metabox = new VEU_Metabox_CSS_Customize();
+
+		$_POST[ 'noncename__' . $metabox->args['cf_name'] ] = 'invalid_nonce_value';
+		$_POST[ $metabox->args['cf_name'] ]                 = 'div { color: red; }';
+
+		$metabox->save_custom_field( $post_id );
+
+		$actual = get_post_meta( $post_id, '_veu_custom_css', true );
+		$this->assertEmpty( $actual, 'nonce が不正な場合は保存されない' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * test_save_custom_field_does_not_double_unslash_backslash_values
+	 *
+	 * $_POST の値に含まれる本物のバックスラッシュが二重に unslash されず、
+	 * 1 回だけ除去された状態で保存されることを検証する ( issue #1471 項目2 )。
+	 *
+	 * WordPress の magic quotes 互換仕様では、実際の HTTP リクエストで $_POST の値に
+	 * スラッシュが 1 段だけ付加されて渡ってくる。ここではその状態を、実際の 1 本の
+	 * バックスラッシュを意図した値として二重バックスラッシュ ( PHP 文字列リテラルの
+	 * \\\\ は実体として 2 文字 ) で再現する。
+	 */
+	public function test_save_custom_field_does_not_double_unslash_backslash_values() {
+
+		$post_id = $this->create_test_post();
+		$this->login_as_administrator();
+
+		$metabox = new VEU_Metabox_CSS_Customize();
+
+		// 実際の HTTP リクエストで $_POST に渡ってくる、スラッシュが 1 段付加された状態を再現する。
+		// 実体としては 2 文字のバックスラッシュ ( \\ ) で、意図する実際の値は 1 本のバックスラッシュ。
+		$raw_value = 'div::before { content: "\\\\f101"; }';
+
+		$this->set_post_data( $metabox, $raw_value );
+		$metabox->save_custom_field( $post_id );
+
+		// 1 回だけ unslash された状態でサニタイズされた値が期待値。
+		$expected = veu_sanitize_custom_css_input( stripslashes( $raw_value ) );
+
+		$this->assertSame( $expected, get_post_meta( $post_id, '_veu_custom_css', true ) );
+
+		wp_delete_post( $post_id, true );
+	}
+}

--- a/tests/test-css-customize-save-custom-field.php
+++ b/tests/test-css-customize-save-custom-field.php
@@ -105,6 +105,19 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 		);
 
 		foreach ( $test_cases as $case ) {
+			// 前周に set_post_data() でセットした nonce / CSS 値が $_POST に残ったままだと、
+			// 次の create_test_post()（wp_insert_post() -> save_post 発火）の時点で古い nonce が
+			// 有効なまま複数の VEU_Metabox_CSS_Customize インスタンス（ファイル末尾のグローバル
+			// インスタンス含む）の save_custom_field() が新しい投稿に対して発火してしまい、
+			// テストがケースの実行順序に依存してしまう。ループの先頭で必ずクリアする。
+			// If the nonce / CSS value set by set_post_data() in the previous iteration is still
+			// in $_POST, the next create_test_post() ( wp_insert_post() -> save_post ) fires with
+			// that stale nonce still valid, so save_custom_field() on multiple
+			// VEU_Metabox_CSS_Customize instances ( including the file's global instance ) runs
+			// against the new post. That makes the test order-dependent, so clear $_POST at the
+			// top of every iteration.
+			$_POST = array();
+
 			$post_id = $this->create_test_post();
 			$metabox = new VEU_Metabox_CSS_Customize();
 
@@ -128,7 +141,49 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 
 			delete_post_meta( $post_id, '_veu_custom_css' );
 			wp_delete_post( $post_id, true );
+			// 使用後は必ず片付ける（親テストの do_save() と同じ考え方）。
+			// Always clean up after use ( same idea as do_save() in the parent test ).
+			$_POST = array();
 		}
+	}
+
+	/**
+	 * test_save_custom_field_allows_author_of_own_post
+	 *
+	 * edit_others_posts を持たない author ロールでも、自分自身の投稿であれば
+	 * 保存できることを検証する。edit_post capability チェックを採用したことで、
+	 * 自分の投稿を編集できる author / contributor 等にリグレッションが無いことの確認
+	 * ( issue #1471 のレビュー指摘 )。
+	 *
+	 * Verify that an author role ( which lacks edit_others_posts ) can still save
+	 * custom CSS on their own post. Confirms adopting the edit_post capability check
+	 * does not regress authors / contributors editing their own posts
+	 * ( issue #1471 review feedback ).
+	 */
+	public function test_save_custom_field_allows_author_of_own_post() {
+
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Own Post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+				'post_author' => $author_id,
+			)
+		);
+		$_POST   = array();
+
+		$metabox = new VEU_Metabox_CSS_Customize();
+		$this->set_post_data( $metabox, 'div { color: red; }' );
+		$metabox->save_custom_field( $post_id );
+
+		$this->assertSame( 'div { color: red; }', get_post_meta( $post_id, '_veu_custom_css', true ), '自分の投稿であれば author ロールでも保存できる' );
+
+		delete_post_meta( $post_id, '_veu_custom_css' );
+		wp_delete_post( $post_id, true );
+		$_POST = array();
 	}
 
 	/**

--- a/tests/test-css-customize-save-custom-field.php
+++ b/tests/test-css-customize-save-custom-field.php
@@ -165,6 +165,12 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $author_id );
 
+		// 前のテストの tearDown() が $_POST を空にしてくれていることに依存しないよう、
+		// wp_insert_post()（save_post 発火）より前に明示的にクリアする。
+		// Do not rely on the previous test's tearDown() having emptied $_POST; clear it
+		// explicitly before wp_insert_post() ( which fires save_post ).
+		$_POST = array();
+
 		$post_id = wp_insert_post(
 			array(
 				'post_title'  => 'Own Post',
@@ -173,7 +179,6 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 				'post_author' => $author_id,
 			)
 		);
-		$_POST   = array();
 
 		$metabox = new VEU_Metabox_CSS_Customize();
 		$this->set_post_data( $metabox, 'div { color: red; }' );

--- a/tests/test-css-customize-save-custom-field.php
+++ b/tests/test-css-customize-save-custom-field.php
@@ -13,6 +13,16 @@
  * - edit_post 権限があるユーザーからの保存は許可され、CSS がサニタイズされて保存されること
  * - $_POST の値が二重に unslash されず、本物のバックスラッシュが 1 本だけ残ること
  * - nonce が不正な場合は保存されないこと
+ *
+ * Tests for VEU_Metabox_CSS_Customize::save_custom_field().
+ *
+ * Mainly verifies the following behavior ( the permission check / unslash handling
+ * added in issue #1471 ):
+ * - Saving is rejected for a user without the edit_post capability.
+ * - Saving is allowed for a user with the edit_post capability, and the CSS is
+ *   sanitized before being saved.
+ * - The $_POST value is not double-unslashed; a genuine backslash survives as one.
+ * - Saving is rejected when the nonce is invalid.
  */
 
 // VEU_Metabox_CSS_Customize は本体側で admin_menu フック内でのみ require されるため
@@ -40,8 +50,9 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 
 	/**
 	 * テスト用投稿を作成する
+	 * Create a test post.
 	 *
-	 * @return int 作成した投稿 ID
+	 * @return int 作成した投稿 ID / Created post ID.
 	 */
 	protected function create_test_post() {
 		return wp_insert_post(
@@ -57,7 +68,10 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 	 * 管理者ユーザーを作成しログイン状態にする。
 	 * save_custom_field() は edit_post 権限を要求するため、多くのテストで必要になる。
 	 *
-	 * @return int 作成した管理者ユーザーの ID
+	 * Create an administrator and switch the current user to it.
+	 * save_custom_field() requires edit_post capability, so most tests need this.
+	 *
+	 * @return int 作成した管理者ユーザーの ID / Created administrator user ID.
 	 */
 	protected function login_as_administrator() {
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
@@ -67,9 +81,10 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 
 	/**
 	 * $_POST に正規の nonce と CSS 値をセットするヘルパー
+	 * Helper that sets a valid nonce and CSS value in $_POST.
 	 *
-	 * @param VEU_Metabox_CSS_Customize $metabox テスト対象のメタボックスインスタンス
-	 * @param string                    $value   保存する CSS 値
+	 * @param VEU_Metabox_CSS_Customize $metabox テスト対象のメタボックスインスタンス / Metabox instance under test.
+	 * @param string                    $value   保存する CSS 値 / CSS value to save.
 	 */
 	protected function set_post_data( $metabox, $value ) {
 		$cf_name = $metabox->args['cf_name'];
@@ -88,6 +103,7 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 	 * test_save_custom_field_requires_edit_post_capability
 	 *
 	 * edit_post 権限の有無で保存の可否が変わることを検証する。
+	 * Verify that whether saving is allowed depends on the edit_post capability.
 	 */
 	public function test_save_custom_field_requires_edit_post_capability() {
 
@@ -195,6 +211,7 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 	 * test_save_custom_field_with_invalid_nonce
 	 *
 	 * nonce が不正な場合はカスタム CSS が保存されないことを検証する。
+	 * Verify that custom CSS is not saved when the nonce is invalid.
 	 */
 	public function test_save_custom_field_with_invalid_nonce() {
 
@@ -224,6 +241,14 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 	 * スラッシュが 1 段だけ付加されて渡ってくる。ここではその状態を、実際の 1 本の
 	 * バックスラッシュを意図した値として二重バックスラッシュ ( PHP 文字列リテラルの
 	 * \\\\ は実体として 2 文字 ) で再現する。
+	 *
+	 * Verify that a genuine backslash in a $_POST value is not double-unslashed
+	 * ( issue #1471 item 2 ) and survives as a single backslash after saving.
+	 *
+	 * Under WordPress's magic-quotes-compatible behavior, a real HTTP request delivers
+	 * $_POST values with one extra level of slashes added. This test reproduces that
+	 * state with a doubled backslash ( standing in for one intended real backslash,
+	 * as explained above ).
 	 */
 	public function test_save_custom_field_does_not_double_unslash_backslash_values() {
 
@@ -234,12 +259,16 @@ class CssCustomizeSaveCustomFieldTest extends WP_UnitTestCase {
 
 		// 実際の HTTP リクエストで $_POST に渡ってくる、スラッシュが 1 段付加された状態を再現する。
 		// 実体としては 2 文字のバックスラッシュ ( \\ ) で、意図する実際の値は 1 本のバックスラッシュ。
+		// Reproduce the one-level-slashed state that arrives in $_POST on a real HTTP
+		// request. This is 2 real backslash characters, standing in for the one
+		// intended real backslash.
 		$raw_value = 'div::before { content: "\\\\f101"; }';
 
 		$this->set_post_data( $metabox, $raw_value );
 		$metabox->save_custom_field( $post_id );
 
 		// 1 回だけ unslash された状態でサニタイズされた値が期待値。
+		// The expected value is sanitized after being unslashed exactly once.
 		$expected = veu_sanitize_custom_css_input( stripslashes( $raw_value ) );
 
 		$this->assertSame( $expected, get_post_meta( $post_id, '_veu_custom_css', true ) );

--- a/tests/test-metabox-save-custom-field.php
+++ b/tests/test-metabox-save-custom-field.php
@@ -14,6 +14,9 @@
  * - XSS 文字列がサニタイズされて保存されること
  * - nonce が不正な場合は保存されないこと
  * - edit_post 権限が無い場合は保存されないこと（issue #1471 で追加した多層防御チェック）
+ *
+ * Also verifies that saving is rejected without the edit_post capability
+ * ( the defense-in-depth check added in issue #1471 ).
  */
 class VEUMetaboxSaveCustomFieldTest extends WP_UnitTestCase {
 
@@ -203,6 +206,10 @@ class VEUMetaboxSaveCustomFieldTest extends WP_UnitTestCase {
 	 * save_custom_field() の edit_post 権限チェックを検証する。
 	 * 権限が無いユーザーからの保存は拒否され、権限があるユーザーからの保存のみ許可される事を確認する
 	 * ( issue #1471 で追加した多層防御チェック ).
+	 *
+	 * Verify the edit_post capability check in save_custom_field(). Saving must be
+	 * rejected without the capability and allowed with it
+	 * ( the defense-in-depth check added in issue #1471 ).
 	 */
 	public function test_save_custom_field_requires_edit_post_capability() {
 

--- a/tests/test-metabox-save-custom-field.php
+++ b/tests/test-metabox-save-custom-field.php
@@ -13,8 +13,18 @@
  * - 文字列形式のカスタムフィールドが正しく保存されること
  * - XSS 文字列がサニタイズされて保存されること
  * - nonce が不正な場合は保存されないこと
+ * - edit_post 権限が無い場合は保存されないこと（issue #1471 で追加した多層防御チェック）
  */
 class VEUMetaboxSaveCustomFieldTest extends WP_UnitTestCase {
+
+	/**
+	 * テストごとにログインユーザー状態をリセットする（未ログイン状態に戻す）。
+	 * Reset the logged-in user state after each test ( back to logged out ).
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		wp_set_current_user( 0 );
+	}
 
 	/**
 	 * テスト用投稿を作成する
@@ -29,6 +39,21 @@ class VEUMetaboxSaveCustomFieldTest extends WP_UnitTestCase {
 				'post_type'   => 'post',
 			)
 		);
+	}
+
+	/**
+	 * 管理者ユーザーを作成しログイン状態にする。
+	 * save_custom_field() は edit_post 権限を要求するため、多くのテストで必要になる。
+	 *
+	 * Create an administrator and switch the current user to it.
+	 * save_custom_field() requires edit_post capability, so most tests need this.
+	 *
+	 * @return int 作成した管理者ユーザーの ID
+	 */
+	protected function login_as_administrator() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		return $admin_id;
 	}
 
 	/**
@@ -61,6 +86,12 @@ class VEUMetaboxSaveCustomFieldTest extends WP_UnitTestCase {
 	public function test_save_custom_field() {
 
 		$post_id = $this->create_test_post();
+
+		// save_custom_field() は edit_post 権限を要求するため、管理者としてログインする
+		// ( issue #1471 で追加された多層防御チェック ).
+		// save_custom_field() requires edit_post capability, so log in as an administrator
+		// ( the defense-in-depth check added in issue #1471 ).
+		$this->login_as_administrator();
 
 		$test_cases = array(
 			// 配列形式の値が正しく保存される（#1284 の修正対象）
@@ -164,5 +195,57 @@ class VEUMetaboxSaveCustomFieldTest extends WP_UnitTestCase {
 		$this->assertEmpty( $actual, 'nonce が不正な場合は保存されない' );
 
 		delete_post_meta( $post_id, $cf_name );
+	}
+
+	/**
+	 * test_save_custom_field_requires_edit_post_capability
+	 *
+	 * save_custom_field() の edit_post 権限チェックを検証する。
+	 * 権限が無いユーザーからの保存は拒否され、権限があるユーザーからの保存のみ許可される事を確認する
+	 * ( issue #1471 で追加した多層防御チェック ).
+	 */
+	public function test_save_custom_field_requires_edit_post_capability() {
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '権限の無いユーザー（購読者）の場合 => 保存されない',
+				'role'                => 'subscriber',
+				'expected_saved'      => false,
+			),
+			array(
+				'test_condition_name' => '権限のあるユーザー（管理者）の場合 => 保存される',
+				'role'                => 'administrator',
+				'expected_saved'      => true,
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$post_id = $this->create_test_post();
+			$cf_name = 'test_capability_field';
+
+			$metabox = new VEU_Metabox(
+				array(
+					'slug'       => 'test_capability_' . $case['role'],
+					'cf_name'    => $cf_name,
+					'individual' => true,
+				)
+			);
+
+			$user_id = self::factory()->user->create( array( 'role' => $case['role'] ) );
+			wp_set_current_user( $user_id );
+
+			$this->do_save( $metabox, $post_id, 'Save attempt' );
+
+			$actual = get_post_meta( $post_id, $cf_name, true );
+
+			if ( $case['expected_saved'] ) {
+				$this->assertSame( 'Save attempt', $actual, $case['test_condition_name'] );
+			} else {
+				$this->assertEmpty( $actual, $case['test_condition_name'] );
+			}
+
+			delete_post_meta( $post_id, $cf_name );
+			wp_delete_post( $post_id, true );
+		}
 	}
 }


### PR DESCRIPTION
Closes #1471

@coderabbitai ignore

## 概要

WordPress.org へのプラグイン公開・審査で使われる公式ツール「Plugin Check」（プラグインの実装が WordPress.org のガイドラインに沿っているかを機械的に検査するツール）の指摘に対応しました。

投稿編集画面のメタボックス（編集画面に並ぶ入力欄のまとまり。カスタム CSS などが該当）の保存処理には、これまでノンス検証（フォーム送信が正規の画面から来たことを確かめる使い捨ての合言葉の照合）だけが入っていました。ここに **権限チェック**（`current_user_can( 'edit_post', $post_id )`。今ログインしている人がその投稿を編集してよいかどうかの確認）を多層防御として追加し、あわせて入力値のスラッシュ処理を整えています。

同種の対応は CTA の保存処理に対して #1458 で先行して行っており、書き方をそちらに揃えています。

## 変更点

1. **権限チェックを親クラス・子クラスの両方に追加**
   - `VEU_Metabox::save_custom_field()`（親）と、それを上書きしている `VEU_Metabox_CSS_Customize::save_custom_field()`（子）の両方に入れています。保存の入口である `save_post` フック（投稿が保存されるたびに WordPress が呼び出す処理）の登録は親側にあるため、片方だけでは経路が塞がりません。
   - チェックは `delete_post_meta()` **より前**に置いています。そのため「権限が無くて保存できないのに、既存の値だけ消える」という取りこぼしは起きません。
2. **ノンス値の取得に `wp_unslash()` + `sanitize_text_field()` を追加**（`wp_unslash()` は WordPress が自動的に付けた余分なバックスラッシュを取り除く処理）
3. **カスタム CSS の値を `wp_unslash()` してからサニタイズし、保存直前に `wp_slash()` で相殺**
   - `add_post_meta()` は「バックスラッシュが付いた状態の値を受け取り、内部で自分で取り除く」という仕様です。相殺しないと二重に取り除かれ、CSS 内の本物のバックスラッシュ（`\f101` のようなアイコンフォントのエスケープ記法など）が消えてしまいます。
4. **`inc/contact-section/block/index.php` の `$_GET['context']` 分岐に理由コメント付きの `phpcs:ignore` を追加**（`phpcs:ignore` は静的解析の警告をその行だけ抑止する指定）
   - ノンス検証は**追加していません**。この分岐はブロックエディターでのプレビュー時にだけ「お問い合わせページ未設定」の注意書きを出すための読み取り専用の判定で、`$_GET['context']` の値そのものは使わず、指定されているかどうか（`isset()`）だけを見ています。ここに検証を足すと、ノンスが付かない通常のプレビュー要求で検証が失敗し、注意書きが出せなくなります。同種の対応は `inc/sns/function-sns-btns.php` に既存の前例があり、その書き方に揃えました。
5. **PHPUnit テストの追加・修正**
   - 権限チェック追加により既存テストが失敗したため、管理者としてログインした状態に修正。
   - 「権限のない利用者では保存されない／管理者では保存できる」「他人の投稿は編集できない author が、自分の投稿なら保存できる」「バックスラッシュが二重に除去されない」の各ケースを追加。

## 挙動の変化

**通常の入力では、保存される値は変わりません。**

加えて、HTML エンティティ（`&bsol;` や `&#92;` のような、記号を文字列で表す記法）がバックスラッシュへ変換される入力について、**変更前はそのバックスラッシュが後段の処理に食われて消えていた既存の不具合も併せて解消されます**。

| 入力 | 変更前の保存値 | 変更後の保存値 |
|---|---|---|
| `content:"&bsol;f101"` | `content:"f101"` | `content:"\f101"` |
| `content:"&#92;f101"` | `content:"f101"` | `content:"\f101"` |

これは既存の不具合の修正であり、後退ではありません。

## 確認手順

### 1. カスタム CSS メタボックスが従来どおり動くこと

1. 管理者でログインし、任意の投稿の編集画面を開く
2. エディター右上のツールバーにある「VK All in One Expansion Unit」アイコンを押し、サイドバーの「Custom CSS」パネルを開く
   - 補足: 投稿タイプが `custom-fields` をサポートしているため、従来のメタボックスは `__back_compat_meta_box` としてブロックエディターでは非表示になります。実際の入力欄はこのサイドバーパネルです（本 PR とは無関係の既存仕様）。クラシックエディター利用時は画面下部の「Custom CSS」メタボックスが該当します
3. `.entry-body { background: #ffeeee; }` と入力し、「更新」ボタンを押す
   - → エラーにならず保存され、再読み込み後もメタボックスに入力した CSS が残っていること
4. その投稿をフロント側で表示する
   - → 記事本文の背景が薄いピンクになり、CSS が反映されていること（出力時に空白は詰められますが、これは本 PR とは無関係の既存挙動です）

### 1-2. バックスラッシュを含む CSS が壊れないこと

1. 同じ「Custom CSS」の入力欄に `.entry-body::before { content: "\f101"; }` と入力して更新する
   - → 再読み込み後も `content: "\f101"` のまま残っていること（`content: "f101"` とバックスラッシュが消えていたら NG）

### 2. お問い合わせセクションの注意書きが従来どおり出ること

1. ExUnit の設定で、お問い合わせページを未設定の状態にする
2. 任意の固定ページをブロックエディターで開き、「お問い合わせ」ブロックを挿入する
   - → エディター上に「No Contact Page Setting.」の注意書きが表示されること（この PR の変更前と同じ挙動）

### 3. PHPUnit

```bash
npx wp-env run tests-cli --env-cwd='wp-content/plugins/vk-all-in-one-expansion-unit' vendor/bin/phpunit -c .phpunit.xml
```

→ `OK (143 tests, 1044 assertions)` となること

### 4. Plugin Check（任意）

```bash
wp plugin check vk-all-in-one-expansion-unit --format=json
```

→ `admin/class-veu-metabox.php` / `inc/css-customize/class-veu-metabox-css-customize.php` / `inc/contact-section/block/index.php` の3ファイルについて、`WordPress.Security.NonceVerification.*` と `WordPress.Security.ValidatedSanitizedInput.*` の警告が 0 件であること

## レビュー状況

- 安藤（リードエンジニア）: `セキュリティレビュー結果: PASS`
  - サニタイズ関数の中身と実際の出力先まで辿り、`phpcs:ignore` が真の誤検知であること（不正な UTF-8 で閉じる作り、デコードとタグ除去の順序、`</style>` を使った脱出パターン各種の無害化）を実測で確認済み
  - `edit_post` はメタ cap（WordPress が投稿タイプに応じて実際の権限へ展開する種類の権限名）のため、コア側が `edit_page` / `edit_others_posts` 等へ自動展開する。既存コードにある手動分岐は不要で、この書き方のほうが正確
  - `save_custom_field()` を上書きしているのは今回の2クラスのみで、他の保存処理は既に権限チェックを持っていることを確認済み
- 植草（UX デザイナー）: `UXレビュー結果: PASS`
  - 追加した権限チェックは、コアが編集画面へのアクセスや「更新」の送信を許可する判定と同じ材料を使うため、「投稿は編集できるのにカスタム CSS だけ保存されない」という中途半端な状態は起こらない
  - 編集画面を開いたまま権限を下げられたケースは、メタボックスに到達する前にコア側が投稿更新全体を止めて目に見えるエラーを出すため、フィードバックは既に確保されている

UI の見た目に変更は無いため、スクリーンショットは添付していません。

## この PR では対応しないもの

- ブロックエディター上の「No Contact Page Setting.」注意書きに、設定画面への移動導線が無い点（植草の低優先度メモ）。今回の変更範囲外のため対応せず、記録として残します。
- 同じ `$_GET['context']` の読み取り専用パターンが `inc/page-list-ancestor/block/index.php` と `inc/child-page-index/block/index.php` にもありますが、issue #1471 のスコープ外のため今回は触っていません。
- レビュー中に、本 PR のスコープ外でセキュリティ観点の確認が必要な箇所が 1 件見つかっています。非管理者は到達できない権限設計のため悪用シナリオは書けず優先度は下げますが、破棄はしません。**公開の場に詳細を書かない方針のため内容はここに記載せず、別途非公開でリポジトリ管理者へ共有します。対応期限は次のリリースまで。**

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/811
