### PR TITLE
[ 不具合修正 ] 設定画面のチェックリストがラベルしか表示せず、同じラベルの投稿タイプ・タクソノミーを選び分けられない不具合を修正

### DIFF
--- a/inc/sitemap-page/sitemap-page-admin-main-setting.php
+++ b/inc/sitemap-page/sitemap-page-admin-main-setting.php
@@ -34,6 +34,11 @@ function veu_sitemap_options_validate( $input ) {
 					if ( 'excludeTaxonomies' === $value && ! taxonomy_exists( $post_typ ) ) {
 						continue;
 					}
+					// Do not save a post type key that is not registered, to keep out invalid keys and option bloat.
+					// 登録されていない投稿タイプ名は保存しない（option の肥大化と不正キーの混入を防ぐ）
+					if ( 'excludePostTypes' === $value && ! post_type_exists( $post_typ ) ) {
+						continue;
+					}
 					$output[ $value ][ $post_typ ] = esc_html( $post_type_boolean );
 				}
 			} else {

--- a/inc/template-tags/package/template-tags.php
+++ b/inc/template-tags/package/template-tags.php
@@ -408,7 +408,11 @@ if ( ! function_exists( 'vk_the_post_type_check_list' ) ) {
 				}
 
 				echo '<li><label>';
-				echo '<input type="checkbox" name="' . esc_attr( $args['name'] ) . '[' . $key . ']"' . $id . ' value="true"' . $checked . ' />' . esc_html( $value->label );
+				echo '<input type="checkbox" name="' . esc_attr( $args['name'] ) . '[' . esc_attr( $key ) . ']"' . $id . ' value="true"' . $checked . ' />';
+				echo ' ' . esc_html( $value->label );
+				// スラッグは分類の手がかりとして表示するため、翻訳関数には通さない（自然言語ではないため i18n 対象外）。
+				// The slug is shown as a disambiguation cue and is intentionally not passed through a translation function (not natural language).
+				echo ' <span class="description">(<code>' . esc_html( $key ) . '</code>)</span>';
 				echo '</label></li>';
 			}
 		}
@@ -488,7 +492,11 @@ if ( ! function_exists( 'vk_the_taxonomy_check_list' ) ) {
 				$id      = ! empty( $args['id'][ $key ] ) ? ' id="' . esc_attr( $args['id'][ $key ] ) . '"' : '';
 
 				echo '<li><label>';
-				echo '<input type="checkbox" name="' . esc_attr( $args['name'] ) . '[' . esc_attr( $key ) . ']"' . $id . ' value="true"' . $checked . ' />' . esc_html( $value->label );
+				echo '<input type="checkbox" name="' . esc_attr( $args['name'] ) . '[' . esc_attr( $key ) . ']"' . $id . ' value="true"' . $checked . ' />';
+				echo ' ' . esc_html( $value->label );
+				// スラッグは分類の手がかりとして表示するため、翻訳関数には通さない（自然言語ではないため i18n 対象外）。
+				// The slug is shown as a disambiguation cue and is intentionally not passed through a translation function (not natural language).
+				echo ' <span class="description">(<code>' . esc_html( $key ) . '</code>)</span>';
 				echo '</label></li>';
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,8 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
+[ Bug Fix ] Fixed the exclusion checklist (HTML Sitemap, Ads, SNS Share Button, New Posts Widget) showing only the label, causing identically labeled taxonomies or post types (e.g. two "Tag" taxonomies) to be indistinguishable and the wrong one excluded by mistake. The slug is now shown next to the label.
+
 = 9.122.1 =
 [ Security Fix ][ Article Structured Data ] Added a capability check and sanitization when saving the author structured data settings (author_type / author_name / author_url / author_sameAs) on the user profile screen, as defense-in-depth hardening.
 [ Security Fix ][ Custom CSS ] Added a permission check on save and hardened input handling on the classic edit screen as defense in depth.

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
-[ Bug Fix ] Fixed the exclusion checklist (HTML Sitemap, Ads, SNS Share Button, New Posts Widget) showing only the label, causing identically labeled taxonomies or post types (e.g. two "Tag" taxonomies) to be indistinguishable and the wrong one excluded by mistake. The slug is now shown next to the label.
+[ Bug Fix ] Fixed the post type and taxonomy checklists in the settings screens showing only labels, making identically labeled items indistinguishable and easy to check by mistake. The slug is now shown next to the label.
 
 = 9.122.1 =
 [ Security Fix ][ Article Structured Data ] Added a capability check and sanitization when saving the author structured data settings (author_type / author_name / author_url / author_sameAs) on the user profile screen, as defense-in-depth hardening.

--- a/tests/test-sitemap-page.php
+++ b/tests/test-sitemap-page.php
@@ -641,6 +641,22 @@ class SitemapPageTest extends WP_UnitTestCase {
 				),
 				'expected_not_contains' => array(),
 			),
