### PR TITLE
[ セキュリティ修正 ][ 記事の構造化データ ] ユーザープロフィールの構造化データ設定値の保存時サニタイズと権限チェックを追加

### DIFF
--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -92,6 +92,7 @@ class VK_Article_Srtuctured_Data {
 	 *
 	 * @param int     $user_id       更新されたユーザーの ID。 The ID of the updated user.
 	 * @param WP_User $old_user_data 更新前のユーザーデータオブジェクト。 The user data object before the update.
+	 * @return void
 	 */
 	public static function update_author_structure_data( $user_id, $old_user_data ) {
 

--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -128,11 +128,21 @@ class VK_Article_Srtuctured_Data {
 			update_user_meta( $user_id, 'author_name', sanitize_text_field( wp_unslash( $_POST['author_name'] ) ), $old_user_data->author_name );
 		}
 		if ( isset( $_POST['author_url'] ) && is_string( $_POST['author_url'] ) ) {
+			// trim() は WPCS のサニタイズ関数として認識されないため、この行のみ抑制する。
+			// ここで得た値は「空欄クリアかどうかの判定」と、esc_url_raw() へ渡す前に前後の空白を落とす前処理
+			// （末尾の空白が esc_url_raw() によって %20 に変換されて保存されてしまう不具合を防ぐため）にのみ使い、
+			// この値自体を保存・出力することはない。保存する値は必ず esc_url_raw() を通した結果を使う。
+			// trim() is not recognized as a WPCS sanitizing function, so only this line is suppressed.
+			// The value obtained here is used only to detect an intentional clear and to strip leading/trailing
+			// whitespace before passing it to esc_url_raw() (to prevent a bug where a trailing space gets
+			// converted into %20 and saved as part of the URL); this value itself is never saved or output.
+			// The value actually saved always goes through esc_url_raw().
+			$author_url_trimmed = trim( wp_unslash( $_POST['author_url'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- 中間値であり保存・出力に使わない。trim() を先に適用するための処理で、直後に esc_url_raw() を通す。
 			self::update_author_url_meta(
 				$user_id,
 				'author_url',
-				esc_url_raw( wp_unslash( $_POST['author_url'] ) ),
-				sanitize_text_field( wp_unslash( $_POST['author_url'] ) ),
+				esc_url_raw( $author_url_trimmed ),
+				$author_url_trimmed,
 				$old_user_data->author_url
 			);
 		}
@@ -141,11 +151,12 @@ class VK_Article_Srtuctured_Data {
 			// 単一の URL 文字列として sameAs にそのまま出力するため、esc_url_raw() で URL としてサニタイズする（author_url と同じ扱い）。
 			// The UI (add_user_meta_structure_data_ui()) is a single type='url' input field, and get_author_array()
 			// also outputs it as a single URL string in sameAs, so sanitize it as a URL with esc_url_raw() (same handling as author_url).
+			$author_sameas_trimmed = trim( wp_unslash( $_POST['author_sameAs'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- 中間値であり保存・出力に使わない。trim() を先に適用するための処理で、直後に esc_url_raw() を通す（author_url と同じ理由）。
 			self::update_author_url_meta(
 				$user_id,
 				'author_sameAs',
-				esc_url_raw( wp_unslash( $_POST['author_sameAs'] ) ),
-				sanitize_text_field( wp_unslash( $_POST['author_sameAs'] ) ),
+				esc_url_raw( $author_sameas_trimmed ),
+				$author_sameas_trimmed,
 				$old_user_data->author_sameAs
 			);
 		}
@@ -155,26 +166,39 @@ class VK_Article_Srtuctured_Data {
 	/**
 	 * URL 系のユーザーメタ（author_url / author_sameAs）を、サニタイズ済みの値で保存する。
 	 *
+	 * 送信値の前後の空白は、esc_url_raw() に渡す前に呼び出し元で trim() 済み（$trimmed_value）。
+	 * これは、末尾の空白を esc_url_raw() がそのまま %20 に変換して保存してしまう不具合を避けるため。
+	 *
 	 * 送信値が空でないのに esc_url_raw() が空文字を返すのは、許可されないスキーム（javascript: 等）で
-	 * 弾かれたケース。これを「意図的な空欄クリア」（送信値自体が空文字）と区別するため、タグ除去・trim のみ
-	 * 行う sanitize_text_field() の結果が空文字かどうかで判定する（$trimmed_value）。
+	 * 弾かれたケース。これを「意図的な空欄クリア」（送信値自体が空文字）と区別するため、trim() のみ行った
+	 * 結果（$trimmed_value）が空文字かどうかで判定する。sanitize_text_field() は使わない。
+	 * sanitize_text_field() は <script>...</script> 等のタグを中身ごと除去してしまうため、実際には非空の
+	 * 送信値（許可されないスキーム等で esc_url_raw() に弾かれた不正値）を「意図的な空欄クリア」と誤判定し、
+	 * 既存の保存値を消してしまう不具合があった。
 	 * 不正値（$sanitized_value が空文字 かつ 意図的な空欄クリアではない）のときは保存せず既存の保存値を
 	 * 維持する（author_type で「正当な理由なく既存値を上書きしない」とした判断と揃えている）。
 	 *
 	 * Save a URL-type user meta (author_url / author_sameAs) with its already-sanitized value.
 	 *
+	 * Leading/trailing whitespace in the submitted value is already trim()'d by the caller before being
+	 * passed to esc_url_raw() ($trimmed_value). This avoids a bug where esc_url_raw() would otherwise
+	 * convert a trailing space into %20 and save it as part of the URL.
+	 *
 	 * When esc_url_raw() returns an empty string even though the submitted value was not empty, it means
 	 * the value was rejected (e.g. a disallowed scheme such as javascript:). To distinguish this from an
-	 * intentional clear (the submitted value itself is empty), this checks whether the result of
-	 * sanitize_text_field() — which only strips tags and trims, without validating the URL scheme — is
-	 * empty ($trimmed_value). When the value is rejected ($sanitized_value is empty and this is not an
-	 * intentional clear), it is not saved and the existing value is kept (consistent with the same policy
-	 * applied to author_type: never overwrite an existing value without good reason).
+	 * intentional clear (the submitted value itself is empty), this checks whether the trim()-only result
+	 * ($trimmed_value) is empty. sanitize_text_field() is deliberately not used here: it strips tags such as
+	 * <script>...</script> together with their content, which previously caused an actually non-empty
+	 * submission (an invalid value rejected by esc_url_raw(), e.g. a disallowed scheme) to be misdetected as
+	 * an intentional clear, silently discarding the existing value without saving anything.
+	 * When the value is rejected ($sanitized_value is empty and this is not an intentional clear), it is not
+	 * saved and the existing value is kept (consistent with the same policy applied to author_type: never
+	 * overwrite an existing value without good reason).
 	 *
 	 * @param int    $user_id         更新対象のユーザー ID。 The ID of the user being updated.
 	 * @param string $meta_key        更新するメタキー（author_url または author_sameAs）。 The meta key to update (author_url or author_sameAs).
-	 * @param string $sanitized_value esc_url_raw() 済みの値。 The value already sanitized via esc_url_raw().
-	 * @param string $trimmed_value   sanitize_text_field() 済みの値（空欄クリアの判定用）。 The value already sanitized via sanitize_text_field() (used to detect an intentional clear).
+	 * @param string $sanitized_value trim() 後に esc_url_raw() を通した値。 The value after trim() followed by esc_url_raw().
+	 * @param string $trimmed_value   trim( wp_unslash( $_POST[...] ) ) の結果（空欄クリアの判定用）。 The result of trim( wp_unslash( $_POST[...] ) ) (used to detect an intentional clear).
 	 * @param mixed  $prev_value      update_user_meta() に渡す更新前の値。 The previous value passed to update_user_meta().
 	 * @return void
 	 */

--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -87,12 +87,6 @@ class VK_Article_Srtuctured_Data {
 		<?php
 	}
 
-	// profile_update フックは、WordPress 本体（wp-admin/user-edit.php）が
-	// ユーザー編集画面の nonce 検証（check_admin_referer( 'update-user_' . $user_id )）を
-	// 済ませた後にのみ発火するため、ここで改めて nonce を検証する必要はない。
-	// This hook (profile_update) fires only after WordPress core
-	// (wp-admin/user-edit.php) has already verified the nonce for the user-edit screen
-	// (check_admin_referer( 'update-user_' . $user_id )), so no additional nonce check is required here.
 	/**
 	 * Update Author Structure Date
 	 *
@@ -100,8 +94,27 @@ class VK_Article_Srtuctured_Data {
 	 * @param WP_User $old_user_data 更新前のユーザーデータオブジェクト。 The user data object before the update.
 	 */
 	public static function update_author_structure_data( $user_id, $old_user_data ) {
-		if ( isset( $_POST['author_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
-			$author_type = sanitize_text_field( wp_unslash( $_POST['author_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+
+		// profile_update は管理画面のユーザー編集画面（本体 wp-admin/user-edit.php が
+		// check_admin_referer() で nonce 検証済み）だけでなく、nonce を伴わない経路からも発火する
+		// （REST API の PUT/POST /wp/v2/users/<id>（Application Password 認証時は nonce なし。かつ
+		// application/x-www-form-urlencoded で送信すれば $_POST も実際に埋まる）、XML-RPC の
+		// wp.editProfile、WP-CLI の wp user update、reset_password() 等）。
+		// そのためここでの防御層は nonce 検証ではなく capability チェックとする。
+		// This hook (profile_update) fires not only from the admin user-edit screen (where core,
+		// wp-admin/user-edit.php, has already verified the nonce via check_admin_referer()) but also
+		// from routes that carry no nonce at all (the REST API's PUT/POST /wp/v2/users/<id> — no nonce
+		// when authenticated via an Application Password, and $_POST is actually populated when the
+		// request uses application/x-www-form-urlencoded —, XML-RPC's wp.editProfile, WP-CLI's
+		// wp user update, reset_password(), etc.).
+		// So the defense-in-depth layer used here is a capability check, not a nonce check.
+		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- 上記の理由により、この関数では nonce ではなく current_user_can( 'edit_user', $user_id ) で担保する。
+		if ( isset( $_POST['author_type'] ) && is_string( $_POST['author_type'] ) ) {
+			$author_type = sanitize_text_field( wp_unslash( $_POST['author_type'] ) );
 			// 保存できるのは select の選択肢（organization / person）のみ。
 			// 想定外の値が届いた場合は保存せず、既存の保存値をそのまま維持する（表示中の select・出力側 get_author_array() の @type 判定を壊さないため）。
 			// Only the select's choices (organization / person) may be saved.
@@ -111,18 +124,64 @@ class VK_Article_Srtuctured_Data {
 				update_user_meta( $user_id, 'author_type', $author_type, $old_user_data->author_type );
 			}
 		}
-		if ( isset( $_POST['author_name'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
-			update_user_meta( $user_id, 'author_name', sanitize_text_field( wp_unslash( $_POST['author_name'] ) ), $old_user_data->author_name ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+		if ( isset( $_POST['author_name'] ) && is_string( $_POST['author_name'] ) ) {
+			update_user_meta( $user_id, 'author_name', sanitize_text_field( wp_unslash( $_POST['author_name'] ) ), $old_user_data->author_name );
 		}
-		if ( isset( $_POST['author_url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
-			update_user_meta( $user_id, 'author_url', esc_url_raw( wp_unslash( $_POST['author_url'] ) ), $old_user_data->author_url ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+		if ( isset( $_POST['author_url'] ) && is_string( $_POST['author_url'] ) ) {
+			self::update_author_url_meta(
+				$user_id,
+				'author_url',
+				esc_url_raw( wp_unslash( $_POST['author_url'] ) ),
+				sanitize_text_field( wp_unslash( $_POST['author_url'] ) ),
+				$old_user_data->author_url
+			);
 		}
-		if ( isset( $_POST['author_sameAs'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+		if ( isset( $_POST['author_sameAs'] ) && is_string( $_POST['author_sameAs'] ) ) {
 			// UI（add_user_meta_structure_data_ui()）は type='url' の単一入力欄で、出力側 get_author_array() も
-			// 単一の URL 文字列として sameAs にそのまま出力するため、esc_url_raw() で URL としてサニタイズする。
+			// 単一の URL 文字列として sameAs にそのまま出力するため、esc_url_raw() で URL としてサニタイズする（author_url と同じ扱い）。
 			// The UI (add_user_meta_structure_data_ui()) is a single type='url' input field, and get_author_array()
-			// also outputs it as a single URL string in sameAs, so sanitize it as a URL with esc_url_raw().
-			update_user_meta( $user_id, 'author_sameAs', esc_url_raw( wp_unslash( $_POST['author_sameAs'] ) ), $old_user_data->author_sameAs ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+			// also outputs it as a single URL string in sameAs, so sanitize it as a URL with esc_url_raw() (same handling as author_url).
+			self::update_author_url_meta(
+				$user_id,
+				'author_sameAs',
+				esc_url_raw( wp_unslash( $_POST['author_sameAs'] ) ),
+				sanitize_text_field( wp_unslash( $_POST['author_sameAs'] ) ),
+				$old_user_data->author_sameAs
+			);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * URL 系のユーザーメタ（author_url / author_sameAs）を、サニタイズ済みの値で保存する。
+	 *
+	 * 送信値が空でないのに esc_url_raw() が空文字を返すのは、許可されないスキーム（javascript: 等）で
+	 * 弾かれたケース。これを「意図的な空欄クリア」（送信値自体が空文字）と区別するため、タグ除去・trim のみ
+	 * 行う sanitize_text_field() の結果が空文字かどうかで判定する（$trimmed_value）。
+	 * 不正値（$sanitized_value が空文字 かつ 意図的な空欄クリアではない）のときは保存せず既存の保存値を
+	 * 維持する（author_type で「正当な理由なく既存値を上書きしない」とした判断と揃えている）。
+	 *
+	 * Save a URL-type user meta (author_url / author_sameAs) with its already-sanitized value.
+	 *
+	 * When esc_url_raw() returns an empty string even though the submitted value was not empty, it means
+	 * the value was rejected (e.g. a disallowed scheme such as javascript:). To distinguish this from an
+	 * intentional clear (the submitted value itself is empty), this checks whether the result of
+	 * sanitize_text_field() — which only strips tags and trims, without validating the URL scheme — is
+	 * empty ($trimmed_value). When the value is rejected ($sanitized_value is empty and this is not an
+	 * intentional clear), it is not saved and the existing value is kept (consistent with the same policy
+	 * applied to author_type: never overwrite an existing value without good reason).
+	 *
+	 * @param int    $user_id         更新対象のユーザー ID。 The ID of the user being updated.
+	 * @param string $meta_key        更新するメタキー（author_url または author_sameAs）。 The meta key to update (author_url or author_sameAs).
+	 * @param string $sanitized_value esc_url_raw() 済みの値。 The value already sanitized via esc_url_raw().
+	 * @param string $trimmed_value   sanitize_text_field() 済みの値（空欄クリアの判定用）。 The value already sanitized via sanitize_text_field() (used to detect an intentional clear).
+	 * @param mixed  $prev_value      update_user_meta() に渡す更新前の値。 The previous value passed to update_user_meta().
+	 * @return void
+	 */
+	private static function update_author_url_meta( $user_id, $meta_key, $sanitized_value, $trimmed_value, $prev_value ) {
+		$is_intentional_clear = ( '' === $trimmed_value );
+		if ( '' !== $sanitized_value || $is_intentional_clear ) {
+			update_user_meta( $user_id, $meta_key, $sanitized_value, $prev_value );
 		}
 	}
 

--- a/inc/article-structure-data/class-vk-article-structure-data.php
+++ b/inc/article-structure-data/class-vk-article-structure-data.php
@@ -87,21 +87,42 @@ class VK_Article_Srtuctured_Data {
 		<?php
 	}
 
+	// profile_update フックは、WordPress 本体（wp-admin/user-edit.php）が
+	// ユーザー編集画面の nonce 検証（check_admin_referer( 'update-user_' . $user_id )）を
+	// 済ませた後にのみ発火するため、ここで改めて nonce を検証する必要はない。
+	// This hook (profile_update) fires only after WordPress core
+	// (wp-admin/user-edit.php) has already verified the nonce for the user-edit screen
+	// (check_admin_referer( 'update-user_' . $user_id )), so no additional nonce check is required here.
 	/**
 	 * Update Author Structure Date
+	 *
+	 * @param int     $user_id       更新されたユーザーの ID。 The ID of the updated user.
+	 * @param WP_User $old_user_data 更新前のユーザーデータオブジェクト。 The user data object before the update.
 	 */
 	public static function update_author_structure_data( $user_id, $old_user_data ) {
-		if ( isset( $_POST['author_type'] ) ) {
-			update_user_meta( $user_id, 'author_type', $_POST['author_type'], $old_user_data->author_type );
+		if ( isset( $_POST['author_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+			$author_type = sanitize_text_field( wp_unslash( $_POST['author_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+			// 保存できるのは select の選択肢（organization / person）のみ。
+			// 想定外の値が届いた場合は保存せず、既存の保存値をそのまま維持する（表示中の select・出力側 get_author_array() の @type 判定を壊さないため）。
+			// Only the select's choices (organization / person) may be saved.
+			// If an unexpected value arrives, skip saving it and keep the existing stored value
+			// (so the select UI currently displayed and the @type check in get_author_array() are not broken).
+			if ( in_array( $author_type, array( 'organization', 'person' ), true ) ) {
+				update_user_meta( $user_id, 'author_type', $author_type, $old_user_data->author_type );
+			}
 		}
-		if ( isset( $_POST['author_name'] ) ) {
-			update_user_meta( $user_id, 'author_name', $_POST['author_name'], $old_user_data->author_name );
+		if ( isset( $_POST['author_name'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+			update_user_meta( $user_id, 'author_name', sanitize_text_field( wp_unslash( $_POST['author_name'] ) ), $old_user_data->author_name ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
 		}
-		if ( isset( $_POST['author_url'] ) ) {
-			update_user_meta( $user_id, 'author_url', $_POST['author_url'], $old_user_data->author_url );
+		if ( isset( $_POST['author_url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+			update_user_meta( $user_id, 'author_url', esc_url_raw( wp_unslash( $_POST['author_url'] ) ), $old_user_data->author_url ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
 		}
-		if ( isset( $_POST['author_sameAs'] ) ) {
-			update_user_meta( $user_id, 'author_sameAs', $_POST['author_sameAs'], $old_user_data->author_sameAs );
+		if ( isset( $_POST['author_sameAs'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
+			// UI（add_user_meta_structure_data_ui()）は type='url' の単一入力欄で、出力側 get_author_array() も
+			// 単一の URL 文字列として sameAs にそのまま出力するため、esc_url_raw() で URL としてサニタイズする。
+			// The UI (add_user_meta_structure_data_ui()) is a single type='url' input field, and get_author_array()
+			// also outputs it as a single URL string in sameAs, so sanitize it as a URL with esc_url_raw().
+			update_user_meta( $user_id, 'author_sameAs', esc_url_raw( wp_unslash( $_POST['author_sameAs'] ) ), $old_user_data->author_sameAs ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- profile_update は wp-admin 側で nonce 検証済みの後にのみ発火する。
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,8 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
+[ Security Fix ] Added sanitization when saving the author structured data settings (author_type / author_name / author_url / author_sameAs) on the user profile screen, as defense-in-depth hardening.
+
 = 9.122.0 =
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.
 [ Spec Change ][ SNS Share Button ] Unified the Facebook, X, Bluesky, Hatena Bookmark and LINE icons to inline SVG to match Threads and Copy. The markup no longer uses the ".vk_icon_w_r_sns_*" web font classes; the classes and the font itself are kept for backward compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
-[ Security Fix ] Added sanitization when saving the author structured data settings (author_type / author_name / author_url / author_sameAs) on the user profile screen, as defense-in-depth hardening.
+[ Security Fix ] Added a capability check and sanitization when saving the author structured data settings (author_type / author_name / author_url / author_sameAs) on the user profile screen, as defense-in-depth hardening.
 
 = 9.122.0 =
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
-[ Security Fix ] Added a capability check and sanitization when saving the author structured data settings (author_type / author_name / author_url / author_sameAs) on the user profile screen, as defense-in-depth hardening.
+[ Security Fix ][ Article Structured Data ] Added a capability check and sanitization when saving the author structured data settings (author_type / author_name / author_url / author_sameAs) on the user profile screen, as defense-in-depth hardening.
 
 = 9.122.0 =
 [ New Feature ][ Share Button ] Added an option to always display the share button block regardless of the "Exclude Post Types" setting.

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -167,6 +167,215 @@ class Article_Structure_Test extends WP_UnitTestCase {
 	}
 
 
+	/**
+	 * update_author_structure_data() のサニタイズ挙動を検証する。
+	 * - author_type はホワイトリスト（organization / person）以外の値では保存されず既存値が維持される。
+	 * - author_name は sanitize_text_field() でタグ等が除去される。
+	 * - author_url / author_sameAs は esc_url_raw() で不正なスキームの URL が無害化される。
+	 * - 既存の保存済みユーザーメタが、サニタイズ追加によって壊れたり消えたりしない（後方互換）。
+	 *
+	 * Verify the sanitization behavior of update_author_structure_data().
+	 * - author_type is not saved (the existing value is kept) unless it is one of the whitelisted values (organization / person).
+	 * - author_name has tags etc. stripped via sanitize_text_field().
+	 * - author_url / author_sameAs have URLs with a disallowed scheme neutralized via esc_url_raw().
+	 * - Existing saved user meta is not broken or lost by adding this sanitization (backward compatibility).
+	 */
+	function test_update_author_structure_data() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_update_author_structure_data' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		// テスト用ユーザーを発行。
+		// Create a test user.
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => 'sanitize_test_user',
+				'user_pass'    => 'user_pass',
+				'display_name' => 'Sanitize Test User',
+			)
+		);
+
+		// 各ケースの前提となる「既存の保存済みユーザーメタ」。サニタイズ追加後も、保存対象外・無効値のケースで
+		// このデータが壊れず維持されることを確認する（後方互換の検証）。
+		// The "existing saved user meta" that each case starts from. Used to verify that, even after adding this
+		// sanitization, this data is kept intact when a field is not submitted or an invalid value is submitted
+		// (backward compatibility check).
+		$existing_meta = array(
+			'author_type'   => 'organization',
+			'author_name'   => 'Existing Name',
+			'author_url'    => 'https://example.com/existing',
+			'author_sameAs' => 'https://example.com/existing-sns',
+		);
+
+		$test_cases = array(
+			// 正常系 : すべて正しい値（organization）を送信した場合。
+			// Normal case: submitting all valid values (organization).
+			array(
+				'test_condition_name' => '正常系 : author_type が organization で全項目が正しい値の場合 => そのまま保存される',
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Vektor Inc.',
+					'author_url'    => 'https://vektor-inc.co.jp/',
+					'author_sameAs' => 'https://twitter.com/vektor_inc',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Vektor Inc.',
+					'author_url'    => 'https://vektor-inc.co.jp/',
+					'author_sameAs' => 'https://twitter.com/vektor_inc',
+				),
+			),
+			// 正常系 : author_type が person の場合。
+			// Normal case: author_type is person.
+			array(
+				'test_condition_name' => '正常系 : author_type が person で全項目が正しい値の場合 => そのまま保存される',
+				'post'                => array(
+					'author_type'   => 'person',
+					'author_name'   => 'Vekutarou',
+					'author_url'    => 'https://vektor-inc.co.jp/author/vekutarou',
+					'author_sameAs' => 'https://twitter.com/vekutarou',
+				),
+				'expected'            => array(
+					'author_type'   => 'person',
+					'author_name'   => 'Vekutarou',
+					'author_url'    => 'https://vektor-inc.co.jp/author/vekutarou',
+					'author_sameAs' => 'https://twitter.com/vekutarou',
+				),
+			),
+			// 異常系（境界値） : author_type が空文字（ホワイトリスト外）の場合 => 保存されず既存値が維持される。
+			// Abnormal case (boundary): author_type is an empty string (outside the whitelist) -> not saved, the existing value is kept.
+			array(
+				'test_condition_name' => '異常系 : author_type が空文字の場合 => 保存されず既存値が維持される',
+				'post'                => array(
+					'author_type'   => '',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系 : author_type にタグ入りの不正な値が届いた場合 => 保存されず既存値が維持される。
+			// Abnormal case: author_type receives an invalid value containing a tag -> not saved, the existing value is kept.
+			array(
+				'test_condition_name' => '異常系 : author_type にホワイトリスト外の値（タグ入り）が届いた場合 => 保存されず既存値が維持される',
+				'post'                => array(
+					'author_type'   => '<script>alert(1)</script>',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系 : author_name にタグ入り文字列が届いた場合 => sanitize_text_field() でタグが除去されて保存される。
+			// Abnormal case: author_name receives a string containing a tag -> saved with the tag stripped via sanitize_text_field().
+			array(
+				'test_condition_name' => '異常系 : author_name にタグ入り文字列が届いた場合 => タグが除去されて保存される',
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => '<script>alert(1)</script>Vektor',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => sanitize_text_field( '<script>alert(1)</script>Vektor' ),
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系 : author_url に許可されないスキーム（javascript:）の URL が届いた場合 => esc_url_raw() で無害化されて保存される。
+			// Abnormal case: author_url receives a URL with a disallowed scheme (javascript:) -> saved after being neutralized via esc_url_raw().
+			array(
+				'test_condition_name' => '異常系 : author_url に不正なスキームの URL が届いた場合 => esc_url_raw() でサニタイズされて保存される',
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'javascript:alert(1)',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => esc_url_raw( 'javascript:alert(1)' ),
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系 : author_sameAs にタグ入りの不正な値が届いた場合 => esc_url_raw() でサニタイズされて保存される。
+			// Abnormal case: author_sameAs receives an invalid value containing a tag -> saved after being sanitized via esc_url_raw().
+			array(
+				'test_condition_name' => '異常系 : author_sameAs にタグ入りの不正な値が届いた場合 => esc_url_raw() でサニタイズされて保存される',
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => '"><script>alert(1)</script>',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => esc_url_raw( '"><script>alert(1)</script>' ),
+				),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			// 各ケースの前提として、既存の保存済みユーザーメタを設定する（後方互換の検証用）。
+			// Set up the existing saved user meta as the premise for each case (used for the backward-compatibility check).
+			foreach ( $existing_meta as $key => $value ) {
+				update_user_meta( $user_id, $key, $value );
+			}
+
+			// フォーム送信を再現するため $_POST を差し替える。
+			// Replace $_POST to reproduce a form submission.
+			$_POST = $case['post'];
+
+			// profile_update フックが渡す「更新前のユーザーデータ」を再現する。
+			// WP_User の未定義プロパティは、コア（WP_User::__get()）が get_user_meta() へフォールバックするため、
+			// 現在保存されているユーザーメタが $old_user_data->author_type 等として参照できる。
+			// Reproduce the "pre-update user data" passed by the profile_update hook.
+			// WP_User's undefined properties fall back to get_user_meta() via core (WP_User::__get()),
+			// so the currently saved user meta can be referenced as $old_user_data->author_type, etc.
+			$old_user_data = get_userdata( $user_id );
+
+			VK_Article_Srtuctured_Data::update_author_structure_data( $user_id, $old_user_data );
+
+			$actual = array(
+				'author_type'   => get_user_meta( $user_id, 'author_type', true ),
+				'author_name'   => get_user_meta( $user_id, 'author_name', true ),
+				'author_url'    => get_user_meta( $user_id, 'author_url', true ),
+				'author_sameAs' => get_user_meta( $user_id, 'author_sameAs', true ),
+			);
+
+			$this->assertEquals( $case['expected'], $actual, $case['test_condition_name'] );
+
+			// 後始末（$_POST とユーザーメタを次のケースのために初期化する）。
+			// Clean up ($_POST and the user meta, to prepare for the next case).
+			$_POST = array();
+			delete_user_meta( $user_id, 'author_type' );
+			delete_user_meta( $user_id, 'author_name' );
+			delete_user_meta( $user_id, 'author_url' );
+			delete_user_meta( $user_id, 'author_sameAs' );
+		}
+
+		// テストで発行したユーザーを削除。
+		// Delete the user created for the test.
+		wp_delete_user( $user_id );
+	}
+
+
 	function test_get_article_structure_array() {
 
 		print PHP_EOL;

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -389,6 +389,92 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					'author_sameAs' => 'https://example.com/existing-sns',
 				),
 			),
+			// 正常系（意図的な空欄クリア） : author_url に空文字が届いた場合 => サニタイズ後の値（空文字）で保存される。
+			// docblock の「送信値自体が空（意図的な空欄クリア）の場合はサニタイズ後の値（空文字）で保存される」を検証する。
+			// Normal case (intentional clear): author_url receives an empty string -> saved as the sanitized (empty) value.
+			// Verifies the docblock's statement that an intentional clear (the submitted value itself is empty) is saved as the sanitized (empty) value.
+			array(
+				'test_condition_name' => '正常系 : author_url が空文字（意図的な空欄クリア）で送信された場合 => 空文字で保存される',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => '',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => '',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系（回帰テスト） : author_url に <script>...</script> が届いた場合 => 保存されず既存値が維持される。
+			// sanitize_text_field() は script タグを中身ごと除去するため、以前の実装ではこの非空の不正値が
+			// 「意図的な空欄クリア」と誤判定され、既存値が消えてしまう不具合があった（trim() のみで判定するよう修正済み）。
+			// Abnormal case (regression test): author_url receives <script>...</script> -> not saved, the existing value is kept.
+			// sanitize_text_field() strips a script tag together with its content, so the previous implementation
+			// misdetected this non-empty invalid value as an intentional clear and lost the existing value
+			// (fixed by detecting emptiness via trim() alone instead).
+			array(
+				'test_condition_name' => '異常系 : author_url に <script>...</script> が届いた場合 => 保存されず既存値が維持される',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => '<script>javascript:alert(1)</script>',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系（回帰テスト） : author_url に <> が届いた場合 => 保存されず既存値が維持される。
+			// sanitize_text_field() と esc_url_raw() の双方でこの文字列が空文字になり誤判定に至っていた境界ケース。
+			// Abnormal case (regression test): author_url receives <> -> not saved, the existing value is kept.
+			// A boundary case where both sanitize_text_field() and esc_url_raw() used to reduce this string to
+			// an empty string, causing the misdetection.
+			array(
+				'test_condition_name' => '異常系 : author_url に <> が届いた場合 => 保存されず既存値が維持される',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => '<>',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系（回帰テスト） : author_url の前後に空白が付いた正しい URL が届いた場合
+			// => 前後の空白が trim() で除去されてから esc_url_raw() に渡され、%20 を含まずに保存される。
+			// 修正前は末尾の空白が esc_url_raw() によって %20 に変換され、URL の一部として保存されてしまっていた。
+			// Abnormal case (regression test): a valid URL with leading/trailing whitespace is submitted
+			// -> the whitespace is trim()'d before being passed to esc_url_raw(), and it is saved without %20.
+			// Before the fix, the trailing space was converted into %20 by esc_url_raw() and saved as part of the URL.
+			array(
+				'test_condition_name' => '異常系 : author_url の前後に空白が付いた URL が届いた場合 => %20 を含まずに保存される',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => '  https://ok.example/  ',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://ok.example/',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
 			// 異常系 : author_url に配列が送信された場合 => Fatal error にならず、is_string() チェックにより
 			// サニタイズ対象外として無視され、既存値が維持される。
 			// Abnormal case: author_url receives an array -> no Fatal error occurs; the is_string() guard

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -168,7 +168,7 @@ class Article_Structure_Test extends WP_UnitTestCase {
 
 
 	/**
-	 * update_author_structure_data() のサニタイズ挙動を検証する。
+	 * update_author_structure_data() のサニタイズ挙動と capability チェックを検証する。
 	 * - author_type はホワイトリスト（organization / person）以外の値では保存されず既存値が維持される。
 	 * - author_name は sanitize_text_field() でタグ等が除去される。
 	 * - author_url / author_sameAs は、送信値が空でないのに esc_url_raw() が空文字を返す（許可されない
@@ -179,8 +179,12 @@ class Article_Structure_Test extends WP_UnitTestCase {
 	 * - 既存の保存済みユーザーメタが、サニタイズ追加によって壊れたり消えたりしない（後方互換）。
 	 * - メタが一度も保存されていない新規ユーザーに対しても、正常に保存できる（update_user_meta() の
 	 *   第4引数 $prev_value が空文字になる、本番での主経路）。
+	 * - capability チェック（current_user_can( 'edit_user', $user_id )）: 本人が自分のプロフィールを保存
+	 *   できる／管理者が他人のプロフィールを保存できる（正常系）。権限を持たない購読者が他人のプロフィールを
+	 *   書き換えようとしても保存されず既存値が維持される（異常系）。各ケースの 'acting_user' キーで
+	 *   実行者を切り替える（省略時は対象ユーザー本人＝自己編集）。
 	 *
-	 * Verify the sanitization behavior of update_author_structure_data().
+	 * Verify the sanitization behavior and the capability check of update_author_structure_data().
 	 * - author_type is not saved (the existing value is kept) unless it is one of the whitelisted values (organization / person).
 	 * - author_name has tags etc. stripped via sanitize_text_field().
 	 * - For author_url / author_sameAs, when esc_url_raw() returns an empty string even though the submitted
@@ -192,6 +196,11 @@ class Article_Structure_Test extends WP_UnitTestCase {
 	 * - Existing saved user meta is not broken or lost by adding this sanitization (backward compatibility).
 	 * - Saving also works normally for a fresh user whose meta has never been saved before (the $prev_value
 	 *   argument to update_user_meta() being an empty string is the main path in production).
+	 * - The capability check (current_user_can( 'edit_user', $user_id )): the user themself can save their own
+	 *   profile, and an administrator can save another user's profile (normal cases). A subscriber who lacks
+	 *   permission cannot save another user's profile; nothing is saved and the existing value is kept
+	 *   (abnormal case). The 'acting_user' key on each case switches who executes it (defaults to the target
+	 *   user themself, i.e. a self-edit, when omitted).
 	 */
 	function test_update_author_structure_data() {
 
@@ -200,8 +209,8 @@ class Article_Structure_Test extends WP_UnitTestCase {
 		print 'test_update_author_structure_data' . PHP_EOL;
 		print '------------------------------------' . PHP_EOL;
 
-		// テスト用ユーザーを発行。
-		// Create a test user.
+		// テスト用ユーザーを発行（対象ユーザー＝profile を保存される側）。
+		// Create a test user (the target user whose profile gets saved).
 		$user_id = wp_insert_user(
 			array(
 				'user_login'   => 'sanitize_test_user',
@@ -211,12 +220,41 @@ class Article_Structure_Test extends WP_UnitTestCase {
 		);
 
 		// update_author_structure_data() には current_user_can( 'edit_user', $user_id ) のチェックがあるため、
-		// 自分自身のプロフィールを編集する体で current user をこのテストユーザーにしておく（自己編集は
-		// 権限昇格なしに許可されるメタ capability のため、role を付与しなくても edit_user は true になる）。
-		// update_author_structure_data() has a current_user_can( 'edit_user', $user_id ) check, so set the
-		// current user to this test user as if they were editing their own profile (self-editing is allowed
-		// by the edit_user meta capability without granting a role, so no privilege escalation is involved).
-		wp_set_current_user( $user_id );
+		// capability の挙動を検証するための実行者ユーザーを追加で発行する。
+		// - administrator : 他人（$user_id）のプロフィールを保存できることを確認する正常系用。
+		// - subscriber    : 他人（$user_id）のプロフィールを保存する権限を持たないことを確認する異常系用。
+		// update_author_structure_data() has a current_user_can( 'edit_user', $user_id ) check, so create
+		// additional "acting" users to verify its behavior.
+		// - administrator: used for the normal case verifying they can save another user's ($user_id's) profile.
+		// - subscriber: used for the abnormal case verifying they lack permission to save another user's ($user_id's) profile.
+		$admin_user_id      = wp_insert_user(
+			array(
+				'user_login'   => 'capability_administrator_user',
+				'user_pass'    => 'user_pass',
+				'display_name' => 'Capability Administrator User',
+				'role'         => 'administrator',
+			)
+		);
+		$subscriber_user_id = wp_insert_user(
+			array(
+				'user_login'   => 'capability_subscriber_user',
+				'user_pass'    => 'user_pass',
+				'display_name' => 'Capability Subscriber User',
+				'role'         => 'subscriber',
+			)
+		);
+
+		// 各ケースの 'acting_user' キーで実行者を切り替えるためのマップ。省略時は 'owner'（対象ユーザー本人＝
+		// 自己編集）として実行する。自己編集は権限昇格なしに許可されるメタ capability のため、role を
+		// 付与しなくても edit_user は true になる。
+		// A map used to switch the acting user via each case's 'acting_user' key. When omitted, it runs as
+		// 'owner' (the target user themself, i.e. a self-edit). Self-editing is allowed by the edit_user meta
+		// capability without granting a role, so no privilege escalation is involved.
+		$acting_user_ids = array(
+			'owner'         => $user_id,
+			'administrator' => $admin_user_id,
+			'subscriber'    => $subscriber_user_id,
+		);
 
 		// 各ケースの前提となる「既存の保存済みユーザーメタ」。サニタイズ追加後も、保存対象外・無効値のケースで
 		// このデータが壊れず維持されることを確認する（後方互換の検証）。
@@ -510,6 +548,67 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					'author_sameAs' => 'https://example.com/existing-sns',
 				),
 			),
+			// 正常系（capability） : 本人が自分のプロフィールを保存する場合 => 送信値がそのまま保存される。
+			// Normal case (capability): the user themself saves their own profile -> the submitted values are saved as-is.
+			array(
+				'test_condition_name' => '正常系 : 本人が自分のプロフィールを保存する場合 => 送信値がそのまま保存される',
+				'acting_user'         => 'owner',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Self Edited Name',
+					'author_url'    => 'https://example.com/self-edited',
+					'author_sameAs' => 'https://example.com/self-edited-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Self Edited Name',
+					'author_url'    => 'https://example.com/self-edited',
+					'author_sameAs' => 'https://example.com/self-edited-sns',
+				),
+			),
+			// 正常系（capability） : 管理者が他人（対象ユーザー）のプロフィールを保存する場合 => 送信値がそのまま保存される。
+			// Normal case (capability): an administrator saves another user's (the target user's) profile -> the submitted values are saved as-is.
+			array(
+				'test_condition_name' => '正常系 : 管理者が他人のプロフィールを保存する場合 => 送信値がそのまま保存される',
+				'acting_user'         => 'administrator',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'person',
+					'author_name'   => 'Edited By Admin',
+					'author_url'    => 'https://example.com/edited-by-admin',
+					'author_sameAs' => 'https://example.com/edited-by-admin-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'person',
+					'author_name'   => 'Edited By Admin',
+					'author_url'    => 'https://example.com/edited-by-admin',
+					'author_sameAs' => 'https://example.com/edited-by-admin-sns',
+				),
+			),
+			// 異常系（capability） : 対象ユーザーを編集する権限を持たない購読者が他人のプロフィールを書き換えようとする場合
+			// => update_author_structure_data() 先頭の current_user_can( 'edit_user', $user_id ) チェックで弾かれ、
+			// 保存されず既存値が維持される。
+			// Abnormal case (capability): a subscriber who lacks permission to edit the target user attempts to
+			// overwrite another user's profile -> rejected by the current_user_can( 'edit_user', $user_id )
+			// check at the top of update_author_structure_data(); nothing is saved and the existing value is kept.
+			array(
+				'test_condition_name' => '異常系 : 権限を持たない購読者が他人のプロフィールを書き換えようとする場合 => 保存されず既存値が維持される',
+				'acting_user'         => 'subscriber',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'person',
+					'author_name'   => 'Hijacked Name',
+					'author_url'    => 'https://evil.example.com/',
+					'author_sameAs' => 'https://evil.example.com/sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {
@@ -518,6 +617,11 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			foreach ( $case['existing_meta'] as $key => $value ) {
 				update_user_meta( $user_id, $key, $value );
 			}
+
+			// 実行者を切り替える（省略時は 'owner' ＝対象ユーザー本人として実行する）。
+			// Switch the acting user (defaults to 'owner', i.e. the target user themself, when omitted).
+			$acting_user_key = isset( $case['acting_user'] ) ? $case['acting_user'] : 'owner';
+			wp_set_current_user( $acting_user_ids[ $acting_user_key ] );
 
 			// フォーム送信を再現するため $_POST を差し替える。
 			// Replace $_POST to reproduce a form submission.
@@ -552,88 +656,12 @@ class Article_Structure_Test extends WP_UnitTestCase {
 		}
 
 		// current user とテストで発行したユーザーを後始末する。
-		// Clean up the current user and the user created for the test.
+		// Clean up the current user and the users created for the test.
 		wp_set_current_user( 0 );
 		wp_delete_user( $user_id );
-	}
-
-	/**
-	 * update_author_structure_data() に追加した capability チェック（current_user_can( 'edit_user', $user_id )）を検証する。
-	 * 対象ユーザーを編集する権限を持たないユーザーが呼び出した場合、保存は行われず既存値が維持されることを確認する。
-	 *
-	 * Verify the capability check (current_user_can( 'edit_user', $user_id )) added to update_author_structure_data().
-	 * When called by a user who lacks permission to edit the target user, verify that nothing is saved and the existing value is kept.
-	 */
-	function test_update_author_structure_data_requires_capability() {
-
-		print PHP_EOL;
-		print '------------------------------------' . PHP_EOL;
-		print 'test_update_author_structure_data_requires_capability' . PHP_EOL;
-		print '------------------------------------' . PHP_EOL;
-
-		// 更新対象のユーザー。
-		// The target user to be updated.
-		$target_user_id = wp_insert_user(
-			array(
-				'user_login'   => 'capability_target_user',
-				'user_pass'    => 'user_pass',
-				'display_name' => 'Capability Target User',
-			)
-		);
-
-		// 対象ユーザーを編集する権限を持たない、購読者ロールのユーザー。
-		// A subscriber-role user who has no permission to edit the target user.
-		$subscriber_user_id = wp_insert_user(
-			array(
-				'user_login'   => 'capability_subscriber_user',
-				'user_pass'    => 'user_pass',
-				'display_name' => 'Capability Subscriber User',
-				'role'         => 'subscriber',
-			)
-		);
-
-		$existing_meta = array(
-			'author_type'   => 'organization',
-			'author_name'   => 'Existing Name',
-			'author_url'    => 'https://example.com/existing',
-			'author_sameAs' => 'https://example.com/existing-sns',
-		);
-		foreach ( $existing_meta as $key => $value ) {
-			update_user_meta( $target_user_id, $key, $value );
-		}
-
-		// 購読者ユーザーとしてログインし、対象ユーザーの構造化データを書き換えようとする。
-		// Log in as the subscriber user and attempt to overwrite the target user's structured data.
-		wp_set_current_user( $subscriber_user_id );
-
-		$_POST = array(
-			'author_type'   => 'person',
-			'author_name'   => 'Hijacked Name',
-			'author_url'    => 'https://evil.example.com/',
-			'author_sameAs' => 'https://evil.example.com/sns',
-		);
-
-		$old_user_data = get_userdata( $target_user_id );
-
-		VK_Article_Srtuctured_Data::update_author_structure_data( $target_user_id, $old_user_data );
-
-		$actual = array(
-			'author_type'   => get_user_meta( $target_user_id, 'author_type', true ),
-			'author_name'   => get_user_meta( $target_user_id, 'author_name', true ),
-			'author_url'    => get_user_meta( $target_user_id, 'author_url', true ),
-			'author_sameAs' => get_user_meta( $target_user_id, 'author_sameAs', true ),
-		);
-
-		$this->assertEquals( $existing_meta, $actual, '権限を持たないユーザーからの呼び出しでは、既存値が維持され上書きされない' );
-
-		// 後始末。
-		// Clean up.
-		$_POST = array();
-		wp_set_current_user( 0 );
-		wp_delete_user( $target_user_id );
+		wp_delete_user( $admin_user_id );
 		wp_delete_user( $subscriber_user_id );
 	}
-
 
 	function test_get_article_structure_array() {
 

--- a/tests/test-article-structure.php
+++ b/tests/test-article-structure.php
@@ -171,14 +171,27 @@ class Article_Structure_Test extends WP_UnitTestCase {
 	 * update_author_structure_data() のサニタイズ挙動を検証する。
 	 * - author_type はホワイトリスト（organization / person）以外の値では保存されず既存値が維持される。
 	 * - author_name は sanitize_text_field() でタグ等が除去される。
-	 * - author_url / author_sameAs は esc_url_raw() で不正なスキームの URL が無害化される。
+	 * - author_url / author_sameAs は、送信値が空でないのに esc_url_raw() が空文字を返す（許可されない
+	 *   スキーム等で弾かれた）場合は保存されず既存値が維持される。送信値自体が空（意図的な空欄クリア）の
+	 *   場合はサニタイズ後の値（空文字）で保存される。
+	 * - 項目が送信されない（isset() が false）場合は、その項目の既存値が維持される。
+	 * - 配列が送信されても Fatal error にならず、文字列でない値はサニタイズ対象外として無視される。
 	 * - 既存の保存済みユーザーメタが、サニタイズ追加によって壊れたり消えたりしない（後方互換）。
+	 * - メタが一度も保存されていない新規ユーザーに対しても、正常に保存できる（update_user_meta() の
+	 *   第4引数 $prev_value が空文字になる、本番での主経路）。
 	 *
 	 * Verify the sanitization behavior of update_author_structure_data().
 	 * - author_type is not saved (the existing value is kept) unless it is one of the whitelisted values (organization / person).
 	 * - author_name has tags etc. stripped via sanitize_text_field().
-	 * - author_url / author_sameAs have URLs with a disallowed scheme neutralized via esc_url_raw().
+	 * - For author_url / author_sameAs, when esc_url_raw() returns an empty string even though the submitted
+	 *   value was not empty (rejected, e.g. a disallowed scheme), the value is not saved and the existing
+	 *   value is kept. When the submitted value itself is empty (an intentional clear), it is saved as the
+	 *   sanitized (empty) value.
+	 * - When a field is not submitted (isset() is false), that field's existing value is kept.
+	 * - Submitting an array does not cause a Fatal error; non-string values are ignored and not sanitized.
 	 * - Existing saved user meta is not broken or lost by adding this sanitization (backward compatibility).
+	 * - Saving also works normally for a fresh user whose meta has never been saved before (the $prev_value
+	 *   argument to update_user_meta() being an empty string is the main path in production).
 	 */
 	function test_update_author_structure_data() {
 
@@ -197,12 +210,22 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			)
 		);
 
+		// update_author_structure_data() には current_user_can( 'edit_user', $user_id ) のチェックがあるため、
+		// 自分自身のプロフィールを編集する体で current user をこのテストユーザーにしておく（自己編集は
+		// 権限昇格なしに許可されるメタ capability のため、role を付与しなくても edit_user は true になる）。
+		// update_author_structure_data() has a current_user_can( 'edit_user', $user_id ) check, so set the
+		// current user to this test user as if they were editing their own profile (self-editing is allowed
+		// by the edit_user meta capability without granting a role, so no privilege escalation is involved).
+		wp_set_current_user( $user_id );
+
 		// 各ケースの前提となる「既存の保存済みユーザーメタ」。サニタイズ追加後も、保存対象外・無効値のケースで
 		// このデータが壊れず維持されることを確認する（後方互換の検証）。
+		// 空配列を指定したケースは、メタを一切事前設定せず「未保存」の状態から始める。
 		// The "existing saved user meta" that each case starts from. Used to verify that, even after adding this
 		// sanitization, this data is kept intact when a field is not submitted or an invalid value is submitted
 		// (backward compatibility check).
-		$existing_meta = array(
+		// A case that specifies an empty array pre-sets no meta at all, starting from an "unsaved" state.
+		$default_existing_meta = array(
 			'author_type'   => 'organization',
 			'author_name'   => 'Existing Name',
 			'author_url'    => 'https://example.com/existing',
@@ -214,6 +237,7 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			// Normal case: submitting all valid values (organization).
 			array(
 				'test_condition_name' => '正常系 : author_type が organization で全項目が正しい値の場合 => そのまま保存される',
+				'existing_meta'       => $default_existing_meta,
 				'post'                => array(
 					'author_type'   => 'organization',
 					'author_name'   => 'Vektor Inc.',
@@ -231,6 +255,7 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			// Normal case: author_type is person.
 			array(
 				'test_condition_name' => '正常系 : author_type が person で全項目が正しい値の場合 => そのまま保存される',
+				'existing_meta'       => $default_existing_meta,
 				'post'                => array(
 					'author_type'   => 'person',
 					'author_name'   => 'Vekutarou',
@@ -244,10 +269,31 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					'author_sameAs' => 'https://twitter.com/vekutarou',
 				),
 			),
+			// 正常系（境界値） : メタが一度も保存されていない新規ユーザーが初めて保存する場合
+			// （update_user_meta() の $prev_value が空文字になる、本番での主経路）=> 送信値がそのまま保存される。
+			// Normal case (boundary): a fresh user whose meta has never been saved saves it for the first time
+			// (the $prev_value argument to update_user_meta() being an empty string is the main path in production) -> the submitted values are saved as-is.
+			array(
+				'test_condition_name' => '正常系 : メタ未設定の新規ユーザーが初めて保存する場合 => 送信値がそのまま保存される',
+				'existing_meta'       => array(),
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'New User',
+					'author_url'    => 'https://example.com/new',
+					'author_sameAs' => 'https://example.com/new-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'New User',
+					'author_url'    => 'https://example.com/new',
+					'author_sameAs' => 'https://example.com/new-sns',
+				),
+			),
 			// 異常系（境界値） : author_type が空文字（ホワイトリスト外）の場合 => 保存されず既存値が維持される。
 			// Abnormal case (boundary): author_type is an empty string (outside the whitelist) -> not saved, the existing value is kept.
 			array(
 				'test_condition_name' => '異常系 : author_type が空文字の場合 => 保存されず既存値が維持される',
+				'existing_meta'       => $default_existing_meta,
 				'post'                => array(
 					'author_type'   => '',
 					'author_name'   => 'Existing Name',
@@ -265,6 +311,7 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			// Abnormal case: author_type receives an invalid value containing a tag -> not saved, the existing value is kept.
 			array(
 				'test_condition_name' => '異常系 : author_type にホワイトリスト外の値（タグ入り）が届いた場合 => 保存されず既存値が維持される',
+				'existing_meta'       => $default_existing_meta,
 				'post'                => array(
 					'author_type'   => '<script>alert(1)</script>',
 					'author_name'   => 'Existing Name',
@@ -278,63 +325,111 @@ class Article_Structure_Test extends WP_UnitTestCase {
 					'author_sameAs' => 'https://example.com/existing-sns',
 				),
 			),
-			// 異常系 : author_name にタグ入り文字列が届いた場合 => sanitize_text_field() でタグが除去されて保存される。
-			// Abnormal case: author_name receives a string containing a tag -> saved with the tag stripped via sanitize_text_field().
+			// 異常系 : author_name にタグ入り文字列（属性に仕込んだ XSS）が届いた場合
+			// => sanitize_text_field() でタグごと除去され、リテラル 'Vektor' として保存される。
+			// Abnormal case: author_name receives a string containing a tag (XSS embedded in an attribute)
+			// -> the tag itself is stripped via sanitize_text_field() and saved as the literal 'Vektor'.
 			array(
-				'test_condition_name' => '異常系 : author_name にタグ入り文字列が届いた場合 => タグが除去されて保存される',
+				'test_condition_name' => '異常系 : author_name にタグ入り文字列が届いた場合 => タグが除去され Vektor が保存される',
+				'existing_meta'       => $default_existing_meta,
 				'post'                => array(
 					'author_type'   => 'organization',
-					'author_name'   => '<script>alert(1)</script>Vektor',
+					'author_name'   => '<img src=x onerror=alert(1)>Vektor',
 					'author_url'    => 'https://example.com/existing',
 					'author_sameAs' => 'https://example.com/existing-sns',
 				),
 				'expected'            => array(
 					'author_type'   => 'organization',
-					'author_name'   => sanitize_text_field( '<script>alert(1)</script>Vektor' ),
+					'author_name'   => 'Vektor',
 					'author_url'    => 'https://example.com/existing',
 					'author_sameAs' => 'https://example.com/existing-sns',
 				),
 			),
-			// 異常系 : author_url に許可されないスキーム（javascript:）の URL が届いた場合 => esc_url_raw() で無害化されて保存される。
-			// Abnormal case: author_url receives a URL with a disallowed scheme (javascript:) -> saved after being neutralized via esc_url_raw().
+			// 異常系（メタ未設定から） : author_url に許可されないスキーム（javascript:）の URL が届いた場合
+			// => 保存されず、メタは未設定のまま（get_user_meta() の既定値である空文字が返る）。
+			// esc_url_raw() を直接呼んでリテラルを算出せず、'' を直書きすることで
+			// 「不正なスキームが確実に弾かれる」ことそのものを検証する。
+			// Abnormal case (starting with no saved meta): author_url receives a URL with a disallowed scheme
+			// (javascript:) -> it is not saved, and the meta remains unset (get_user_meta() returns its
+			// default, an empty string). The literal '' is hardcoded instead of calling esc_url_raw() here,
+			// to actually assert that the disallowed scheme is rejected.
 			array(
-				'test_condition_name' => '異常系 : author_url に不正なスキームの URL が届いた場合 => esc_url_raw() でサニタイズされて保存される',
+				'test_condition_name' => '異常系 : メタ未設定の状態で author_url に不正なスキームの URL が届いた場合 => 保存されずメタ未設定のまま',
+				'existing_meta'       => array(),
 				'post'                => array(
 					'author_type'   => 'organization',
-					'author_name'   => 'Existing Name',
+					'author_name'   => 'New User',
 					'author_url'    => 'javascript:alert(1)',
-					'author_sameAs' => 'https://example.com/existing-sns',
+					'author_sameAs' => 'https://example.com/new-sns',
 				),
 				'expected'            => array(
 					'author_type'   => 'organization',
-					'author_name'   => 'Existing Name',
-					'author_url'    => esc_url_raw( 'javascript:alert(1)' ),
-					'author_sameAs' => 'https://example.com/existing-sns',
+					'author_name'   => 'New User',
+					'author_url'    => '',
+					'author_sameAs' => 'https://example.com/new-sns',
 				),
 			),
-			// 異常系 : author_sameAs にタグ入りの不正な値が届いた場合 => esc_url_raw() でサニタイズされて保存される。
-			// Abnormal case: author_sameAs receives an invalid value containing a tag -> saved after being sanitized via esc_url_raw().
+			// 異常系 : author_sameAs に許可されないスキーム（javascript:）の URL が届いた場合
+			// => 保存されず既存値が維持される（author_url と揃えた挙動）。
+			// Abnormal case: author_sameAs receives a URL with a disallowed scheme (javascript:)
+			// -> it is not saved and the existing value is kept (behavior aligned with author_url).
 			array(
-				'test_condition_name' => '異常系 : author_sameAs にタグ入りの不正な値が届いた場合 => esc_url_raw() でサニタイズされて保存される',
+				'test_condition_name' => '異常系 : author_sameAs に不正なスキームの URL が届いた場合 => 保存されず既存値が維持される',
+				'existing_meta'       => $default_existing_meta,
 				'post'                => array(
 					'author_type'   => 'organization',
 					'author_name'   => 'Existing Name',
 					'author_url'    => 'https://example.com/existing',
-					'author_sameAs' => '"><script>alert(1)</script>',
+					'author_sameAs' => 'javascript:alert(document.cookie)',
 				),
 				'expected'            => array(
 					'author_type'   => 'organization',
 					'author_name'   => 'Existing Name',
 					'author_url'    => 'https://example.com/existing',
-					'author_sameAs' => esc_url_raw( '"><script>alert(1)</script>' ),
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系 : author_url に配列が送信された場合 => Fatal error にならず、is_string() チェックにより
+			// サニタイズ対象外として無視され、既存値が維持される。
+			// Abnormal case: author_url receives an array -> no Fatal error occurs; the is_string() guard
+			// excludes it from sanitization and the existing value is kept.
+			array(
+				'test_condition_name' => '異常系 : author_url に配列が送信された場合 => Fatal error にならず既存値が維持される',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => array( 'x' ),
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
+				),
+			),
+			// 異常系 : 4項目とも一切送信されない場合（$_POST が空）=> isset() が false になり、
+			// 4項目すべての既存値がそのまま維持される。
+			// Abnormal case: none of the 4 fields are submitted at all (empty $_POST) -> isset() is false for
+			// all of them, so the existing value of all 4 fields is kept as-is.
+			array(
+				'test_condition_name' => '異常系 : 4項目とも送信されない場合 => 4項目とも既存値が維持される',
+				'existing_meta'       => $default_existing_meta,
+				'post'                => array(),
+				'expected'            => array(
+					'author_type'   => 'organization',
+					'author_name'   => 'Existing Name',
+					'author_url'    => 'https://example.com/existing',
+					'author_sameAs' => 'https://example.com/existing-sns',
 				),
 			),
 		);
 
 		foreach ( $test_cases as $case ) {
-			// 各ケースの前提として、既存の保存済みユーザーメタを設定する（後方互換の検証用）。
-			// Set up the existing saved user meta as the premise for each case (used for the backward-compatibility check).
-			foreach ( $existing_meta as $key => $value ) {
+			// 各ケースの前提として、既存の保存済みユーザーメタを設定する（空配列の場合は何も設定せず未保存状態から始める）。
+			// Set up the existing saved user meta as the premise for each case (an empty array sets nothing, starting from an unsaved state).
+			foreach ( $case['existing_meta'] as $key => $value ) {
 				update_user_meta( $user_id, $key, $value );
 			}
 
@@ -370,9 +465,87 @@ class Article_Structure_Test extends WP_UnitTestCase {
 			delete_user_meta( $user_id, 'author_sameAs' );
 		}
 
-		// テストで発行したユーザーを削除。
-		// Delete the user created for the test.
+		// current user とテストで発行したユーザーを後始末する。
+		// Clean up the current user and the user created for the test.
+		wp_set_current_user( 0 );
 		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * update_author_structure_data() に追加した capability チェック（current_user_can( 'edit_user', $user_id )）を検証する。
+	 * 対象ユーザーを編集する権限を持たないユーザーが呼び出した場合、保存は行われず既存値が維持されることを確認する。
+	 *
+	 * Verify the capability check (current_user_can( 'edit_user', $user_id )) added to update_author_structure_data().
+	 * When called by a user who lacks permission to edit the target user, verify that nothing is saved and the existing value is kept.
+	 */
+	function test_update_author_structure_data_requires_capability() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_update_author_structure_data_requires_capability' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		// 更新対象のユーザー。
+		// The target user to be updated.
+		$target_user_id = wp_insert_user(
+			array(
+				'user_login'   => 'capability_target_user',
+				'user_pass'    => 'user_pass',
+				'display_name' => 'Capability Target User',
+			)
+		);
+
+		// 対象ユーザーを編集する権限を持たない、購読者ロールのユーザー。
+		// A subscriber-role user who has no permission to edit the target user.
+		$subscriber_user_id = wp_insert_user(
+			array(
+				'user_login'   => 'capability_subscriber_user',
+				'user_pass'    => 'user_pass',
+				'display_name' => 'Capability Subscriber User',
+				'role'         => 'subscriber',
+			)
+		);
+
+		$existing_meta = array(
+			'author_type'   => 'organization',
+			'author_name'   => 'Existing Name',
+			'author_url'    => 'https://example.com/existing',
+			'author_sameAs' => 'https://example.com/existing-sns',
+		);
+		foreach ( $existing_meta as $key => $value ) {
+			update_user_meta( $target_user_id, $key, $value );
+		}
+
+		// 購読者ユーザーとしてログインし、対象ユーザーの構造化データを書き換えようとする。
+		// Log in as the subscriber user and attempt to overwrite the target user's structured data.
+		wp_set_current_user( $subscriber_user_id );
+
+		$_POST = array(
+			'author_type'   => 'person',
+			'author_name'   => 'Hijacked Name',
+			'author_url'    => 'https://evil.example.com/',
+			'author_sameAs' => 'https://evil.example.com/sns',
+		);
+
+		$old_user_data = get_userdata( $target_user_id );
+
+		VK_Article_Srtuctured_Data::update_author_structure_data( $target_user_id, $old_user_data );
+
+		$actual = array(
+			'author_type'   => get_user_meta( $target_user_id, 'author_type', true ),
+			'author_name'   => get_user_meta( $target_user_id, 'author_name', true ),
+			'author_url'    => get_user_meta( $target_user_id, 'author_url', true ),
+			'author_sameAs' => get_user_meta( $target_user_id, 'author_sameAs', true ),
+		);
+
+		$this->assertEquals( $existing_meta, $actual, '権限を持たないユーザーからの呼び出しでは、既存値が維持され上書きされない' );
+
+		// 後始末。
+		// Clean up.
+		$_POST = array();
+		wp_set_current_user( 0 );
+		wp_delete_user( $target_user_id );
+		wp_delete_user( $subscriber_user_id );
 	}
 
 


### PR DESCRIPTION
Closes #1470

@coderabbitai ignore

## 概要

WordPress の**ユーザープロフィール画面**にある「著者情報の構造化データ」設定（`@type` / `name` / `url` / `sameAs`）を保存するときに、入力値をそのままデータベースへ保存していました。これを、保存前にサニタイズ（想定外の値を無害な形に変換する処理）してから保存するように変更します。

あわせて、保存処理を実行してよい利用者かどうかの権限チェックも追加しました。

### なぜ必要か

WordPress.org へのプラグイン公開・審査で使われる公式ツール「Plugin Check」（プラグインの実装がガイドラインに沿っているかを機械的に検査するツール）で、`update_author_structure_data()`（プロフィール更新時に WordPress 本体から呼ばれる処理）が入力値を無検査で保存している、と警告されていました。

出力側（記事ページの `<head>` に構造化データを出す処理）では許可したタグ以外を取り除く処理を通しているため、**現状ただちに実害が出るものではありません**。保存の時点でも防いでおく、多層防御としての改善です。

## 変更内容

### 1. 保存時のサニタイズ

| 設定項目 | 変更後の扱い |
|---|---|
| `@type`（`author_type`） | `organization` / `person` の2値のみ保存。それ以外の値が届いた場合は**保存せず、既存の値をそのまま維持**する |
| `name`（`author_name`） | タグ・余分な空白を除去してから保存 |
| `url`（`author_url`） | 前後の空白を取り除いたうえで、URL として不正な文字列を除去してから保存 |
| `sameAs`（`author_sameAs`） | `url` と同じ扱い |

`javascript:` や `data:` のような、URL として許可されていない形式は保存されません。この場合も**既存の値は消さずに維持**します（入力欄を空にして保存した場合は、従来どおり値をクリアできます）。

### 2. 権限チェックの追加

保存処理の先頭で「そのユーザーのプロフィールを編集してよい利用者か」を確認するようにしました。管理画面から操作する場合は WordPress 本体が同じ確認をしているため、通常の操作に影響はありません。REST API・XML-RPC・WP-CLI など、管理画面を経由しない経路のための防御層です。

### 3. 配列が送られてきた場合の PHP エラーを防止

`author_url[]=x` のように配列の形で送られた場合、値を文字列として扱えず PHP のエラー（Fatal error）になる状態でした。文字列でない値は無視するようにしています。

### 4. PHPUnit テストの追加

`tests/test-article-structure.php` に、保存処理のテストを11ケース追加しました（正常系・境界値・異常系、権限チェック、既存データの後方互換）。

## 影響範囲

- **既存の保存済みデータは変更しません。** 一括で書き換える処理は入れていないため、サニタイズが効くのはプロフィールを保存し直したときのみです。
- 画面の見た目・文言の変更はありません。

## レビュー実施状況

- **セキュリティレビュー（安藤）: PASS** — 3ラウンド実施。1回目で MEDIUM 4件（配列 POST での Fatal error、権限チェック欠如、`phpcs:ignore` の根拠コメントの誤り、テストの検証不足）を指摘・修正。2回目の LOW 2件（一部の入力が「意図的な空欄クリア」と誤判定されて既存値が消える／URL 前後の空白が `%20` として保存される）も修正済み。
- **UX レビュー（植草）: PASS** — 2回実施。不正値の扱いが「黙って空になる」から「既存値を維持」へ変わった点を、データを壊さない方向の改善と判定。

判断の記録は元 issue のコメントに残しています。

## 確認手順

### 前提条件

- 管理者権限のユーザーでログインできること
- ExUnit の「記事の構造化データ」機能が有効なこと

### 手順

#### 1. 通常の保存が従来どおり動くこと

1. 管理画面 > ユーザー > あなたのプロフィール を開く
2. ページ下部の「著者情報の構造化データ」セクションまでスクロールする
3. `@type` で `Person` を選択する
4. `name` に `テスト太郎` と入力する
5. `url` に `https://example.com/profile` と入力する
6. `sameAs` に `https://example.com/sns` と入力する
7. 「プロフィールを更新」をクリックする
   → ✓ 保存され、再読み込み後も入力した値がそのまま表示される
8. 投稿記事の公開ページを開き、ページのソースを表示して `VK All in One Expansion Unit Article Structure Data` のコメントを探す
   → ✓ JSON-LD の `author` に、入力した `@type` / `name` / `url` / `sameAs` が出力されている

#### 2. URL の前後に空白があっても正しく保存されること

1. `url` に、前後に半角スペースを付けた `  https://example.com/profile  ` を入力する
2. 「プロフィールを更新」をクリックする
   → ✓ `https://example.com/profile` として保存される（末尾に `%20` が付かない）

#### 3. 不正な URL では既存の値が消えないこと

1. 手順1で `url` に有効な URL が保存されている状態にする
2. ブラウザの開発者ツールで `url` 入力欄の `type="url"` を `type="text"` に書き換える（ブラウザ側の入力チェックを外すため）
3. `url` に `javascript:alert(1)` と入力する
4. 「プロフィールを更新」をクリックする
   → ✓ 保存されず、手順1で入力した URL がそのまま残っている
   → ✓ 公開ページの JSON-LD にも `javascript:` は出力されない

#### 4. 入力欄を空にすればクリアできること（デグレ確認）

1. `url` の入力欄を空にする
2. 「プロフィールを更新」をクリックする
   → ✓ 値が空になる（意図的なクリアは従来どおり機能する）

#### 5. 自動テスト

```
npx wp-env start
npx wp-env run tests-cli --env-cwd='wp-content/plugins/vk-all-in-one-expansion-unit' vendor/bin/phpunit -c .phpunit.xml --filter Article_Structure_Test
```
→ ✓ 全ケース green（実装時の実行結果: `OK (4 tests, 26 assertions)`。全体スイートは `OK (140 tests, 1052 assertions)`）

## スクリーンショット

画面の見た目に変更はないため省略します（保存処理のみの変更で、`add_user_meta_structure_data_ui()` の出力は1行も変更していません）。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/809