+			array(
+				// 境界値: exclude_post_types で指定した投稿タイプは一覧から除外され、出力に含まれない事を検証する。
+				// Boundary case: a post type listed in exclude_post_types is left out of the checklist entirely.
+				'test_condition_name'   => '境界値: exclude_post_types で指定した投稿タイプは出力に含まれない',
+				'args'                  => array(
+					'name'               => 'vkExUnit_sitemap_options[excludePostTypes]',
+					'checked'            => array(),
+					'exclude_post_types' => array( 'attachment', 'veu_test_cpt_dup_b' ),
+				),
+				'expected_contains'     => array(
+					'<code>veu_test_cpt_dup_a</code>',
+				),
+				'expected_not_contains' => array(
+					'<code>veu_test_cpt_dup_b</code>',
+				),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {

--- a/tests/test-sitemap-page.php
+++ b/tests/test-sitemap-page.php
@@ -342,12 +342,15 @@ class SitemapPageTest extends WP_UnitTestCase {
 
 	/**
 	 * veu_sitemap_options_validate() のテスト。
-	 * 登録済みのタクソノミー名は保存され、未登録のタクソノミー名は保存されない事
-	 * （安藤さんレビュー LOW 指摘の入力検証）を検証する。
+	 * 登録済みのタクソノミー名・投稿タイプ名は保存され、未登録の名前は保存されない事
+	 * （安藤さんレビュー LOW 指摘の入力検証。excludePostTypes 側のガードは Issue #1475
+	 * 対応時に excludeTaxonomies 側と対称になるよう追加した）を検証する。
 	 *
 	 * Test for veu_sitemap_options_validate().
-	 * Verifies that a registered taxonomy name is saved, and that an unregistered
-	 * taxonomy name is dropped ( input validation gap pointed out in the code review ).
+	 * Verifies that a registered taxonomy or post type name is saved, and that an
+	 * unregistered name is dropped ( input validation gap pointed out in the code review;
+	 * the excludePostTypes guard was added during the Issue #1475 work to make it symmetric
+	 * with the existing excludeTaxonomies guard ).
 	 */
 	function test_veu_sitemap_options_validate() {
 
@@ -381,6 +384,25 @@ class SitemapPageTest extends WP_UnitTestCase {
 				'test_condition_name'         => '境界値: excludeTaxonomies が送信されない場合は何も保存されない',
 				'input'                       => array(
 					'excludePostTypes' => array( 'post' => 'true' ),
+				),
+				'expected_exclude_post_types' => array( 'post' => 'true' ),
+				'expected_exclude_taxonomies' => array(),
+			),
+			array(
+				'test_condition_name'         => '登録済みの投稿タイプ名（page）は excludePostTypes にそのまま保存される',
+				'input'                       => array(
+					'excludePostTypes' => array( 'page' => 'true' ),
+				),
+				'expected_exclude_post_types' => array( 'page' => 'true' ),
+				'expected_exclude_taxonomies' => array(),
+			),
+			array(
+				'test_condition_name'         => '未登録の投稿タイプ名は excludePostTypes から除かれる（登録済みの分は保存される）',
+				'input'                       => array(
+					'excludePostTypes' => array(
+						'post'                     => 'true',
+						'veu_test_not_a_post_type' => 'true',
+					),
 				),
 				'expected_exclude_post_types' => array( 'post' => 'true' ),
 				'expected_exclude_taxonomies' => array(),
@@ -499,6 +521,23 @@ class SitemapPageTest extends WP_UnitTestCase {
 				),
 				'expected_not_contains' => array(),
 			),
+			array(
+				// 境界値: スラッグに HTML 特殊文字が含まれる場合、name 属性・スラッグ表示の両方がエスケープされる事を検証する。
+				// esc_attr() / esc_html() を外すと落ちるケースにする事で、エスケープ処理の退行を検出できるようにしている。
+				// Boundary case: a slug containing HTML special characters must be escaped in both the name
+				// attribute and the slug display. Removing esc_attr()/esc_html() makes this case fail.
+				'test_condition_name'   => '境界値: スラッグに HTML 特殊文字が含まれる場合、name 属性とスラッグ表示の両方がエスケープされる',
+				'args'                  => array(
+					'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
+					'checked'    => array(),
+					'taxonomies' => array( 'veu"tax<x' => $taxonomy_object ),
+				),
+				'expected_contains'     => array(
+					'name="vkExUnit_sitemap_options[excludeTaxonomies][veu&quot;tax&lt;x]"',
+					'<code>veu&quot;tax&lt;x</code>',
+				),
+				'expected_not_contains' => array( '[veu"tax<x]' ),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {
@@ -518,13 +557,19 @@ class SitemapPageTest extends WP_UnitTestCase {
 	/**
 	 * vk_the_post_type_check_list() のテスト。
 	 * Issue #1475 対応として、見出しに「ラベル (スラッグ)」の形式でスラッグが併記される事、
-	 * name 属性のスラッグが esc_attr() される事、同じラベルで異なるスラッグの投稿タイプが
+	 * name 属性にスラッグが出力される事、同じラベルで異なるスラッグの投稿タイプが
 	 * 並んでも出力から判別できる事を検証する。
+	 * register_post_type() はスラッグを英数字・アンダースコア・ハイフンに制限するため、
+	 * HTML 特殊文字を含むスラッグのエスケープ挙動そのものは注入できない。その検証は
+	 * taxonomies を任意キーで受け取れる vk_the_taxonomy_check_list() 側で行っている。
 	 *
 	 * Test for vk_the_post_type_check_list().
 	 * Covers Issue #1475: the checkbox label is followed by its slug in "Label (slug)" form,
-	 * the slug in the name attribute is escaped via esc_attr(), and two post types that share
-	 * the same label but have different slugs remain distinguishable in the output.
+	 * the slug appears in the name attribute, and two post types that share the same label
+	 * but have different slugs remain distinguishable in the output.
+	 * register_post_type() restricts slugs to alphanumeric/underscore/hyphen, so a slug
+	 * containing HTML special characters cannot be injected here; that escaping behavior is
+	 * covered by vk_the_taxonomy_check_list(), which accepts arbitrary keys.
 	 */
 	function test_vk_the_post_type_check_list() {
 
@@ -562,7 +607,7 @@ class SitemapPageTest extends WP_UnitTestCase {
 
 		$test_cases = array(
 			array(
-				'test_condition_name'   => 'チェック済みの場合 => name 属性が esc_attr() されたスラッグで出力され、checked も出力される',
+				'test_condition_name'   => 'チェック済みの場合 => name 属性がスラッグ付きで出力され、checked も出力される',
 				'args'                  => array(
 					'name'    => 'vkExUnit_sitemap_options[excludePostTypes]',
 					'checked' => array( 'veu_test_cpt_shown' => true ),

--- a/tests/test-sitemap-page.php
+++ b/tests/test-sitemap-page.php
@@ -404,11 +404,15 @@ class SitemapPageTest extends WP_UnitTestCase {
 	 * vk_the_taxonomy_check_list() のテスト。
 	 * name 属性・checked の有無が正しく出力される事、対象タクソノミーが0件の場合に
 	 * 空の一覧ではなくフォールバック文言が出力される事（植草さんレビュー UX-2 指摘）を検証する。
+	 * また Issue #1475 対応として、見出しに「ラベル (スラッグ)」の形式でスラッグが併記される事、
+	 * 同じラベルで異なるスラッグのタクソノミーが並んでも出力から判別できる事を検証する。
 	 *
 	 * Test for vk_the_taxonomy_check_list().
 	 * Verifies the name attribute and the checked state are output correctly, and that a
 	 * fallback message is shown instead of an empty list when there are no taxonomies to
-	 * display ( UX review finding ).
+	 * display ( UX review finding ). Also covers Issue #1475: the checkbox label is followed
+	 * by its slug in "Label (slug)" form, and two taxonomies that share the same label but
+	 * have different slugs remain distinguishable in the output.
 	 */
 	function test_vk_the_taxonomy_check_list() {
 
@@ -419,6 +423,15 @@ class SitemapPageTest extends WP_UnitTestCase {
 
 		$this->register_test_taxonomy( 'veu_test_tax_shown', array(), array( 'label' => 'VEU Test Tax Shown' ) );
 		$taxonomy_object = get_taxonomy( 'veu_test_tax_shown' );
+
+		// Issue #1475: ラベルが同じで slug（スラッグ）だけが異なるタクソノミーを2つ用意し、
+		// 出力からそれぞれを判別できる事を検証するためのテスト用データ。
+		// Two taxonomies sharing the same label but with different slugs, used to verify
+		// that the rendered output still lets the admin tell them apart.
+		$this->register_test_taxonomy( 'veu_test_tax_dup_a', array(), array( 'label' => 'Duplicate Label Tax' ) );
+		$this->register_test_taxonomy( 'veu_test_tax_dup_b', array(), array( 'label' => 'Duplicate Label Tax' ) );
+		$taxonomy_object_dup_a = get_taxonomy( 'veu_test_tax_dup_a' );
+		$taxonomy_object_dup_b = get_taxonomy( 'veu_test_tax_dup_b' );
 
 		$test_cases = array(
 			array(
@@ -458,11 +471,136 @@ class SitemapPageTest extends WP_UnitTestCase {
 				'expected_contains'     => array( 'No taxonomies are available to exclude.' ),
 				'expected_not_contains' => array( '<ul class="no-style">' ),
 			),
+			array(
+				'test_condition_name'   => 'Issue #1475: 見出しがラベルとスラッグの併記（ラベル (スラッグ)）になる',
+				'args'                  => array(
+					'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
+					'checked'    => array(),
+					'taxonomies' => array( 'veu_test_tax_shown' => $taxonomy_object ),
+				),
+				'expected_contains'     => array(
+					'VEU Test Tax Shown <span class="description">(<code>veu_test_tax_shown</code>)</span>',
+				),
+				'expected_not_contains' => array(),
+			),
+			array(
+				'test_condition_name'   => 'Issue #1475: ラベルが同じでスラッグが異なる2つのタクソノミーが、出力上のスラッグ表示で判別できる',
+				'args'                  => array(
+					'name'       => 'vkExUnit_sitemap_options[excludeTaxonomies]',
+					'checked'    => array(),
+					'taxonomies' => array(
+						'veu_test_tax_dup_a' => $taxonomy_object_dup_a,
+						'veu_test_tax_dup_b' => $taxonomy_object_dup_b,
+					),
+				),
+				'expected_contains'     => array(
+					'Duplicate Label Tax <span class="description">(<code>veu_test_tax_dup_a</code>)</span>',
+					'Duplicate Label Tax <span class="description">(<code>veu_test_tax_dup_b</code>)</span>',
+				),
+				'expected_not_contains' => array(),
+			),
 		);
 
 		foreach ( $test_cases as $case ) {
 			ob_start();
 			vk_the_taxonomy_check_list( $case['args'] );
+			$html = ob_get_clean();
+
+			foreach ( $case['expected_contains'] as $expected ) {
+				$this->assertStringContainsString( $expected, $html, $case['test_condition_name'] );
+			}
+			foreach ( $case['expected_not_contains'] as $unexpected ) {
+				$this->assertStringNotContainsString( $unexpected, $html, $case['test_condition_name'] );
+			}
+		}
+	}
+
+	/**
+	 * vk_the_post_type_check_list() のテスト。
+	 * Issue #1475 対応として、見出しに「ラベル (スラッグ)」の形式でスラッグが併記される事、
+	 * name 属性のスラッグが esc_attr() される事、同じラベルで異なるスラッグの投稿タイプが
+	 * 並んでも出力から判別できる事を検証する。
+	 *
+	 * Test for vk_the_post_type_check_list().
+	 * Covers Issue #1475: the checkbox label is followed by its slug in "Label (slug)" form,
+	 * the slug in the name attribute is escaped via esc_attr(), and two post types that share
+	 * the same label but have different slugs remain distinguishable in the output.
+	 */
+	function test_vk_the_post_type_check_list() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_vk_the_post_type_check_list' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$this->register_test_post_type(
+			'veu_test_cpt_shown',
+			array(
+				'public' => true,
+				'label'  => 'VEU Test CPT Shown',
+			)
+		);
+
+		// Issue #1475: ラベルが同じで slug（スラッグ）だけが異なる投稿タイプを2つ用意し、
+		// 出力からそれぞれを判別できる事を検証するためのテスト用データ。
+		// Two post types sharing the same label but with different slugs, used to verify
+		// that the rendered output still lets the admin tell them apart.
+		$this->register_test_post_type(
+			'veu_test_cpt_dup_a',
+			array(
+				'public' => true,
+				'label'  => 'Duplicate Label CPT',
+			)
+		);
+		$this->register_test_post_type(
+			'veu_test_cpt_dup_b',
+			array(
+				'public' => true,
+				'label'  => 'Duplicate Label CPT',
+			)
+		);
+
+		$test_cases = array(
+			array(
+				'test_condition_name'   => 'チェック済みの場合 => name 属性が esc_attr() されたスラッグで出力され、checked も出力される',
+				'args'                  => array(
+					'name'    => 'vkExUnit_sitemap_options[excludePostTypes]',
+					'checked' => array( 'veu_test_cpt_shown' => true ),
+				),
+				'expected_contains'     => array(
+					'name="vkExUnit_sitemap_options[excludePostTypes][veu_test_cpt_shown]"',
+					' checked />',
+				),
+				'expected_not_contains' => array(),
+			),
+			array(
+				'test_condition_name'   => '見出しがラベルとスラッグの併記（ラベル (スラッグ)）になる',
+				'args'                  => array(
+					'name'    => 'vkExUnit_sitemap_options[excludePostTypes]',
+					'checked' => array(),
+				),
+				'expected_contains'     => array(
+					'VEU Test CPT Shown <span class="description">(<code>veu_test_cpt_shown</code>)</span>',
+				),
+				'expected_not_contains' => array(),
+			),
+			array(
+				'test_condition_name'   => 'ラベルが同じでスラッグが異なる2つの投稿タイプが、出力上のスラッグ表示で判別できる',
+				'args'                  => array(
+					'name'    => 'vkExUnit_sitemap_options[excludePostTypes]',
+					'checked' => array(),
+				),
+				'expected_contains'     => array(
+					'Duplicate Label CPT <span class="description">(<code>veu_test_cpt_dup_a</code>)</span>',
+					'Duplicate Label CPT <span class="description">(<code>veu_test_cpt_dup_b</code>)</span>',
+				),
+				'expected_not_contains' => array(),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			ob_start();
+			vk_the_post_type_check_list( $case['args'] );
 			$html = ob_get_clean();
 
 			foreach ( $case['expected_contains'] as $expected ) {


### PR DESCRIPTION
Closes https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1475

@coderabbitai ignore

## 概要

ExUnit の設定画面にある投稿タイプ・タクソノミー（記事を分類するためのまとまり。「カテゴリー」「タグ」がその代表）のチェックリストが、管理画面に表示される名前（ラベル）しか出していませんでした。プラグインが独自の分類を追加すると同じラベルが複数並び、**画面上に選び分ける手がかりが1つも無くなります。**

今回、ラベルの横にスラッグ（分類ごとに1つだけ割り当てられる識別名。`post_tag` など。重複しない）を併記して、選び分けられるようにしました。

### 実際に起きたこと

自社サイトで「投稿のタグを HTML サイトマップに出したくない」という設定を行ったところ、保存しても表示が変わらず「機能が効かない」と判断されました。調査すると、設定画面には「タグ」が2つ・「カテゴリー」が3つ並んでおり、実際に保存されていたのは意図した `post_tag`（投稿のタグ）ではなく `wpdmtag`（ファイル配布を管理するプラグインが追加するタグ）でした。

さらに `wpdmtag` が紐づく投稿タイプは投稿タイプ単位の除外設定で既に除外済みだったため、チェックを入れても外しても表示は一切変わらず、誤って選んだことに気付く手がかりもありませんでした。保存処理・除外判定そのものは正しく動いており、**設定画面の表示が不足していただけ**です。

## 変更内容

### 1. チェックリストにスラッグを併記（`inc/template-tags/package/template-tags.php`）

`vk_the_post_type_check_list()`（投稿タイプをチェックボックスとして並べる関数）と `vk_the_taxonomy_check_list()`（タクソノミーを並べる関数）の見出しを、次の形にしました。

```html
<li><label>
<input type="checkbox" name="vkExUnit_sitemap_options[excludeTaxonomies][post_tag]" value="true" />
タグ <span class="description">(<code>post_tag</code>)</span>
</label></li>
```

- **新しい CSS は追加していません。** `description` は WordPress 管理画面が標準で持つ「補足説明の文字」用のクラス名、`<code>` は等幅フォントで表示するタグで、どちらも既存の仕組みです
- **表示を切り替える引数は設けず、常に併記します。** 「同じラベルが並んで選び分けられない」という問題の構造は投稿タイプ側にも共通しており、画面ごとに出し分けると「直った画面」と「直っていない画面」が混在して新たな混乱を生むためです。また HTML サイトマップ設定では投稿タイプ版とタクソノミー版が同じ表の中に並ぶため、片方だけ表示すると同一パネル内の様式が揃いません
- **スラッグは読み上げの対象から外していません**（`aria-hidden` を付けていません）。現状はスクリーンリーダーでも「タグ」「タグ」と読まれるだけで判別材料が無く、視覚のみの表示にすると目で見る利用者だけが改善される不均衡が生まれるためです
- スラッグは自然言語ではないため、翻訳関数には通していません

### 2. `name` 属性のエスケープ漏れを修正（同ファイル）

`vk_the_post_type_check_list()` の `name` 属性で、スラッグが `esc_attr()`（属性値に使ってはいけない文字を安全な表記へ変換する処理）を通っていませんでした。タクソノミー版は元から通っていたため、同じ行に触れるついでに揃えました。

**これは多層防御（hardening）であり、悪用可能な脆弱性を塞いだものではありません。** WordPress 本体が投稿タイプ名を `[a-z0-9_-]` に制限するため、そもそも特殊文字が入りません。

### 3. 設定保存時のガードを対称化（`inc/sitemap-page/sitemap-page-admin-main-setting.php`）

HTML サイトマップの設定を保存する際、「登録されていない名前は保存しない」というガードがタクソノミー側にしか掛かっておらず、投稿タイプ側は送信されたキーをそのまま設定値へ書いていました。`post_type_exists()` によるガードを追加して対称にしました。

レビューで保存経路を1本ずつ追って確認しており、既存の設定値が消える経路は生まれません。チェックボックスは未チェックだと送信されないため、画面に出ない投稿タイプの保存値は**ガードの有無に関わらず**保存のたびに落ちるのが元からの挙動です。このガードが新たに落とすのは「画面に出ていないのに送信されたキー」だけです。

### 4. PHPUnit テストの追加・更新（`tests/test-sitemap-page.php`）

- 同じラベル・異なるスラッグの投稿タイプ／タクソノミーが2つ並んだときに、出力からそれぞれを判別できること（この issue の再現条件そのもの）
- スラッグに HTML の特殊文字が含まれる場合に、`name` 属性・画面表示の両方がエスケープされること。**エスケープ処理を外すと実際にこのケースだけが落ちることを確認済み**です
- 上記3の保存ガード（登録済みは保存される／未登録は除かれる）

フルスイート OK（146 tests, 1085 assertions）。

## 影響範囲

`vk_the_post_type_check_list()` は HTML サイトマップ以外の画面からも呼ばれており、**4画面すべてでスラッグが併記されます**。

| 画面 | ファイル | チェックの意味 |
|---|---|---|
| HTML サイトマップ | `inc/sitemap-page/sitemap-page-admin-main-setting.php` | 除外する |
| 広告 | `inc/insert-ads.php` | この投稿タイプに広告を**表示する** |
| SNS シェアボタン | `inc/sns/sns_admin.php` | 除外する |
| 新着記事ウィジェット | `inc/other-widget/widget-new-posts.php` | このウィジェットに**表示する** |

`vk_the_taxonomy_check_list()` は HTML サイトマップの1箇所のみです。

保存値の形（`excludePostTypes` / `excludeTaxonomies`）・`name` 属性の構造・チェック状態の判定はいずれも変わっていないため、既存の設定は失われません。

## この PR で対応しなかったこと

レビューで挙がった以下は、理由を添えて見送っています。

- **上流ライブラリ（vektor-inc/vektor-wp-libraries）への反映** … このファイルは他製品へ手動コピーで配布される共有パッケージですが、確認したところ `vk_the_taxonomy_check_list()` は上流に存在せず、`<ul>` のクラス指定も異なっており、#1448 の時点で既に ExUnit 側だけの実装として分岐しています。この PR は **ExUnit 単体で進めており、上流には未反映**です。あわせて、**上流の `vk_the_post_type_check_list()` は `name` 属性のスラッグが未エスケープのまま**であり、上記2の多層防御は上流を同梱する他製品には入りません（悪用シナリオは書けず、Security Advisory 相当ではありません）。次のライブラリ更新に含めるかどうかは、上流側で判断してください
- **2関数の出力ブロックの共通ヘルパー化** … 上流へ反映するタイミングで検討する話のため、この PR では入れません
- **テストファイルの置き場所の見直し** … 既存の並びを崩すコストと釣り合わないため現状維持

## 確認手順

### 前提条件

- ExUnit を有効化し、**同じラベルのタクソノミーが複数存在する状態**を作る。手軽な再現方法は、`functions.php` などで「タグ」というラベルのタクソノミーをもう1つ登録する

```php
add_action( 'init', function() {
	register_taxonomy( 'veu_dup_tag', 'post', array(
		'label'  => 'タグ',
		'public' => true,
	) );
} );
```

### Before（修正前の再現手順）

1. 管理画面 > ExUnit > メイン設定 を開く
2. 「HTML サイトマップ」セクションの「サイトマップから除外するタクソノミー」の一覧を見る
   → ✗ 「タグ」という項目が2つ並び、**どちらが投稿のタグなのか判断できない**
3. 上から2番目の「タグ」にチェックを入れて保存する
   → ✗ どちらを選んだのか画面からは確認できない

### After（修正後）

1. 管理画面 > ExUnit > メイン設定 を開く
2. 「HTML サイトマップ」セクションの「サイトマップから除外するタクソノミー」の一覧を見る
   → ✓ 各項目が `タグ (post_tag)` `タグ (veu_dup_tag)` のように、ラベルの後ろにスラッグが併記される
   → ✓ スラッグは等幅フォントの補助的な見た目で、ラベルが主として読める
3. `タグ (post_tag)` にチェックを入れて保存する
   → ✓ 再読み込み後も `タグ (post_tag)` にチェックが入ったままになる（既存の保存値の形は変わっていない）
4. HTML サイトマップを表示しているページを開く
   → ✓ 投稿のタグの一覧が表示されなくなる
5. 「サイトマップから除外する投稿タイプ」の一覧も見る
   → ✓ こちらも `投稿 (post)` のようにスラッグが併記される

### デグレ確認

6. 管理画面 > ExUnit > メイン設定 の「広告」セクションを開く
   → ✓ 「広告を表示する投稿タイプ」の一覧にもスラッグが併記され、既存のチェック状態は保たれている
7. 管理画面 > ExUnit > メイン設定 の「SNS」セクションを開く
   → ✓ 同様にスラッグが併記され、既存のチェック状態は保たれている
8. 管理画面 > 外観 > ウィジェット で「[VK] 新着記事」ウィジェットを開く
   → ✓ 投稿タイプの一覧にスラッグが併記され、**表示幅が狭い場所でもレイアウトが崩れない**
9. いずれの画面でも、設定を変更せずに保存する
   → ✓ 既存のチェック状態が失われない

## スクリーンショット

UI テスト担当（麗美）が実機で撮影したものです。同じ画面・同じ条件（同じテストデータ・同じ DB）で撮影しています。

再現用に、ラベルが重複するタクソノミー・投稿タイプと、スラッグが上限文字数（タクソノミー32文字 / 投稿タイプ20文字）のものを登録した状態です。

### HTML サイトマップ設定 — 除外するタクソノミー

#### Before
![before](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/before-sitemap-taxonomies.png?raw=true)

「タグ」が2つ並んでおり、どちらが投稿のタグなのか画面からは判断できません。

#### After
![after](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/after-sitemap-taxonomies.png?raw=true)

`タグ (post_tag)` `タグ (veu_dup_tag)` のようにスラッグが併記され、選び分けられます。

### HTML サイトマップ設定 — 除外する投稿タイプ

#### Before
![before](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/before-sitemap-posttypes.png?raw=true)

#### After
![after](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/after-sitemap-posttypes.png?raw=true)

### 広告設定（デグレ確認）

#### Before
![before](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/before-ads-section.png?raw=true)

#### After
![after](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/after-ads-section.png?raw=true)

### SNS 設定（デグレ確認）

#### Before
![before](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/before-sns-section.png?raw=true)

#### After
![after](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/after-sns-section.png?raw=true)

### 新着記事ウィジェット（表示幅が狭い場所での折り返し確認）

#### Before
![before](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/before-widget-posttypes.png?raw=true)

#### After（幅 480px）
![after 480px](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/after-widget-posttypes-480px.png?raw=true)

1行に収まっています。

#### After（幅 320px）
![after 320px](https://github.com/vektor-inc/review-assets/blob/main/vk-all-in-one-expansion-unit/pr-1477/after-widget-posttypes-320px.png?raw=true)

320px まで狭めると折り返しますが、**ラベルとスラッグの境目で改行**されており、スラッグの途中で割れたり括弧だけが孤立したりはしていません。

> **注:** 画像はレビュー用アセットリポジトリ（プライベート）に置いているため、アクセス権のない閲覧者には表示されません。各画像の内容は上の説明文にも書いています。

## 実機確認で分かったこと（`.description` の灰色スタイル）

**`<span class="description">` の灰色スタイルは、実際には効いていません。** 文字色はラベルと同じ `rgb(60, 67, 74)` のままでした。

WordPress 本体の `.description` の灰色定義は `p.description` やクラシックウィジェット画面専用のセレクタにしかスコープされておらず、今回の `<li><label><span class="description">` というマークアップにはどのルールも一致しないためです。

ただし **`<code>` の等幅フォントは効いており**、ラベルとは明確に見た目が変わるため、「ラベルが主・スラッグが補助」という判別は成立しています（HTML サイトマップ・広告・SNS の3画面では薄い背景色も付きます）。UX 担当の受け入れ基準（灰色が効かなくても等幅フォントで区別できていれば追加 CSS は入れない）を満たしているため、**この PR では対応せず、事実として記録します。**

将来的に確実に灰色を当てたい場合は、`.description` に頼らず専用クラスを切ってスタイルを明示する方が確実です。
