### PR TITLE
[ 機能追加 ] サイトヘルスと WP-CLI で、共通ファイルがどの製品のコピーで動いているかを確認できる表示を追加

### DIFF
--- a/inc/template-tags-status/collector.php
+++ b/inc/template-tags-status/collector.php
@@ -1,0 +1,437 @@
+<?php
+/**
+ * Collects, for each of ExUnit's shared template-tag files, which plugin's bundled copy is
+ * currently the one actually running.
+ *
+ * ExUnit と一部の Vektor 製プラグイン（VK Post Author Display 等）は、同じ共有テンプレートタグ
+ * ファイル（inc/template-tags/package/ 配下）をそれぞれ同梱している。ファイル内の各関数は
+ * function_exists() で個別にガードされているため、先に読み込まれた側の実装が採用され、後から
+ * 読み込まれた側は無視される。このファイルは、共有ファイルごとに「どのプラグインのコピーが
+ * 現在採用されているか」を機械的に集計する事実収集レイヤーで、表示用の整形は行わない。
+ * サイトヘルス「情報」タブ（inc/template-tags-status/site-health.php）と WP-CLI コマンド
+ * （inc/template-tags-status/wp-cli.php）の両方がこの層の関数を共有する。
+ *
+ * This file is the fact-collection layer only; it never formats output for display. Both the
+ * Site Health "Info" tab integration (site-health.php) and the WP-CLI command (wp-cli.php)
+ * build on top of the functions defined here.
+ *
+ * @package VK All in One Expansion Unit
+ * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * List the shared template-tag package files, in the same order they are require_once'd by
+ * inc/template-tags/template-tags-config.php.
+ *
+ * 共有テンプレートタグパッケージファイルの一覧を、inc/template-tags/template-tags-config.php
+ * が require_once している順序と同じ順序で返す。
+ *
+ * @return string[] Absolute file paths.
+ */
+function veu_get_shared_template_tags_files() {
+	return array(
+		VEU_DIRECTORY_PATH . '/inc/template-tags/package/template-tags.php',
+		VEU_DIRECTORY_PATH . '/inc/template-tags/package/template-tags-veu.php',
+		VEU_DIRECTORY_PATH . '/inc/template-tags/package/template-tags-veu-old.php',
+	);
+}
+
+/**
+ * Extract the names of the functions a PHP file declares at file scope (i.e. not methods on a
+ * class/interface/trait, and not anonymous functions/closures).
+ *
+ * PHP ファイルがファイルスコープで宣言している関数名（クラス／インターフェース／トレイトの
+ * メソッドではなく、無名関数／クロージャでもないもの）を抽出する。
+ *
+ * The file is read with token_get_all() rather than any hardcoded function list, so newly added
+ * functions are picked up automatically. This is intentional: if this list had to be maintained
+ * by hand, a missed update would recreate exactly the kind of invisible "which copy actually
+ * runs" ambiguity this feature exists to surface.
+ *
+ * このファイルは関数名をハードコードした配列を持たず、token_get_all() でファイル自体を解析する。
+ * 手動更新が必要な一覧にすると、更新漏れがまさにこの機能が可視化しようとしている
+ * 「気づかないうちにどちらが採用されているか分からなくなる」問題を再現してしまうため。
+ *
+ * @param string $file_path Absolute path to the PHP file to inspect.
+ * @return string[] Function names, in declaration order, without duplicates.
+ */
+function veu_extract_top_level_function_names( $file_path ) {
+	if ( ! is_readable( $file_path ) ) {
+		return array();
+	}
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading one of this plugin's own bundled PHP files for static analysis, not remote/user input.
+	$source = file_get_contents( $file_path );
+	if ( false === $source ) {
+		return array();
+	}
+
+	$tokens = token_get_all( $source );
+	if ( ! is_array( $tokens ) ) {
+		return array();
+	}
+
+	$function_names = array();
+	$brace_depth    = 0;
+	// Stack of brace depths at which a class/interface/trait body began, so methods (declared
+	// while this stack is non-empty) are not mistaken for file-scope functions.
+	// クラス／インターフェース／トレイトの本体が始まった時点の波括弧の深さを積むスタック。
+	// これが空でない間に宣言された関数はメソッドなので、ファイルスコープの関数として扱わない.
+	$class_body_start   = array();
+	$expect_class_brace = false;
+
+	$token_count = count( $tokens );
+	for ( $i = 0; $i < $token_count; $i++ ) {
+		$token = $tokens[ $i ];
+
+		if ( is_array( $token ) ) {
+			$token_id = $token[0];
+
+			if ( in_array( $token_id, array( T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+				$expect_class_brace = true;
+				continue;
+			}
+
+			if ( T_FUNCTION === $token_id ) {
+				if ( empty( $class_body_start ) ) {
+					// Look ahead, skipping whitespace/comments, for the function name. Anonymous
+					// functions/closures have '(' immediately after `function` (no name token in
+					// between), so they are naturally excluded here.
+					// 空白・コメントを読み飛ばしながら関数名を探す。無名関数／クロージャは
+					// `function` の直後が '(' になり名前トークンが挟まらないため、
+					// ここでは自然に除外される.
+					for ( $j = $i + 1; $j < $token_count; $j++ ) {
+						$next = $tokens[ $j ];
+						if ( is_array( $next ) ) {
+							if ( in_array( $next[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+								continue;
+							}
+							if ( T_STRING === $next[0] ) {
+								$function_names[] = $next[1];
+							}
+						}
+						break;
+					}
+				}
+				continue;
+			}
+			// Single-character tokens (braces etc.) are returned as plain strings (not arrays) by
+			// token_get_all(), which is why they are handled in the elseif branches below rather
+			// than here.
+		} elseif ( '{' === $token ) {
+			if ( $expect_class_brace ) {
+				$class_body_start[] = $brace_depth;
+				$expect_class_brace = false;
+			}
+			++$brace_depth;
+		} elseif ( '}' === $token ) {
+			--$brace_depth;
+			if ( ! empty( $class_body_start ) && end( $class_body_start ) === $brace_depth ) {
+				array_pop( $class_body_start );
+			}
+		}
+	}
+
+	return array_values( array_unique( $function_names ) );
+}
+
+/**
+ * Express a file path relative to ABSPATH, without ever leaking the server's absolute path.
+ *
+ * ファイルパスを ABSPATH からの相対パスとして表現する。サーバー上の絶対パスは出さない。
+ *
+ * @param string $file_path Absolute file path.
+ * @return string|null Relative path (no leading slash), or null when $file_path is not located
+ *                      under ABSPATH and therefore cannot be safely relativized.
+ */
+function veu_get_relative_path_from_abspath( $file_path ) {
+	$normalized_file    = wp_normalize_path( $file_path );
+	$normalized_abspath = wp_normalize_path( ABSPATH );
+
+	if ( 0 !== strpos( $normalized_file, $normalized_abspath ) ) {
+		return null;
+	}
+
+	return substr( $normalized_file, strlen( $normalized_abspath ) );
+}
+
+/**
+ * Find which installed plugin a given file belongs to, using plugin header data (Name/Version)
+ * rather than any filter-modifiable value such as veu_get_name().
+ *
+ * 指定されたファイルがどのインストール済みプラグインに属するかを、プラグインヘッダのデータ
+ * （Name / Version）を使って特定する。apply_filters() でサイト側から書き換え可能な
+ * veu_get_name() のような値は使わない。
+ *
+ * @param string $file_path Absolute path of the file that defines the function in question.
+ * @return array{name:string,version:string,basename:string}|null Plugin info, or null when no
+ *                                                                  installed plugin's directory
+ *                                                                  contains this file.
+ */
+function veu_find_plugin_by_file( $file_path ) {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$normalized_file = wp_normalize_path( $file_path );
+	$plugins_dir     = trailingslashit( wp_normalize_path( WP_PLUGIN_DIR ) );
+
+	$all_plugins = get_plugins();
+
+	$matched_basename   = null;
+	$matched_dir_length = -1;
+
+	foreach ( $all_plugins as $plugin_basename => $plugin_data ) {
+		$plugin_dir_relative = dirname( $plugin_basename );
+		if ( '.' === $plugin_dir_relative ) {
+			// Single-file plugins living directly under wp-content/plugins/ cannot bundle a
+			// sub-path like inc/template-tags/package/*.php, so they are not candidates here.
+			continue;
+		}
+
+		$plugin_dir_abs = $plugins_dir . $plugin_dir_relative . '/';
+
+		// Prefer the most specific (longest) matching plugin directory, in case one plugin's
+		// folder name happens to be a prefix of another's.
+		if ( 0 === strpos( $normalized_file, $plugin_dir_abs ) && strlen( $plugin_dir_abs ) > $matched_dir_length ) {
+			$matched_dir_length = strlen( $plugin_dir_abs );
+			$matched_basename   = $plugin_basename;
+		}
+	}
+
+	if ( null === $matched_basename ) {
+		return null;
+	}
+
+	return array(
+		'name'     => $all_plugins[ $matched_basename ]['Name'],
+		'version'  => $all_plugins[ $matched_basename ]['Version'],
+		'basename' => $matched_basename,
+	);
+}
+
+/**
+ * Turn a "defined in this file" fact into a source descriptor: which plugin (if identifiable),
+ * or a documented fallback when it cannot be identified.
+ *
+ * 「このファイルで定義されている」という事実を、採用元の記述（特定できればどのプラグインか、
+ * できなければ既定のフォールバック）に変換する。
+ *
+ * This function is intentionally a pure function of its $defined_file argument (rather than
+ * reaching for ReflectionFunction itself) so the "could not identify" fallback branches can be
+ * exercised directly and deterministically from tests.
+ *
+ * この関数はあえて $defined_file 引数だけに依存する純粋関数にしている（内部で
+ * ReflectionFunction を呼ばない）。これにより「特定できない」場合のフォールバック分岐を、
+ * テストから直接かつ決定的に検証できるようにしている。
+ *
+ * @param string|false $defined_file Absolute path of the defining file, or false when unknown
+ *                                    (e.g. an internal/core PHP function, or reflection failed).
+ * @return array Source descriptor. One of:
+ *               - array{type:'plugin',name:string,version:string,basename:string}
+ *               - array{type:'unidentified_file',relative_path:string}
+ *               - array{type:'unidentified'}
+ */
+function veu_identify_template_tags_source_from_file( $defined_file ) {
+	if ( empty( $defined_file ) || ! is_string( $defined_file ) ) {
+		return array( 'type' => 'unidentified' );
+	}
+
+	$plugin = veu_find_plugin_by_file( $defined_file );
+	if ( null !== $plugin ) {
+		return array(
+			'type'     => 'plugin',
+			'name'     => $plugin['name'],
+			'version'  => $plugin['version'],
+			'basename' => $plugin['basename'],
+		);
+	}
+
+	$relative_path = veu_get_relative_path_from_abspath( $defined_file );
+	if ( null === $relative_path ) {
+		// Cannot safely express this path relative to ABSPATH (e.g. it points outside the
+		// WordPress install entirely) -- never fall back to leaking the absolute path.
+		return array( 'type' => 'unidentified' );
+	}
+
+	return array(
+		'type'          => 'unidentified_file',
+		'relative_path' => $relative_path,
+	);
+}
+
+/**
+ * Resolve which source (plugin, or a fallback descriptor) currently provides a given function.
+ *
+ * 指定した関数を現在どの採用元（プラグイン、またはフォールバック記述）が提供しているかを解決する。
+ *
+ * @param string $function_name Function name to look up.
+ * @return array|null Source descriptor (see veu_identify_template_tags_source_from_file()), or
+ *                     null when the function is not currently defined at all.
+ */
+function veu_identify_shared_template_tags_source( $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		return null;
+	}
+
+	$defined_file = false;
+	try {
+		$reflection   = new ReflectionFunction( $function_name );
+		$defined_file = $reflection->getFileName();
+	} catch ( \Throwable $e ) {
+		$defined_file = false;
+	}
+
+	return veu_identify_template_tags_source_from_file( $defined_file );
+}
+
+/**
+ * Build a deduplication key for a source descriptor, so the same source is never listed twice
+ * for one file.
+ *
+ * 採用元記述の重複排除キーを組み立てる。1つのファイルに対して同じ採用元が2回以上表示されない
+ * ようにするために使う。
+ *
+ * @param array $source Source descriptor.
+ * @return string
+ */
+function veu_get_template_tags_source_dedupe_key( array $source ) {
+	switch ( $source['type'] ) {
+		case 'plugin':
+			return 'plugin:' . $source['basename'];
+		case 'unidentified_file':
+			return 'unidentified_file:' . $source['relative_path'];
+		default:
+			return 'unidentified';
+	}
+}
+
+/**
+ * Collect, for each shared template-tag file, the set of sources currently providing its
+ * functions.
+ *
+ * 共有テンプレートタグファイルごとに、その関数を現在提供している採用元の集合を収集する。
+ *
+ * This is the single fact-collection entry point shared by the Site Health "Info" tab and the
+ * `wp exunit template-tags status` WP-CLI command; both only format this data differently.
+ *
+ * これがサイトヘルス「情報」タブと `wp exunit template-tags status` WP-CLI コマンドの両方が
+ * 共有する唯一の事実収集の入口であり、両者はこのデータを異なる形式に整形するだけである。
+ *
+ * @return array<int, array{file:string, sources:array}> One entry per shared file, in
+ *               require_once order, each with:
+ *               - 'file'    Bare file name (e.g. "template-tags.php").
+ *               - 'sources' De-duplicated list of source descriptors (see
+ *                            veu_identify_template_tags_source_from_file()); empty when none of
+ *                            the file's functions are currently defined by anything.
+ */
+function veu_get_shared_template_tags_status() {
+	$status = array();
+
+	foreach ( veu_get_shared_template_tags_files() as $file_path ) {
+		$function_names = veu_extract_top_level_function_names( $file_path );
+
+		$sources   = array();
+		$seen_keys = array();
+
+		foreach ( $function_names as $function_name ) {
+			$source = veu_identify_shared_template_tags_source( $function_name );
+			if ( null === $source ) {
+				// Not currently defined by any loaded copy of this shared file.
+				continue;
+			}
+
+			$dedupe_key = veu_get_template_tags_source_dedupe_key( $source );
+			if ( isset( $seen_keys[ $dedupe_key ] ) ) {
+				continue;
+			}
+			$seen_keys[ $dedupe_key ] = true;
+			$sources[]                = $source;
+		}
+
+		$status[] = array(
+			'file'    => basename( $file_path ),
+			'sources' => $sources,
+		);
+	}
+
+	return $status;
+}
+
+/**
+ * Normalize the collected status into a flat, one-row-per-source table suitable for
+ * `WP_CLI\Utils\format_items()`.
+ *
+ * 収集した状態を、`WP_CLI\Utils\format_items()` にそのまま渡せる「1行1採用元」のフラットな
+ * 表に正規化する。
+ *
+ * Unlike the Site Health "Info" tab (which joins multiple sources for the same file into one
+ * "A / B" display string), each source gets its own row here so scripts consuming --format=json
+ * / --format=csv don't need to parse a joined string back apart.
+ *
+ * サイトヘルス「情報」タブ（同一ファイルの複数採用元を "A / B" のように1つの文字列へ結合して
+ * 表示する）とは異なり、ここでは採用元ごとに行を分ける。--format=json / --format=csv を使う
+ * スクリプト側が結合済み文字列を再度分解しなくて済むようにするため。
+ *
+ * @param array|null $status Pre-computed status from veu_get_shared_template_tags_status(), or
+ *                            null to compute it. Accepting an explicit $status keeps this
+ *                            function testable with synthetic data (e.g. fallback branches that
+ *                            are hard to reproduce with real plugins installed).
+ * @return array<int, array{file:string, product:string, version:string, plugin:string}>
+ */
+function veu_get_shared_template_tags_status_rows( $status = null ) {
+	if ( null === $status ) {
+		$status = veu_get_shared_template_tags_status();
+	}
+
+	$rows = array();
+
+	foreach ( $status as $file_status ) {
+		if ( empty( $file_status['sources'] ) ) {
+			$rows[] = array(
+				'file'    => $file_status['file'],
+				'product' => 'Not loaded',
+				'version' => '',
+				'plugin'  => '',
+			);
+			continue;
+		}
+
+		foreach ( $file_status['sources'] as $source ) {
+			switch ( $source['type'] ) {
+				case 'plugin':
+					$rows[] = array(
+						'file'    => $file_status['file'],
+						'product' => $source['name'],
+						'version' => $source['version'],
+						'plugin'  => $source['basename'],
+					);
+					break;
+
+				case 'unidentified_file':
+					$rows[] = array(
+						'file'    => $file_status['file'],
+						'product' => 'Could not identify the plugin (defined in ' . $source['relative_path'] . ')',
+						'version' => '',
+						'plugin'  => '',
+					);
+					break;
+
+				default:
+					$rows[] = array(
+						'file'    => $file_status['file'],
+						'product' => 'Could not identify the plugin',
+						'version' => '',
+						'plugin'  => '',
+					);
+					break;
+			}
+		}
+	}
+
+	return $rows;
+}

--- a/inc/template-tags-status/collector.php
+++ b/inc/template-tags-status/collector.php
@@ -30,6 +30,26 @@ if ( ! defined( 'ABSPATH' ) ) {
  * 共有テンプレートタグパッケージファイルの一覧を、inc/template-tags/template-tags-config.php
  * が require_once している順序と同じ順序で返す。
  *
+ * inc/template-tags/template-tags-config.php is the source of truth: it is the file that
+ * actually loads ExUnit's shared package copies. This list is a separate, hand-written copy of
+ * that -- there is no code-level link between them -- so if a shared file is ever added to or
+ * removed from template-tags-config.php, THIS function must be updated to match by hand. That
+ * match (same files, same order) is enforced by
+ * tests/test-template-tags-status.php::test_veu_get_shared_template_tags_files_matches_template_tags_config(),
+ * which reads template-tags-config.php's own require_once lines and fails the suite if this list
+ * ever drifts from them, so an update here left out is caught immediately rather than silently
+ * dropping a file from the Site Health / WP-CLI report.
+ *
+ * 正（source of truth）は inc/template-tags/template-tags-config.php 側であり、実際に ExUnit の
+ * 共有パッケージのコピーを読み込んでいるのはそちらである。この一覧はそれとは別に手書きされた
+ * コピーで、コード上の連動は無いため、template-tags-config.php に共有ファイルが追加・削除された
+ * 場合はこの関数側も手動で追随させる必要がある。両者が一致していること（対象・順序とも）は
+ * tests/test-template-tags-status.php の
+ * test_veu_get_shared_template_tags_files_matches_template_tags_config() が保証している。同テストは
+ * template-tags-config.php 自身の require_once 行を読み取り、この一覧とずれた瞬間に失敗するため、
+ * ここでの更新漏れは、サイトヘルス／WP-CLI のレポートから静かにファイルが抜け落ちるのではなく、
+ * その場でテストの失敗として検知できる。
+ *
  * @return string[] Absolute file paths.
  */
 function veu_get_shared_template_tags_files() {
@@ -482,19 +502,21 @@ function veu_get_shared_template_tags_status_rows( $status = null ) {
 
 	foreach ( $status as $file_status ) {
 		if ( empty( $file_status['sources'] ) ) {
-			// Keep this fallback text in sync with the "Not loaded" fallback in
-			// veu_format_shared_template_tags_status_value() (site-health.php). They are kept as
-			// two separate literals on purpose -- this one is a fixed English string so
+			// This handles the same "not loaded" case as veu_format_shared_template_tags_status_value()
+			// (site-health.php); update that one too when this one changes. They are two
+			// separate literals on purpose -- this one is a fixed English string so
 			// --format=json/csv output stays stable regardless of site locale, while the Site
 			// Health one goes through __() so the admin screen can be translated. Sharing one
 			// literal would either break that translation or leak translated text into scripted
-			// CLI output, so update both by hand instead.
-			// このフォールバック文言は veu_format_shared_template_tags_status_value()
-			// （site-health.php）の "Not loaded" と表示を揃えること。あえて別々のリテラルに
-			// している。こちらはサイトのロケールに関係なく --format=json/csv の出力を安定させる
-			// ための固定の英語文字列で、サイトヘルス側は管理画面を翻訳できるよう __() を通す。
-			// 1つに共通化すると翻訳が効かなくなるか、翻訳済み文言が CLI 出力に混ざるかのどちらかに
-			// なるため、直すときは両方を手で直すこと.
+			// CLI output. The text happens to read identically ("Not loaded") today, but that is
+			// not the point being guarded here -- only the case is, not the wording.
+			// これは veu_format_shared_template_tags_status_value()（site-health.php）と同じ
+			// 「読み込まれていない」ケースを扱っている。片方を変えたらもう片方も直すこと。あえて
+			// 別々のリテラルにしている。こちらはサイトのロケールに関係なく --format=json/csv の
+			// 出力を安定させるための固定の英語文字列で、サイトヘルス側は管理画面を翻訳できるよう
+			// __() を通す。1つに共通化すると翻訳が効かなくなるか、翻訳済み文言が CLI 出力に
+			// 混ざるかのどちらかになる。現状は文言もたまたま同じ（"Not loaded"）だが、ここで
+			// 揃えたいのはケースであって文言そのものではない.
 			$rows[] = array(
 				'file'    => $file_status['file'],
 				'product' => 'Not loaded',
@@ -518,14 +540,28 @@ function veu_get_shared_template_tags_status_rows( $status = null ) {
 					break;
 
 				case 'unidentified_file':
-					// Keep this fallback text in sync with the "Could not identify the plugin
-					// (defined in ...)" fallback in veu_format_template_tags_source_label()
-					// (site-health.php). See the note in the "Not loaded" branch above for why
-					// they are not shared code -- update both.
-					// このフォールバック文言は veu_format_template_tags_source_label()
-					// （site-health.php）の "Could not identify the plugin (defined in ...)" と
-					// 表示を揃えること。なぜ共通化しないかは上の "Not loaded" 分岐のコメントを
-					// 参照。直すときは両方を直すこと.
+					// This handles the same "defining file known, plugin not identified" case as
+					// the 'unidentified_file' branch of veu_format_template_tags_source_label()
+					// (site-health.php) -- update that one too when this one changes. See the
+					// note in the "Not loaded" branch above for why they are not shared code.
+					// UNLIKE that "Not loaded" pair, the text here is INTENTIONALLY NOT the same:
+					// this row keeps 'product' as the fixed "Could not identify the plugin" and
+					// puts the path in its own 'path' column (see this function's docblock),
+					// while the Site Health string embeds the path inline as "...(defined in
+					// %s)". Do not "fix" this by folding the path back into 'product' to make the
+					// wording match -- that would undo the column split requested in the Issue
+					// #1479 UX review specifically so scripts don't have to parse it back out.
+					// これは site-health.php の veu_format_template_tags_source_label() の
+					// 'unidentified_file' 分岐と同じ「定義元ファイルは分かるがプラグインは特定
+					// できない」ケースを扱っている。片方を変えたらもう片方も直すこと。共通化しない
+					// 理由は上の "Not loaded" 分岐のコメントを参照。ただしその "Not loaded" の
+					// ペアとは違い、ここは文言をあえて揃えていない。この行は 'product' を固定文言
+					// "Could not identify the plugin" のままにし、パスは独立した 'path' 列に
+					// 入れる（この関数の docblock 参照）。一方サイトヘルス側は "...(defined in
+					// %s)" のようにパスを文中に埋め込む。文言を合わせようとして 'product' へ
+					// パスを埋め戻してはいけない。それは Issue #1479 の UX レビューで
+					// スクリプト側が文字列を分解し直さずに済むよう指示されて分離した列構成を
+					// 巻き戻す変更になる.
 					$rows[] = array(
 						'file'    => $file_status['file'],
 						'product' => 'Could not identify the plugin',
@@ -536,14 +572,19 @@ function veu_get_shared_template_tags_status_rows( $status = null ) {
 					break;
 
 				default:
-					// Keep this fallback text in sync with the "Could not identify the plugin"
-					// fallback in veu_format_template_tags_source_label() (site-health.php). See
-					// the note in the "Not loaded" branch above for why they are not shared code
-					// -- update both.
-					// このフォールバック文言は veu_format_template_tags_source_label()
-					// （site-health.php）の "Could not identify the plugin" と表示を揃えること。
-					// なぜ共通化しないかは上の "Not loaded" 分岐のコメントを参照。直すときは
-					// 両方を直すこと.
+					// This handles the same "nothing identifiable at all" case as the
+					// 'unidentified' branch of veu_format_template_tags_source_label()
+					// (site-health.php) -- update that one too when this one changes. See the
+					// note in the "Not loaded" branch above for why they are not shared code.
+					// The text happens to read identically ("Could not identify the plugin")
+					// today, same as the "Not loaded" case -- but, as with that case, what must
+					// stay in sync is the case being handled, not necessarily the wording.
+					// これは site-health.php の veu_format_template_tags_source_label() の
+					// 'unidentified' 分岐と同じ「何も手がかりがない」ケースを扱っている。片方を
+					// 変えたらもう片方も直すこと。共通化しない理由は上の "Not loaded" 分岐の
+					// コメントを参照。現状は文言もたまたま同じ（"Could not identify the
+					// plugin"）だが、"Not loaded" のケースと同様、揃えるべきなのは扱うケースで
+					// あって、必ずしも文言そのものではない.
 					$rows[] = array(
 						'file'    => $file_status['file'],
 						'product' => 'Could not identify the plugin',

--- a/inc/template-tags-status/collector.php
+++ b/inc/template-tags-status/collector.php
@@ -42,9 +42,9 @@ function veu_get_shared_template_tags_files() {
 
 /**
  * Extract the names of the functions a PHP file declares at file scope (i.e. not methods on a
- * class/interface/trait, and not anonymous functions/closures).
+ * class/interface/trait/enum, and not anonymous functions/closures).
  *
- * PHP ファイルがファイルスコープで宣言している関数名（クラス／インターフェース／トレイトの
+ * PHP ファイルがファイルスコープで宣言している関数名（クラス／インターフェース／トレイト／enum の
  * メソッドではなく、無名関数／クロージャでもないもの）を抽出する。
  *
  * The file is read with token_get_all() rather than any hardcoded function list, so newly added
@@ -56,10 +56,33 @@ function veu_get_shared_template_tags_files() {
  * 手動更新が必要な一覧にすると、更新漏れがまさにこの機能が可視化しようとしている
  * 「気づかないうちにどちらが採用されているか分からなくなる」問題を再現してしまうため。
  *
+ * Brace-depth tracking has three deliberate edge cases handled below (see
+ * tests/fixtures/template-tags-status-bracket-tracking-fixture.php for a regression fixture):
+ * - String interpolation ("{$var}") opens with the special T_CURLY_OPEN token instead of a plain
+ *   '{' string token, but always closes with a plain '}' string token. Left uncounted, this would
+ *   desync $brace_depth from the real nesting level and could make a later class method look like
+ *   a file-scope function.
+ * - T_ENUM (PHP 8.1+) is treated the same as class/interface/trait, so an enum's methods are not
+ *   mistaken for file-scope functions. On PHP < 8.1 (where T_ENUM does not exist as a token/
+ *   constant), the token simply cannot appear, so this is a no-op there rather than a fatal error.
+ * - `Foo::class` also tokenizes its `class` keyword as T_CLASS. Only tokens NOT immediately
+ *   preceded by `::` are treated as an actual class/interface/trait/enum declaration.
+ *
+ * 波括弧の深さの追跡には、意図的に対応している3つの境界ケースがある
+ * （回帰用フィクスチャは tests/fixtures/template-tags-status-bracket-tracking-fixture.php を参照）。
+ * - 文字列内変数展開（"{$var}"）は通常の '{' 文字列トークンではなく専用の T_CURLY_OPEN トークンで
+ *   開始するが、閉じは通常の '}' 文字列トークンで来る。数えないと $brace_depth が実際のネストと
+ *   ずれ、後続のクラスのメソッドをファイルスコープの関数と誤認しうる。
+ * - T_ENUM（PHP 8.1以降）もクラス／インターフェース／トレイトと同様に扱い、enum のメソッドを
+ *   ファイルスコープの関数と誤認しないようにする。PHP 8.1未満では T_ENUM はトークン／定数として
+ *   存在せずこのトークン自体が出現しえないため、単に無効化されるだけで Fatal Error にはならない。
+ * - `Foo::class` の `class` も T_CLASS としてトークン化される。直前が `::` でないものだけを
+ *   実際のクラス／インターフェース／トレイト／enum 宣言として扱う。
+ *
  * @param string $file_path Absolute path to the PHP file to inspect.
  * @return string[] Function names, in declaration order, without duplicates.
  */
-function veu_extract_top_level_function_names( $file_path ) {
+function veu_template_tags_status_extract_function_names( $file_path ) {
 	if ( ! is_readable( $file_path ) ) {
 		return array();
 	}
@@ -75,14 +98,28 @@ function veu_extract_top_level_function_names( $file_path ) {
 		return array();
 	}
 
+	// T_ENUM only exists from PHP 8.1 onward; referencing the bare constant on an older runtime
+	// would itself fatal, so it is added defensively.
+	// T_ENUM は PHP 8.1 以降にのみ存在する。古いランタイムで裸の定数を参照するとそれ自体が
+	// Fatal Error になるため、防御的に追加する.
+	$class_like_token_ids = array( T_CLASS, T_INTERFACE, T_TRAIT );
+	if ( defined( 'T_ENUM' ) ) {
+		$class_like_token_ids[] = T_ENUM;
+	}
+
 	$function_names = array();
 	$brace_depth    = 0;
-	// Stack of brace depths at which a class/interface/trait body began, so methods (declared
-	// while this stack is non-empty) are not mistaken for file-scope functions.
-	// クラス／インターフェース／トレイトの本体が始まった時点の波括弧の深さを積むスタック。
+	// Stack of brace depths at which a class/interface/trait/enum body began, so methods
+	// (declared while this stack is non-empty) are not mistaken for file-scope functions.
+	// クラス／インターフェース／トレイト／enum の本体が始まった時点の波括弧の深さを積むスタック。
 	// これが空でない間に宣言された関数はメソッドなので、ファイルスコープの関数として扱わない.
 	$class_body_start   = array();
 	$expect_class_brace = false;
+	// The last non-whitespace/non-comment token seen so far, used only to tell an actual class
+	// declaration's `class` keyword apart from the `class` in `Foo::class`.
+	// これまでに見た最後の空白／コメント以外のトークン。実際のクラス宣言の `class` キーワードと
+	// `Foo::class` の `class` を区別する用途にのみ使う.
+	$previous_token_id = null;
 
 	$token_count = count( $tokens );
 	for ( $i = 0; $i < $token_count; $i++ ) {
@@ -91,8 +128,27 @@ function veu_extract_top_level_function_names( $file_path ) {
 		if ( is_array( $token ) ) {
 			$token_id = $token[0];
 
-			if ( in_array( $token_id, array( T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
-				$expect_class_brace = true;
+			if ( in_array( $token_id, array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+				// Does not count as "the previous token" for the ::class lookbehind below.
+				continue;
+			}
+
+			if ( in_array( $token_id, array( T_CURLY_OPEN, T_DOLLAR_OPEN_CURLY_BRACES ), true ) ) {
+				// String interpolation ("{$var}" / "${var}") opens with one of these special
+				// tokens but always closes with a plain '}' string token below, so it must be
+				// counted here to keep $brace_depth in sync with those closing braces.
+				++$brace_depth;
+				$previous_token_id = $token_id;
+				continue;
+			}
+
+			if ( in_array( $token_id, $class_like_token_ids, true ) ) {
+				// `Foo::class` also tokenizes its `class` as T_CLASS, so only treat this as an
+				// actual class/interface/trait/enum declaration when it is not preceded by `::`.
+				if ( T_DOUBLE_COLON !== $previous_token_id ) {
+					$expect_class_brace = true;
+				}
+				$previous_token_id = $token_id;
 				continue;
 			}
 
@@ -117,8 +173,11 @@ function veu_extract_top_level_function_names( $file_path ) {
 						break;
 					}
 				}
+				$previous_token_id = $token_id;
 				continue;
 			}
+
+			$previous_token_id = $token_id;
 			// Single-character tokens (braces etc.) are returned as plain strings (not arrays) by
 			// token_get_all(), which is why they are handled in the elseif branches below rather
 			// than here.
@@ -128,11 +187,15 @@ function veu_extract_top_level_function_names( $file_path ) {
 				$expect_class_brace = false;
 			}
 			++$brace_depth;
+			$previous_token_id = $token;
 		} elseif ( '}' === $token ) {
 			--$brace_depth;
 			if ( ! empty( $class_body_start ) && end( $class_body_start ) === $brace_depth ) {
 				array_pop( $class_body_start );
 			}
+			$previous_token_id = $token;
+		} else {
+			$previous_token_id = $token;
 		}
 	}
 
@@ -148,7 +211,7 @@ function veu_extract_top_level_function_names( $file_path ) {
  * @return string|null Relative path (no leading slash), or null when $file_path is not located
  *                      under ABSPATH and therefore cannot be safely relativized.
  */
-function veu_get_relative_path_from_abspath( $file_path ) {
+function veu_template_tags_status_relative_path( $file_path ) {
 	$normalized_file    = wp_normalize_path( $file_path );
 	$normalized_abspath = wp_normalize_path( ABSPATH );
 
@@ -172,7 +235,7 @@ function veu_get_relative_path_from_abspath( $file_path ) {
  *                                                                  installed plugin's directory
  *                                                                  contains this file.
  */
-function veu_find_plugin_by_file( $file_path ) {
+function veu_template_tags_status_find_plugin( $file_path ) {
 	if ( ! function_exists( 'get_plugins' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
@@ -241,7 +304,7 @@ function veu_identify_template_tags_source_from_file( $defined_file ) {
 		return array( 'type' => 'unidentified' );
 	}
 
-	$plugin = veu_find_plugin_by_file( $defined_file );
+	$plugin = veu_template_tags_status_find_plugin( $defined_file );
 	if ( null !== $plugin ) {
 		return array(
 			'type'     => 'plugin',
@@ -251,7 +314,7 @@ function veu_identify_template_tags_source_from_file( $defined_file ) {
 		);
 	}
 
-	$relative_path = veu_get_relative_path_from_abspath( $defined_file );
+	$relative_path = veu_template_tags_status_relative_path( $defined_file );
 	if ( null === $relative_path ) {
 		// Cannot safely express this path relative to ABSPATH (e.g. it points outside the
 		// WordPress install entirely) -- never fall back to leaking the absolute path.
@@ -322,6 +385,19 @@ function veu_get_template_tags_source_dedupe_key( array $source ) {
  * これがサイトヘルス「情報」タブと `wp exunit template-tags status` WP-CLI コマンドの両方が
  * 共有する唯一の事実収集の入口であり、両者はこのデータを異なる形式に整形するだけである。
  *
+ * Note: a source is identified purely by which file currently defines a given function name --
+ * there is no check that the defining file is actually a copy of ExUnit's shared package. If
+ * another plugin happens to declare an unrelated function that shares one of these names in a
+ * completely unrelated file, that plugin would be listed as a source here too. This is accepted
+ * as within scope: the goal is "which currently-defined copy of this function name is running",
+ * not "which file is a verified copy of the shared package".
+ *
+ * 注意: 採用元は「この関数名を現在どのファイルが定義しているか」だけで特定しており、その定義元が
+ * 実際に ExUnit の共有パッケージのコピーであるかどうかまでは確認していない。他プラグインが
+ * たまたま無関係なファイルでこれらと同名の関数を宣言していた場合、そのプラグインもここに採用元
+ * として並ぶ。これは許容範囲としている。目的は「この関数名を現在定義しているのはどれか」であって
+ * 「共有パッケージの正当なコピーであることの検証」ではないため.
+ *
  * @return array<int, array{file:string, sources:array}> One entry per shared file, in
  *               require_once order, each with:
  *               - 'file'    Bare file name (e.g. "template-tags.php").
@@ -333,7 +409,7 @@ function veu_get_shared_template_tags_status() {
 	$status = array();
 
 	foreach ( veu_get_shared_template_tags_files() as $file_path ) {
-		$function_names = veu_extract_top_level_function_names( $file_path );
+		$function_names = veu_template_tags_status_extract_function_names( $file_path );
 
 		$sources   = array();
 		$seen_keys = array();
@@ -371,17 +447,31 @@ function veu_get_shared_template_tags_status() {
  *
  * Unlike the Site Health "Info" tab (which joins multiple sources for the same file into one
  * "A / B" display string), each source gets its own row here so scripts consuming --format=json
- * / --format=csv don't need to parse a joined string back apart.
+ * / --format=csv don't need to parse a joined string back apart. For the same reason, 'product'
+ * never has a file path folded into it (e.g. never "Could not identify the plugin (defined in
+ * ...)") -- the path lives in its own 'path' column, so a script never has to pull it back out of
+ * a sentence.
  *
  * サイトヘルス「情報」タブ（同一ファイルの複数採用元を "A / B" のように1つの文字列へ結合して
  * 表示する）とは異なり、ここでは採用元ごとに行を分ける。--format=json / --format=csv を使う
- * スクリプト側が結合済み文字列を再度分解しなくて済むようにするため。
+ * スクリプト側が結合済み文字列を再度分解しなくて済むようにするため。同じ理由で、'product' には
+ * ファイルパスを文中に埋め込まない（"Could not identify the plugin (defined in ...)" のような形に
+ * しない）。パスは独立した 'path' 列に持たせ、スクリプト側が文中からパスを取り出し直す必要が
+ * ないようにしている。
  *
  * @param array|null $status Pre-computed status from veu_get_shared_template_tags_status(), or
  *                            null to compute it. Accepting an explicit $status keeps this
  *                            function testable with synthetic data (e.g. fallback branches that
  *                            are hard to reproduce with real plugins installed).
- * @return array<int, array{file:string, product:string, version:string, plugin:string}>
+ * @return array<int, array{file:string, product:string, version:string, plugin:string, path:string}>
+ *               Columns, in order: file, product, version, plugin, path.
+ *               - Identified: product/version/plugin filled in, path empty.
+ *               - Defining file known but plugin not identified: product is the fixed
+ *                 "Could not identify the plugin" text, version/plugin empty, path holds the
+ *                 file's path relative to the WordPress root.
+ *               - Defining file also unknown, or the shared file is not loaded at all: product is
+ *                 "Could not identify the plugin" or "Not loaded" respectively, version/plugin/
+ *                 path all empty.
  */
 function veu_get_shared_template_tags_status_rows( $status = null ) {
 	if ( null === $status ) {
@@ -392,11 +482,25 @@ function veu_get_shared_template_tags_status_rows( $status = null ) {
 
 	foreach ( $status as $file_status ) {
 		if ( empty( $file_status['sources'] ) ) {
+			// Keep this fallback text in sync with the "Not loaded" fallback in
+			// veu_format_shared_template_tags_status_value() (site-health.php). They are kept as
+			// two separate literals on purpose -- this one is a fixed English string so
+			// --format=json/csv output stays stable regardless of site locale, while the Site
+			// Health one goes through __() so the admin screen can be translated. Sharing one
+			// literal would either break that translation or leak translated text into scripted
+			// CLI output, so update both by hand instead.
+			// このフォールバック文言は veu_format_shared_template_tags_status_value()
+			// （site-health.php）の "Not loaded" と表示を揃えること。あえて別々のリテラルに
+			// している。こちらはサイトのロケールに関係なく --format=json/csv の出力を安定させる
+			// ための固定の英語文字列で、サイトヘルス側は管理画面を翻訳できるよう __() を通す。
+			// 1つに共通化すると翻訳が効かなくなるか、翻訳済み文言が CLI 出力に混ざるかのどちらかに
+			// なるため、直すときは両方を手で直すこと.
 			$rows[] = array(
 				'file'    => $file_status['file'],
 				'product' => 'Not loaded',
 				'version' => '',
 				'plugin'  => '',
+				'path'    => '',
 			);
 			continue;
 		}
@@ -409,24 +513,43 @@ function veu_get_shared_template_tags_status_rows( $status = null ) {
 						'product' => $source['name'],
 						'version' => $source['version'],
 						'plugin'  => $source['basename'],
+						'path'    => '',
 					);
 					break;
 
 				case 'unidentified_file':
-					$rows[] = array(
-						'file'    => $file_status['file'],
-						'product' => 'Could not identify the plugin (defined in ' . $source['relative_path'] . ')',
-						'version' => '',
-						'plugin'  => '',
-					);
-					break;
-
-				default:
+					// Keep this fallback text in sync with the "Could not identify the plugin
+					// (defined in ...)" fallback in veu_format_template_tags_source_label()
+					// (site-health.php). See the note in the "Not loaded" branch above for why
+					// they are not shared code -- update both.
+					// このフォールバック文言は veu_format_template_tags_source_label()
+					// （site-health.php）の "Could not identify the plugin (defined in ...)" と
+					// 表示を揃えること。なぜ共通化しないかは上の "Not loaded" 分岐のコメントを
+					// 参照。直すときは両方を直すこと.
 					$rows[] = array(
 						'file'    => $file_status['file'],
 						'product' => 'Could not identify the plugin',
 						'version' => '',
 						'plugin'  => '',
+						'path'    => $source['relative_path'],
+					);
+					break;
+
+				default:
+					// Keep this fallback text in sync with the "Could not identify the plugin"
+					// fallback in veu_format_template_tags_source_label() (site-health.php). See
+					// the note in the "Not loaded" branch above for why they are not shared code
+					// -- update both.
+					// このフォールバック文言は veu_format_template_tags_source_label()
+					// （site-health.php）の "Could not identify the plugin" と表示を揃えること。
+					// なぜ共通化しないかは上の "Not loaded" 分岐のコメントを参照。直すときは
+					// 両方を直すこと.
+					$rows[] = array(
+						'file'    => $file_status['file'],
+						'product' => 'Could not identify the plugin',
+						'version' => '',
+						'plugin'  => '',
+						'path'    => '',
 					);
 					break;
 			}

--- a/inc/template-tags-status/collector.php
+++ b/inc/template-tags-status/collector.php
@@ -250,6 +250,14 @@ function veu_template_tags_status_relative_path( $file_path ) {
  * （Name / Version）を使って特定する。apply_filters() でサイト側から書き換え可能な
  * veu_get_name() のような値は使わない。
  *
+ * Each candidate plugin directory is matched against $file_path both as configured
+ * (WP_PLUGIN_DIR-based) and via its realpath()-resolved target -- see the inline comment below
+ * for why the realpath() comparison is necessary and cannot simply replace the original one.
+ *
+ * 各候補プラグインディレクトリは、$file_path に対して設定上のパス（WP_PLUGIN_DIR 由来）と
+ * realpath() で解決した実体のパスの両方で照合する。なぜ realpath() での照合が必要で、かつ
+ * 元の照合を置き換えるのではなく併用するのかは、下のインラインコメントを参照。
+ *
  * @param string $file_path Absolute path of the file that defines the function in question.
  * @return array{name:string,version:string,basename:string}|null Plugin info, or null when no
  *                                                                  installed plugin's directory
@@ -278,11 +286,52 @@ function veu_template_tags_status_find_plugin( $file_path ) {
 
 		$plugin_dir_abs = $plugins_dir . $plugin_dir_relative . '/';
 
-		// Prefer the most specific (longest) matching plugin directory, in case one plugin's
-		// folder name happens to be a prefix of another's.
-		if ( 0 === strpos( $normalized_file, $plugin_dir_abs ) && strlen( $plugin_dir_abs ) > $matched_dir_length ) {
-			$matched_dir_length = strlen( $plugin_dir_abs );
-			$matched_basename   = $plugin_basename;
+		// Candidate directories to compare $normalized_file against: the plugin directory as
+		// configured, and (when it resolves) its realpath()-resolved target.
+		//
+		// ReflectionFunction::getFileName() -- the caller of this function -- returns the
+		// defining file's actual (symlink-resolved) location. On setups where
+		// wp-content/plugins/<x> is itself a symlink (common in some local dev environments),
+		// that resolved path never falls under the WP_PLUGIN_DIR-based $plugin_dir_abs, so
+		// comparing against $plugin_dir_abs alone would always miss and this plugin would
+		// silently become "could not identify" -- defeating this feature's whole point (knowing
+		// which copy is running) on exactly the kind of setup where that matters most. The
+		// original WP_PLUGIN_DIR-based comparison is kept alongside the realpath() one (not
+		// replaced by it) because $file_path is not guaranteed to always be realpath-resolved
+		// either -- that depends on how the defining file was originally required, which this
+		// function has no control over -- so either form of $file_path must be able to match.
+		// realpath() returns false for a path that does not exist (e.g. a plugin directory
+		// entry with no real symlink target), so that candidate is simply skipped in that case.
+		//
+		// 照合対象の候補ディレクトリ: 設定上のプラグインディレクトリと、（解決できれば）その
+		// realpath() 解決後の実体のパス。
+		//
+		// この関数の呼び出し元である ReflectionFunction::getFileName() は、定義元ファイルの
+		// 実体（シンボリックリンク解決後）のパスを返す。wp-content/plugins/<x> 自体が
+		// シンボリックリンクになっている環境（ローカル開発環境などでよくある）では、解決後の
+		// パスが WP_PLUGIN_DIR 由来の $plugin_dir_abs 配下にならないため、$plugin_dir_abs
+		// だけで照合すると常に一致せず、そのプラグインは静かに「特定できませんでした」に
+		// なってしまう。これは「どのコピーが動いているか確認する」というこの機能の目的そのものを、
+		// まさにそれが重要になる環境で果たせなくしてしまう。元の WP_PLUGIN_DIR 由来の照合を
+		// 置き換えるのではなく併用しているのは、$file_path が常に realpath 解決済みとは
+		// 限らないため（定義元ファイルが元々どう require されたかに依存し、この関数からは
+		// 制御できない）で、$file_path がどちらの形であっても一致できるようにするため。
+		// realpath() は存在しないパス（実体を持たないプラグインディレクトリのエントリ等）に
+		// 対して false を返すため、その場合はこの候補を単に無視する.
+		$candidate_dirs = array( $plugin_dir_abs );
+
+		$plugin_dir_real = realpath( $plugin_dir_abs );
+		if ( false !== $plugin_dir_real ) {
+			$candidate_dirs[] = trailingslashit( wp_normalize_path( $plugin_dir_real ) );
+		}
+
+		foreach ( $candidate_dirs as $candidate_dir ) {
+			// Prefer the most specific (longest) matching plugin directory, in case one plugin's
+			// folder name happens to be a prefix of another's.
+			if ( 0 === strpos( $normalized_file, $candidate_dir ) && strlen( $candidate_dir ) > $matched_dir_length ) {
+				$matched_dir_length = strlen( $candidate_dir );
+				$matched_basename   = $plugin_basename;
+			}
 		}
 	}
 

--- a/inc/template-tags-status/package/class-veu-cli-template-tags-command.php
+++ b/inc/template-tags-status/package/class-veu-cli-template-tags-command.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * The `wp exunit template-tags status` WP-CLI command class.
+ *
+ * `wp exunit template-tags status` WP-CLI コマンドのクラス。
+ *
+ * Only ever loaded from inc/template-tags-status/wp-cli.php, which already guards on
+ * `defined( 'WP_CLI' ) && WP_CLI` before requiring this file.
+ *
+ * inc/template-tags-status/wp-cli.php からのみ読み込まれる。同ファイル側で
+ * `defined( 'WP_CLI' ) && WP_CLI` を確認した上でこのファイルを require しているため、
+ * ここでは改めてガードしない。
+ *
+ * @package VK All in One Expansion Unit
+ * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Reports which plugin's bundled copy of ExUnit's shared template-tag files is currently in
+ * effect.
+ *
+ * ExUnit の共有テンプレートタグファイルについて、現在どのプラグインの同梱コピーが
+ * 採用されているかを報告する。
+ */
+class VEU_CLI_Template_Tags_Command {
+
+	/**
+	 * Show, per shared template-tag file, which plugin's bundled copy is currently in effect.
+	 *
+	 * 共有テンプレートタグファイルごとに、現在どのプラグインの同梱コピーが採用されているか
+	 * を表示する。
+	 *
+	 * When a single file's functions come from more than one plugin's copy, that file is
+	 * expanded into one row per source (the `file` column repeats) so the output stays a flat
+	 * table that's easy to consume from a script, rather than a single cell with multiple
+	 * values joined together.
+	 *
+	 * 1つのファイルの関数が複数のプラグインのコピーに分かれて由来している場合、そのファイルは
+	 * 採用元ごとに1行へ展開される（`file` 列は同じ値を繰り返す）。スクリプトから扱いやすい
+	 * フラットな表のままにするため、1セルに複数の値を結合した形にはしない。
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp exunit template-tags status
+	 *     wp exunit template-tags status --format=json
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments; recognizes --format.
+	 * @return void
+	 */
+	public function status( $args, $assoc_args ) {
+		$rows = veu_get_shared_template_tags_status_rows();
+
+		$format_args = wp_parse_args( $assoc_args, array( 'format' => 'table' ) );
+
+		WP_CLI\Utils\format_items( $format_args['format'], $rows, array( 'file', 'product', 'version', 'plugin' ) );
+	}
+}

--- a/inc/template-tags-status/package/class-veu-cli-template-tags-command.php
+++ b/inc/template-tags-status/package/class-veu-cli-template-tags-command.php
@@ -37,11 +37,19 @@ class VEU_CLI_Template_Tags_Command {
 	 * When a single file's functions come from more than one plugin's copy, that file is
 	 * expanded into one row per source (the `file` column repeats) so the output stays a flat
 	 * table that's easy to consume from a script, rather than a single cell with multiple
-	 * values joined together.
+	 * values joined together. Columns, in order: `file`, `product`, `version`, `plugin`, `path`.
+	 * `path` (the defining file's path relative to the WordPress root) is only ever filled in
+	 * when the plugin could not be identified but its defining file could -- it is a separate
+	 * column rather than folded into `product` so scripts never need to parse it back out of a
+	 * sentence.
 	 *
 	 * 1つのファイルの関数が複数のプラグインのコピーに分かれて由来している場合、そのファイルは
 	 * 採用元ごとに1行へ展開される（`file` 列は同じ値を繰り返す）。スクリプトから扱いやすい
-	 * フラットな表のままにするため、1セルに複数の値を結合した形にはしない。
+	 * フラットな表のままにするため、1セルに複数の値を結合した形にはしない。列の並びは
+	 * `file`, `product`, `version`, `plugin`, `path` の順。`path`（定義元ファイルの WordPress
+	 * ルートからの相対パス）は、プラグインは特定できなかったが定義元ファイルは分かった場合にのみ
+	 * 入る。`product` に埋め込まず独立した列にしているのは、スクリプト側が文中からパスを
+	 * 取り出し直す必要をなくすため。
 	 *
 	 * ## OPTIONS
 	 *
@@ -70,6 +78,6 @@ class VEU_CLI_Template_Tags_Command {
 
 		$format_args = wp_parse_args( $assoc_args, array( 'format' => 'table' ) );
 
-		WP_CLI\Utils\format_items( $format_args['format'], $rows, array( 'file', 'product', 'version', 'plugin' ) );
+		WP_CLI\Utils\format_items( $format_args['format'], $rows, array( 'file', 'product', 'version', 'plugin', 'path' ) );
 	}
 }

--- a/inc/template-tags-status/site-health.php
+++ b/inc/template-tags-status/site-health.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Adds a "Shared Template-Tag Files (ExUnit)" section to WordPress' built-in Site Health
+ * "Info" tab (Tools > Site Health > Info), showing which plugin's bundled copy of each shared
+ * template-tag file is currently in effect.
+ *
+ * WordPress 標準のサイトヘルス「情報」タブ（ツール > サイトヘルス > 情報）に
+ * 「Shared Template-Tag Files (ExUnit)」セクションを追加し、共有テンプレートタグファイルごとに
+ * 現在どのプラグインの同梱コピーが採用されているかを表示する。
+ *
+ * This is informational only: no pass/fail judgement, warning, or color/icon is attached to any
+ * combination of results.
+ *
+ * あくまで情報提供のみで、どの組み合わせに対しても良し悪しの判定・警告・色やアイコンは付けない。
+ *
+ * @package VK All in One Expansion Unit
+ * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter( 'debug_information', 'veu_add_shared_template_tags_site_health_section' );
+
+/**
+ * Add the "Shared Template-Tag Files (ExUnit)" section's fields to the Site Health "Info" tab.
+ *
+ * サイトヘルス「情報」タブに「Shared Template-Tag Files (ExUnit)」セクションのフィールドを追加する。
+ *
+ * The status collection this builds on (veu_get_shared_template_tags_status()) parses ExUnit's
+ * own bundled files with token_get_all() and resolves plugin ownership with ReflectionFunction,
+ * both of which are non-trivial work. This filter only ever runs when the Site Health "Info"
+ * screen (or its "copy site info" action) actually renders, so that cost is not paid on every
+ * request.
+ *
+ * ここで利用する状態収集（veu_get_shared_template_tags_status()）は ExUnit 同梱ファイルの
+ * token_get_all() 解析と ReflectionFunction によるプラグイン特定を行うため、それなりのコストが
+ * ある。このフィルターはサイトヘルス「情報」画面（および「サイト情報をコピー」操作）が実際に
+ * 描画されるときにしか呼ばれないため、毎リクエストこのコストを払うことはない。
+ *
+ * @param array $info Existing debug information sections, keyed by section id.
+ * @return array
+ */
+function veu_add_shared_template_tags_site_health_section( $info ) {
+	$status = veu_get_shared_template_tags_status();
+
+	$fields = array();
+	foreach ( $status as $file_status ) {
+		$value = veu_format_shared_template_tags_status_value( $file_status['sources'] );
+
+		$fields[ $file_status['file'] ] = array(
+			'label' => $file_status['file'],
+			// The Info tab's visual table and its "copy site info to clipboard" output are both
+			// built from this data. This section's format never contains markup, so the same
+			// plain-text value is safe to reuse for both, keeping what's shown and what's copied
+			// identical.
+			// 情報タブの表画面と「サイト情報をコピー」の出力はどちらもこのデータから作られる。
+			// このセクションの書式に HTML は含まれないため、同じプレーンテキストの値を
+			// 両方にそのまま使い回せ、画面表示とコピー結果が一致する.
+			'value' => $value,
+			'debug' => $value,
+		);
+	}
+
+	$info['vk-exunit-shared-template-tags'] = array(
+		'label'       => __( 'Shared Template-Tag Files (ExUnit)', 'vk-all-in-one-expansion-unit' ),
+		'description' => __( "VK All in One Expansion Unit and some other Vektor plugins bundle the same shared template-tag files, and whichever plugin's copy loads first is the one that runs. This section lists, for each shared file, which plugin's copy is currently in effect and its version.", 'vk-all-in-one-expansion-unit' ),
+		'fields'      => $fields,
+	);
+
+	return $info;
+}
+
+/**
+ * Format one shared file's list of sources into the single display string shown in its Site
+ * Health row.
+ *
+ * 1つの共有ファイルの採用元一覧を、サイトヘルスの行に表示する1つの文字列へ整形する。
+ *
+ * @param array $sources Source descriptors from veu_get_shared_template_tags_status().
+ * @return string
+ */
+function veu_format_shared_template_tags_status_value( array $sources ) {
+	if ( empty( $sources ) ) {
+		return __( 'Not loaded', 'vk-all-in-one-expansion-unit' );
+	}
+
+	// When a single shared file's functions are split across more than one plugin's copy (e.g.
+	// one function still comes from an older bundled copy while another already comes from
+	// ExUnit's own), all of them are listed side by side. No count limit, "N more" truncation,
+	// special label, color, or icon is added for this case -- it is shown exactly like any other
+	// row, just with more than one entry.
+	// 1つの共有ファイル内で関数ごとに採用元が分かれている場合（例: 一部の関数はまだ古い同梱コピー
+	// のまま、別の関数は既に ExUnit 自身のもの、など）、それらをすべて並べて表示する。件数の上限や
+	// 「ほかN件」の省略、混在を示す専用ラベル・色・アイコンは付けない。他の行と同じ見せ方で、
+	// 単に項目数が複数になるだけである.
+	$labels = array_map( 'veu_format_template_tags_source_label', $sources );
+
+	return implode( ' / ', $labels );
+}
+
+/**
+ * Format a single source descriptor into a display label.
+ *
+ * 1件の採用元記述を表示用ラベルへ整形する。
+ *
+ * Plugin name/version/basename come from a third-party plugin's own header data, so each piece
+ * is escaped individually before being placed into the (translatable) format string.
+ *
+ * プラグイン名・バージョン・ベースネームはサードパーティプラグイン自身のヘッダ由来の外部データ
+ * のため、翻訳可能な書式文字列へ差し込む前に、それぞれ個別にエスケープする。
+ *
+ * @param array $source Source descriptor.
+ * @return string
+ */
+function veu_format_template_tags_source_label( array $source ) {
+	switch ( $source['type'] ) {
+		case 'plugin':
+			return sprintf(
+				/* translators: 1: plugin name (e.g. "VK All in One Expansion Unit"), 2: plugin version (e.g. "9.122.0"), 3: plugin basename -- the path used to identify a plugin, relative to the plugins directory (e.g. "vk-all-in-one-expansion-unit/vkExUnit.php"), as already shown in Site Health's own "Active Plugins" section. */
+				__( '%1$s %2$s (%3$s)', 'vk-all-in-one-expansion-unit' ),
+				esc_html( $source['name'] ),
+				esc_html( $source['version'] ),
+				esc_html( $source['basename'] )
+			);
+
+		case 'unidentified_file':
+			return sprintf(
+				/* translators: %s: file path where the function was found, relative to the WordPress root (never a server absolute path). */
+				__( 'Could not identify the plugin (defined in %s)', 'vk-all-in-one-expansion-unit' ),
+				esc_html( $source['relative_path'] )
+			);
+
+		case 'unidentified':
+		default:
+			return __( 'Could not identify the plugin', 'vk-all-in-one-expansion-unit' );
+	}
+}

--- a/inc/template-tags-status/site-health.php
+++ b/inc/template-tags-status/site-health.php
@@ -65,7 +65,12 @@ function veu_add_shared_template_tags_site_health_section( $info ) {
 
 	$info['vk-exunit-shared-template-tags'] = array(
 		'label'       => __( 'Shared Template-Tag Files (ExUnit)', 'vk-all-in-one-expansion-unit' ),
-		'description' => __( "VK All in One Expansion Unit and some other Vektor plugins bundle the same shared template-tag files, and whichever plugin's copy loads first is the one that runs. This section lists, for each shared file, which plugin's copy is currently in effect and its version.", 'vk-all-in-one-expansion-unit' ),
+		// The decided copy is two sentences. Coding rules require one sentence per translation
+		// function call, so it is split into two __() calls and joined with a single space; the
+		// displayed text is unchanged from the decided copy.
+		// 確定仕様の説明文は2文構成。コーディングルールにより翻訳関数は1文ごとに区切る必要があるため
+		// __() を2つに分け、半角スペースで連結している。表示される文面は確定仕様のままである.
+		'description' => __( 'VK All in One Expansion Unit and some other Vektor plugins bundle the same shared template-tag files, and whichever plugin\'s copy loads first is the one that runs.', 'vk-all-in-one-expansion-unit' ) . ' ' . __( 'This section lists, for each shared file, which plugin\'s copy is currently in effect and its version.', 'vk-all-in-one-expansion-unit' ),
 		'fields'      => $fields,
 	);
 
@@ -83,6 +88,12 @@ function veu_add_shared_template_tags_site_health_section( $info ) {
  */
 function veu_format_shared_template_tags_status_value( array $sources ) {
 	if ( empty( $sources ) ) {
+		// Keep this fallback text in sync with the "Not loaded" fallback in
+		// veu_get_shared_template_tags_status_rows() (collector.php). They are kept as two
+		// separate literals on purpose (see the note there), not shared code -- update both.
+		// このフォールバック文言は veu_get_shared_template_tags_status_rows()（collector.php）の
+		// "Not loaded" と表示を揃えること。あえて共通化せず別々のリテラルにしている（理由は
+		// collector.php 側のコメントを参照）ため、直すときは両方を直すこと.
 		return __( 'Not loaded', 'vk-all-in-one-expansion-unit' );
 	}
 
@@ -105,11 +116,25 @@ function veu_format_shared_template_tags_status_value( array $sources ) {
  *
  * 1件の採用元記述を表示用ラベルへ整形する。
  *
- * Plugin name/version/basename come from a third-party plugin's own header data, so each piece
- * is escaped individually before being placed into the (translatable) format string.
+ * Plugin name/version/basename are intentionally NOT escaped here, even though they come from a
+ * third-party plugin's own header data. WordPress' Site Health "Info" tab escapes 'value' itself
+ * when rendering the on-screen table (wp-admin/site-health-info.php calls esc_html() on it), and
+ * outputs 'debug' completely raw for the "copy site info to clipboard" action
+ * (wp-admin/includes/class-wp-debug-data.php). Escaping here as well would double-escape: a
+ * plugin literally named "Search & Filter Pro" would render as "Search &amp;amp; Filter Pro" on
+ * screen and in the copied text, which defeats the point of "copy site info" (pasting it
+ * somewhere for support). debug_information's contract is to receive plain text and let core do
+ * the escaping, so do not add esc_html() back here.
  *
- * プラグイン名・バージョン・ベースネームはサードパーティプラグイン自身のヘッダ由来の外部データ
- * のため、翻訳可能な書式文字列へ差し込む前に、それぞれ個別にエスケープする。
+ * プラグイン名・バージョン・ベースネームは、サードパーティプラグイン自身のヘッダ由来のデータでは
+ * あるが、ここではあえてエスケープしない。WordPress 本体のサイトヘルス「情報」タブは、画面表示時に
+ * 'value' 自体を esc_html() でエスケープしており（wp-admin/site-health-info.php）、「サイト情報を
+ * コピー」操作では 'debug' を全くエスケープせずそのまま出力する
+ * （wp-admin/includes/class-wp-debug-data.php）。ここでもエスケープすると二重エスケープになり、
+ * 例えば "Search & Filter Pro" という名前のプラグインが画面でもコピー結果でも
+ * "Search &amp;amp; Filter Pro" になってしまい、「コピーしてサポートに貼る」というこの機能の
+ * 目的そのものを壊す。debug_information はプレーンテキストを渡してエスケープは本体に委ねる契約な
+ * ので、ここに esc_html() を書き戻さないこと.
  *
  * @param array $source Source descriptor.
  * @return string
@@ -120,20 +145,32 @@ function veu_format_template_tags_source_label( array $source ) {
 			return sprintf(
 				/* translators: 1: plugin name (e.g. "VK All in One Expansion Unit"), 2: plugin version (e.g. "9.122.0"), 3: plugin basename -- the path used to identify a plugin, relative to the plugins directory (e.g. "vk-all-in-one-expansion-unit/vkExUnit.php"), as already shown in Site Health's own "Active Plugins" section. */
 				__( '%1$s %2$s (%3$s)', 'vk-all-in-one-expansion-unit' ),
-				esc_html( $source['name'] ),
-				esc_html( $source['version'] ),
-				esc_html( $source['basename'] )
+				$source['name'],
+				$source['version'],
+				$source['basename']
 			);
 
 		case 'unidentified_file':
+			// Keep this fallback text in sync with the "Could not identify the plugin (defined
+			// in ...)" fallback in veu_get_shared_template_tags_status_rows() (collector.php).
+			// See the note there for why they are not shared code -- update both.
+			// このフォールバック文言は veu_get_shared_template_tags_status_rows()（collector.php）
+			// の "Could not identify the plugin (defined in ...)" と表示を揃えること。
+			// なぜ共通化しないかは collector.php 側のコメントを参照。直すときは両方を直すこと.
 			return sprintf(
 				/* translators: %s: file path where the function was found, relative to the WordPress root (never a server absolute path). */
 				__( 'Could not identify the plugin (defined in %s)', 'vk-all-in-one-expansion-unit' ),
-				esc_html( $source['relative_path'] )
+				$source['relative_path']
 			);
 
 		case 'unidentified':
 		default:
+			// Keep this fallback text in sync with the "Could not identify the plugin" fallback
+			// in veu_get_shared_template_tags_status_rows() (collector.php). See the note there
+			// for why they are not shared code -- update both.
+			// このフォールバック文言は veu_get_shared_template_tags_status_rows()（collector.php）
+			// の "Could not identify the plugin" と表示を揃えること。なぜ共通化しないかは
+			// collector.php 側のコメントを参照。直すときは両方を直すこと.
 			return __( 'Could not identify the plugin', 'vk-all-in-one-expansion-unit' );
 	}
 }

--- a/inc/template-tags-status/site-health.php
+++ b/inc/template-tags-status/site-health.php
@@ -88,12 +88,15 @@ function veu_add_shared_template_tags_site_health_section( $info ) {
  */
 function veu_format_shared_template_tags_status_value( array $sources ) {
 	if ( empty( $sources ) ) {
-		// Keep this fallback text in sync with the "Not loaded" fallback in
-		// veu_get_shared_template_tags_status_rows() (collector.php). They are kept as two
-		// separate literals on purpose (see the note there), not shared code -- update both.
-		// このフォールバック文言は veu_get_shared_template_tags_status_rows()（collector.php）の
-		// "Not loaded" と表示を揃えること。あえて共通化せず別々のリテラルにしている（理由は
-		// collector.php 側のコメントを参照）ため、直すときは両方を直すこと.
+		// This handles the same "not loaded" case as veu_get_shared_template_tags_status_rows()
+		// (collector.php); update that one too when this one changes. They are two separate
+		// literals on purpose (see the note there), not shared code. The text happens to read
+		// identically ("Not loaded") today, but that is not the point being guarded here -- only
+		// the case is, not the wording.
+		// これは veu_get_shared_template_tags_status_rows()（collector.php）と同じ「読み込まれて
+		// いない」ケースを扱っている。片方を変えたらもう片方も直すこと。あえて共通化せず別々の
+		// リテラルにしている（理由は collector.php 側のコメントを参照）。現状は文言もたまたま
+		// 同じ（"Not loaded"）だが、ここで揃えたいのはケースであって文言そのものではない.
 		return __( 'Not loaded', 'vk-all-in-one-expansion-unit' );
 	}
 
@@ -151,12 +154,29 @@ function veu_format_template_tags_source_label( array $source ) {
 			);
 
 		case 'unidentified_file':
-			// Keep this fallback text in sync with the "Could not identify the plugin (defined
-			// in ...)" fallback in veu_get_shared_template_tags_status_rows() (collector.php).
-			// See the note there for why they are not shared code -- update both.
-			// このフォールバック文言は veu_get_shared_template_tags_status_rows()（collector.php）
-			// の "Could not identify the plugin (defined in ...)" と表示を揃えること。
-			// なぜ共通化しないかは collector.php 側のコメントを参照。直すときは両方を直すこと.
+			// This handles the same "defining file known, plugin not identified" case as the
+			// 'unidentified_file' branch of veu_get_shared_template_tags_status_rows()
+			// (collector.php) -- update that one too when this one changes. See the note there
+			// for why they are not shared code. UNLIKE the "Not loaded" pair above, the text
+			// here is INTENTIONALLY NOT the same: this string embeds the path inline as
+			// "...(defined in %s)", while the CLI row keeps 'product' as the fixed "Could not
+			// identify the plugin" and puts the path in its own 'path' column instead (see
+			// collector.php's docblock on that function). Do not "fix" this by embedding the
+			// path here differently to match some other wording, and do not ask for the CLI
+			// side to fold its 'path' column back into 'product' to match this string -- that
+			// column split was requested in the Issue #1479 UX review specifically so scripts
+			// don't have to parse the path back out of a sentence.
+			// これは collector.php の veu_get_shared_template_tags_status_rows() の
+			// 'unidentified_file' 分岐と同じ「定義元ファイルは分かるがプラグインは特定できない」
+			// ケースを扱っている。片方を変えたらもう片方も直すこと。共通化しない理由は
+			// collector.php 側のコメントを参照。ただし上の "Not loaded" のペアとは違い、ここは
+			// 文言をあえて揃えていない。この文字列は "...(defined in %s)" のようにパスを文中に
+			// 埋め込むが、CLI 側の行は 'product' を固定文言 "Could not identify the plugin" の
+			// ままにし、パスは独立した 'path' 列に入れる（collector.php 側の同関数の docblock
+			// 参照）。ここでの埋め込み方を変えて別の文言に合わせようとしたり、逆に CLI 側の
+			// 'path' 列をこの文言に合わせて 'product' へ戻すよう求めたりしないこと。その列構成は
+			// Issue #1479 の UX レビューで、スクリプト側が文中からパスを分解し直さずに済むよう
+			// 指示されて分離したものである.
 			return sprintf(
 				/* translators: %s: file path where the function was found, relative to the WordPress root (never a server absolute path). */
 				__( 'Could not identify the plugin (defined in %s)', 'vk-all-in-one-expansion-unit' ),
@@ -165,12 +185,17 @@ function veu_format_template_tags_source_label( array $source ) {
 
 		case 'unidentified':
 		default:
-			// Keep this fallback text in sync with the "Could not identify the plugin" fallback
-			// in veu_get_shared_template_tags_status_rows() (collector.php). See the note there
-			// for why they are not shared code -- update both.
-			// このフォールバック文言は veu_get_shared_template_tags_status_rows()（collector.php）
-			// の "Could not identify the plugin" と表示を揃えること。なぜ共通化しないかは
-			// collector.php 側のコメントを参照。直すときは両方を直すこと.
+			// This handles the same "nothing identifiable at all" case as the default branch of
+			// veu_get_shared_template_tags_status_rows() (collector.php) -- update that one too
+			// when this one changes. See the note there for why they are not shared code. The
+			// text happens to read identically ("Could not identify the plugin") today, same as
+			// the "Not loaded" case above -- but, as with that case, what must stay in sync is
+			// the case being handled, not necessarily the wording.
+			// これは collector.php の veu_get_shared_template_tags_status_rows() の default
+			// 分岐と同じ「何も手がかりがない」ケースを扱っている。片方を変えたらもう片方も
+			// 直すこと。共通化しない理由は collector.php 側のコメントを参照。現状は文言も
+			// たまたま同じ（"Could not identify the plugin"）だが、上の "Not loaded" のケースと
+			// 同様、揃えるべきなのは扱うケースであって、必ずしも文言そのものではない.
 			return __( 'Could not identify the plugin', 'vk-all-in-one-expansion-unit' );
 	}
 }

--- a/inc/template-tags-status/template-tags-status-config.php
+++ b/inc/template-tags-status/template-tags-status-config.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Load the "which plugin's copy of ExUnit's shared template-tag files is in effect" feature:
+ * the fact-collection layer, its Site Health "Info" tab section, and its WP-CLI command.
+ *
+ * ExUnit の共有テンプレートタグファイルについて「どのプラグインのコピーが採用されているか」を
+ * 可視化する機能一式（事実収集層、サイトヘルス「情報」タブのセクション、WP-CLI コマンド）を
+ * 読み込む。
+ *
+ * @package VK All in One Expansion Unit
+ * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/collector.php';
+require_once __DIR__ . '/site-health.php';
+require_once __DIR__ . '/wp-cli.php';

--- a/inc/template-tags-status/wp-cli.php
+++ b/inc/template-tags-status/wp-cli.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Registers `wp exunit template-tags status`, a WP-CLI command that reports which plugin's
+ * bundled copy of each of ExUnit's shared template-tag files is currently in effect.
+ *
+ * `wp exunit template-tags status` WP-CLI コマンドを登録する。ExUnit の共有テンプレートタグ
+ * ファイルごとに、現在どのプラグインの同梱コピーが採用されているかを報告する。
+ *
+ * This reports the same file-level facts as the Site Health "Info" tab section (see
+ * site-health.php) -- it does not go down to individual function names, and it makes no
+ * pass/fail judgement about mixed-source files; ExUnit itself does not decide whether a given
+ * combination is "a problem".
+ *
+ * サイトヘルス「情報」タブのセクション（site-health.php）と同じファイル単位の事実を報告する
+ * だけで、関数名までは掘り下げず、採用元が混在しているファイルについて良し悪しの判定も行わない。
+ * ある組み合わせが「問題かどうか」は ExUnit 自身は判定しない。
+ *
+ * @package VK All in One Expansion Unit
+ * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once __DIR__ . '/package/class-veu-cli-template-tags-command.php';
+
+	WP_CLI::add_command( 'exunit template-tags', 'VEU_CLI_Template_Tags_Command' );
+}

--- a/initialize.php
+++ b/initialize.php
@@ -48,11 +48,18 @@ function veu_load_packages() {
 	// template-tags-veuでpackageの関数を使うので package-managerを先に読み込んでいる.
 	require_once VEU_DIRECTORY_PATH . '/inc/template-tags/template-tags-config.php';
 	// Reports which plugin's copy of the shared template-tag files above is currently in effect
-	// (Site Health "Info" tab + WP-CLI). Must load after template-tags-config.php so its
-	// function_exists() lookups can see ExUnit's own copy once loaded.
+	// (Site Health "Info" tab + WP-CLI). This only registers a debug_information filter and a
+	// WP-CLI command; the function_exists()/ReflectionFunction lookups themselves run lazily when
+	// the Site Health "Info" screen renders or the CLI command executes, not here, so load order
+	// relative to template-tags-config.php has no effect on correctness. It is placed right after
+	// it purely for readability (it reports on the file loaded immediately above).
 	// 上記の共有テンプレートタグファイルについて、現在どのプラグインのコピーが採用されているかを
-	// 報告する（サイトヘルス「情報」タブ + WP-CLI）。function_exists() での判定が ExUnit 自身の
-	// コピー読み込み後の状態を見られるよう、template-tags-config.php の後に読み込む必要がある.
+	// 報告する（サイトヘルス「情報」タブ + WP-CLI）。ここで行っているのは debug_information
+	// フィルターと WP-CLI コマンドの登録だけで、function_exists() / ReflectionFunction による
+	// 判定自体はサイトヘルス「情報」画面の描画時または CLI コマンド実行時に遅延して走る
+	// （この require の時点では走らない）ため、template-tags-config.php との読み込み順は
+	// 動作に影響しない。直後に置いているのは、直前で読み込んだファイルについて報告する
+	// という関係が分かりやすいという可読性上の理由のみ.
 	require_once VEU_DIRECTORY_PATH . '/inc/template-tags-status/template-tags-status-config.php';
 	require_once VEU_DIRECTORY_PATH . '/inc/common-block.php';
 	require VEU_DIRECTORY_PATH . '/inc/footer-copyright-change.php';

--- a/initialize.php
+++ b/initialize.php
@@ -47,6 +47,13 @@ function veu_load_packages() {
 	require_once VEU_DIRECTORY_PATH . '/veu-package-manager.php';
 	// template-tags-veuでpackageの関数を使うので package-managerを先に読み込んでいる.
 	require_once VEU_DIRECTORY_PATH . '/inc/template-tags/template-tags-config.php';
+	// Reports which plugin's copy of the shared template-tag files above is currently in effect
+	// (Site Health "Info" tab + WP-CLI). Must load after template-tags-config.php so its
+	// function_exists() lookups can see ExUnit's own copy once loaded.
+	// 上記の共有テンプレートタグファイルについて、現在どのプラグインのコピーが採用されているかを
+	// 報告する（サイトヘルス「情報」タブ + WP-CLI）。function_exists() での判定が ExUnit 自身の
+	// コピー読み込み後の状態を見られるよう、template-tags-config.php の後に読み込む必要がある.
+	require_once VEU_DIRECTORY_PATH . '/inc/template-tags-status/template-tags-status-config.php';
 	require_once VEU_DIRECTORY_PATH . '/inc/common-block.php';
 	require VEU_DIRECTORY_PATH . '/inc/footer-copyright-change.php';
 	veu_package_include(); // package_manager.php.

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
+[ New Feature ] Added a "Shared Template-Tag Files (ExUnit)" section to Site Health > Info and a `wp exunit template-tags status` WP-CLI command, showing which plugin's bundled copy of ExUnit's shared template-tag files is currently in effect.
 [ Bug Fix ] Fixed the post type and taxonomy checklists in the settings screens showing only labels, making identically labeled items indistinguishable and easy to check by mistake. The slug is now shown next to the label.
 
 = 9.122.1 =

--- a/tests/fixtures/template-tags-status-bracket-tracking-fixture.php
+++ b/tests/fixtures/template-tags-status-bracket-tracking-fixture.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Synthetic fixture for TemplateTagsStatusTest's coverage of
+ * veu_template_tags_status_extract_function_names()'s brace-depth tracking.
+ *
+ * veu_template_tags_status_extract_function_names() の波括弧の深さ追跡をカバーするための
+ * 合成フィクスチャ。
+ *
+ * This file is never require'd/executed by anything -- it is only ever passed as a file path to
+ * veu_template_tags_status_extract_function_names(), which merely tokenizes it with
+ * token_get_all() and never includes it. It is therefore fine for it to reference undefined
+ * classes and to contain constructs the real ExUnit-bundled shared files don't currently use;
+ * none of that code ever runs.
+ *
+ * このファイルは一切 require/実行されない。常に
+ * veu_template_tags_status_extract_function_names() へファイルパスとして渡されるだけであり、
+ * 同関数は token_get_all() でトークン化するだけで include はしない。そのため未定義のクラスを
+ * 参照していても、実際の ExUnit 同梱共有ファイルでは現状使っていない書き方を含んでいても問題ない
+ * （このコードが実行されることは一切ない）。
+ *
+ * Covers (see the review that motivated this fixture, Issue #1479):
+ * (a) String interpolation ("{$var}") opens with the special T_CURLY_OPEN token but always
+ *     closes with a plain '}' token, which can desync brace-depth tracking and make a later
+ *     real class method look like a file-scope function.
+ * (b) T_ENUM was missing from the class-like token list, so an enum's methods could be
+ *     misdetected as file-scope functions (only meaningful on PHP 8.1+, where T_ENUM exists).
+ * (c) `Foo::class` also tokenizes its `class` keyword as T_CLASS, which must not be mistaken for
+ *     an actual class/interface/trait/enum declaration.
+ *
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+function veu_bracket_fixture_before_class() {
+	return true;
+}
+
+class VEU_Bracket_Fixture_Curly_Interpolation {
+
+	public function uses_curly_interpolation() {
+		$var = 'x';
+		return "value: {$var}";
+	}
+
+	public function should_stay_a_method() {
+		return 1;
+	}
+}
+
+enum VEU_Bracket_Fixture_Enum {
+	case One;
+	case Two;
+
+	public function should_stay_an_enum_method() {
+		return 1;
+	}
+}
+
+if ( VEU_Bracket_Fixture_Undefined_Class::class === 'x' ) {
+	function veu_bracket_fixture_inside_class_const_if() {
+		return true;
+	}
+}
+
+function veu_bracket_fixture_after_everything() {
+	return true;
+}

--- a/tests/test-template-tags-status.php
+++ b/tests/test-template-tags-status.php
@@ -503,34 +503,64 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 
 	/**
 	 * veu_get_shared_template_tags_files() must return exactly the files that
-	 * inc/template-tags/template-tags-config.php require_once's, in the same order.
+	 * inc/template-tags/template-tags-config.php loads, in the same order.
 	 *
 	 * veu_get_shared_template_tags_files() は、inc/template-tags/template-tags-config.php が
-	 * require_once している対象と、順序も含めて完全に一致しなければならないことを検証する。
+	 * 読み込んでいる対象と、順序も含めて完全に一致しなければならないことを検証する。
 	 *
 	 * inc/template-tags/template-tags-config.php is the source of truth here -- it is the file
 	 * that actually loads ExUnit's shared package copies. veu_get_shared_template_tags_files() is
 	 * a separately hand-written list (see its docblock in collector.php) that must be kept in
-	 * sync with it by hand. This test reads template-tags-config.php's own require_once lines
-	 * with a regex (not a hardcoded expected-files list) and compares them against
-	 * veu_get_shared_template_tags_files()'s output, so that if a shared file is ever added to or
-	 * removed from template-tags-config.php without updating
-	 * veu_get_shared_template_tags_files() to match, this test fails immediately -- catching the
-	 * exact "silently drops from the report" problem raised in the review that motivated this
-	 * test (Issue #1479), rather than only noticing it later via a missing/wrong report.
+	 * sync with it by hand. This test reads template-tags-config.php's own source with two
+	 * regexes (not a hardcoded expected-files list):
+	 *
+	 * - A broad one that matches any `require`/`include`, with or without `_once`, using either
+	 *   quote style, that loads a ".php" file -- used only to COUNT how many files the config
+	 *   actually loads, regardless of exactly how each line is written.
+	 * - A narrower one, anchored to the `__DIR__ . 'path'` shape all three current lines actually
+	 *   use (also tolerant of `require`/`include`, `_once` or not, and either quote style), used
+	 *   to reconstruct the exact list of absolute paths and compare it against
+	 *   veu_get_shared_template_tags_files()'s output for content and order.
+	 *
+	 * Both must agree with veu_get_shared_template_tags_files(): the narrow regex's reconstructed
+	 * list must match it exactly (content and order), AND the broad regex's count must match its
+	 * count. The second, seemingly redundant check exists specifically so that a shared file added
+	 * in a format the narrow regex cannot fully reconstruct a path for (e.g. a different base
+	 * constant than __DIR__) still fails this test on a plain count mismatch, rather than passing
+	 * silently because the narrow regex quietly ignored the line it could not parse. This closes
+	 * the gap an earlier, single-quote-only version of this regex had: that version matched only
+	 * the exact style the three current lines happen to use, so a fourth line added in any other
+	 * style (double quotes, `require` instead of `require_once`, etc.) would not be picked up by
+	 * it at all, and the test would keep passing at 3-vs-3 even though a real file had silently
+	 * gone unlisted.
 	 *
 	 * ここでは inc/template-tags/template-tags-config.php を正とする。実際に ExUnit の共有
 	 * パッケージのコピーを読み込んでいるのはこのファイルであり、veu_get_shared_template_tags_files()
 	 * はそれとは別に手書きされた一覧（collector.php 内の docblock も参照）で、手動で追随させ
-	 * 続ける必要がある。このテストは template-tags-config.php 自身の require_once 行を
-	 * （ハードコードした期待値一覧ではなく）正規表現で読み取り、
-	 * veu_get_shared_template_tags_files() の出力と突き合わせる。これにより、
-	 * template-tags-config.php に共有ファイルが追加・削除されたのに
-	 * veu_get_shared_template_tags_files() 側の更新が漏れると、このテストが即座に失敗する。
-	 * 「レポートから静かに抜ける」問題（この issue の指摘の趣旨）を、レポートの欠落として
-	 * 事後的に気づくのではなく、その場で検知できるようにするため。
+	 * 続ける必要がある。このテストは template-tags-config.php 自身のソースを
+	 * （ハードコードした期待値一覧ではなく）2つの正規表現で読み取る。
+	 *
+	 * - 緩い方: `require` / `include`（`_once` の有無を問わない）で ".php" ファイルを、
+	 *   シングル・ダブルどちらの引用符でも読み込んでいる行に広く一致する。各行が具体的に
+	 *   どう書かれているかに関わらず、config が実際に読み込んでいるファイルの「件数」だけを
+	 *   数えるために使う。
+	 * - 厳密な方: 現状の3行が実際に使っている `__DIR__ . 'パス'` という形に絞り込む（こちらも
+	 *   `require` / `include`、`_once` の有無、引用符の種類は許容する）。絶対パスの一覧を正確に
+	 *   再構築し、veu_get_shared_template_tags_files() の出力と対象・順序を突き合わせるために使う。
+	 *
+	 * どちらも veu_get_shared_template_tags_files() と一致していなければならない。厳密な方で
+	 * 再構築した一覧は対象・順序とも完全一致、かつ緩い方で数えた件数も一致すること。一見冗長な
+	 * 後者の件数チェックをあえて入れているのは、厳密な方の正規表現ではパスを再構築しきれない書式
+	 * （__DIR__ ではない別の定数を使う等）で共有ファイルが追加された場合でも、それを静かに
+	 * 無視して通過するのではなく、単純な件数不一致として確実にこのテストを落とすため。これは
+	 * 以前バージョン（シングルクォートの `require_once __DIR__ . '...'` 形にしか一致しなかった
+	 * 正規表現）が抱えていた抜け穴を塞ぐものである。以前の版では現状の3行がたまたま使っている
+	 * 書式にしか一致せず、4本目が別の書式（ダブルクォート、`require_once` ではなく `require` 等）
+	 * で追加されても抽出されず、実際にはファイルが一覧から漏れているのに 3件 対 3件 のまま
+	 * テストが通り続けてしまっていた。
 	 *
 	 * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479#issuecomment-5394857113
+	 * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479#issuecomment-5395101355
 	 */
 	public function test_veu_get_shared_template_tags_files_matches_template_tags_config() {
 		$config_path = VEU_DIRECTORY_PATH . '/inc/template-tags/template-tags-config.php';
@@ -538,19 +568,28 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 		$config_source = file_get_contents( $config_path );
 		$this->assertNotFalse( $config_source, '前提: template-tags-config.php を読み込めること' );
 
-		// template-tags-config.php 内の `require_once __DIR__ . '/xxxx';` 形式の行を、出現順に
-		// 機械的に抜き出す。期待値をハードコードするのではなく、config ファイル自体を正として
-		// 読み取る.
-		$matched_count = preg_match_all(
-			"/require_once\s+__DIR__\s*\.\s*'([^']+)'\s*;/",
+		// 緩い方の正規表現: require / include（_once の有無を問わない）で、シングル・ダブル
+		// どちらの引用符でも ".php" ファイルを読み込んでいる行に広く一致させ、件数だけを数える.
+		$broad_matched_count = preg_match_all(
+			'/\b(?:require|include)(?:_once)?\b[^;]*?([\'"])([^\'"]+\.php)\1[^;]*;/',
 			$config_source,
-			$matches
+			$broad_matches
 		);
-		$this->assertNotFalse( $matched_count, '前提: require_once の行を抽出できること' );
-		$this->assertGreaterThan( 0, $matched_count, '前提: template-tags-config.php から require_once の行を1件以上抽出できること（0件ならこのテスト自体が壊れている）' );
+		$this->assertNotFalse( $broad_matched_count, '前提: require/include の行を抽出できること' );
+		$this->assertGreaterThan( 0, $broad_matched_count, '前提: template-tags-config.php から require/include の行を1件以上抽出できること（0件ならこのテスト自体が壊れている）' );
+
+		// 厳密な方の正規表現: 現状の3行が実際に使っている `__DIR__ . 'パス'` の形に絞り込み、
+		// 出現順に絶対パスの一覧を再構築する。期待値をハードコードするのではなく、config
+		// ファイル自体を正として読み取る.
+		$narrow_matched_count = preg_match_all(
+			'/\b(?:require|include)(?:_once)?\s*\(?\s*__DIR__\s*\.\s*([\'"])([^\'"]+)\1\s*\)?\s*;/',
+			$config_source,
+			$narrow_matches
+		);
+		$this->assertNotFalse( $narrow_matched_count, '前提: __DIR__ 形式の require/include の行を抽出できること' );
 
 		$expected_files = array();
-		foreach ( $matches[1] as $relative_require ) {
+		foreach ( $narrow_matches[2] as $relative_require ) {
 			$expected_files[] = VEU_DIRECTORY_PATH . '/inc/template-tags' . $relative_require;
 		}
 
@@ -559,7 +598,16 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 		$this->assertSame(
 			$expected_files,
 			$actual_files,
-			'veu_get_shared_template_tags_files() は template-tags-config.php の require_once と対象・順序ともに完全一致するはず（config 側が正）'
+			'veu_get_shared_template_tags_files() は template-tags-config.php の __DIR__ 形式の require/include と対象・順序ともに完全一致するはず（config 側が正）'
+		);
+
+		// 緩い方の正規表現で数えた「config が実際に読み込んでいるファイルの総数」と、一覧の件数が
+		// 一致することも確認する。厳密な方の正規表現がパスを再構築しきれない書式で共有ファイルが
+		// 追加された場合でも、この件数チェックだけは検知できるようにするため（docblock 参照）.
+		$this->assertSame(
+			count( $actual_files ),
+			$broad_matched_count,
+			'veu_get_shared_template_tags_files() の件数は、config 側で実際に require/include されているファイルの総数と一致するはず（書式に関わらず件数だけは必ず検知する保険）'
 		);
 	}
 

--- a/tests/test-template-tags-status.php
+++ b/tests/test-template-tags-status.php
@@ -56,6 +56,11 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 
 		foreach ( $status as $file_status ) {
 			$this->assertNotEmpty( $file_status['sources'], $file_status['file'] . ' は少なくとも1件の採用元を持つはず（何も定義されていない = Not loaded は本テスト環境では想定外）' );
+			// 各共有ファイルは 8〜15 個の関数を宣言しているが（inc/template-tags/package/ 参照）、
+			// 採用元は全て ExUnit 自身の同じプラグインファイルに解決されるはずなので、重複排除により
+			// sources は1件にまとまっているはず。これが崩れる（例: 同じ採用元が関数の数だけ並ぶ）と
+			// ここで検知できる.
+			$this->assertCount( 1, $file_status['sources'], $file_status['file'] . ' は採用元が1件に重複排除されているはず（同じプラグインの関数が複数あっても1件にまとまる）' );
 
 			foreach ( $file_status['sources'] as $source ) {
 				$this->assertSame( 'plugin', $source['type'], $file_status['file'] . ' の採用元はプラグインとして特定できるはず' );
@@ -67,13 +72,13 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * veu_extract_top_level_function_names() reads a shared file with token_get_all() (not a
+	 * veu_template_tags_status_extract_function_names() reads a shared file with token_get_all() (not a
 	 * hardcoded list) and returns the function names it declares at file scope.
 	 *
-	 * veu_extract_top_level_function_names() が（ハードコードした一覧ではなく）token_get_all() で
+	 * veu_template_tags_status_extract_function_names() が（ハードコードした一覧ではなく）token_get_all() で
 	 * 共有ファイルを解析し、ファイルスコープで宣言している関数名を返すことを検証する。
 	 */
-	public function test_veu_extract_top_level_function_names() {
+	public function test_veu_template_tags_status_extract_function_names() {
 		$package_dir = VEU_DIRECTORY_PATH . '/inc/template-tags/package';
 
 		$test_cases = array(
@@ -100,7 +105,7 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 		);
 
 		foreach ( $test_cases as $case ) {
-			$actual = veu_extract_top_level_function_names( $case['file_path'] );
+			$actual = veu_template_tags_status_extract_function_names( $case['file_path'] );
 
 			$this->assertIsArray( $actual, $case['test_condition_name'] );
 			foreach ( $case['must_contain'] as $expected_function_name ) {
@@ -111,7 +116,7 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 		}
 
 		// 読み込めないファイルパスを渡した場合 => 空配列（境界値・異常系）.
-		$unreadable = veu_extract_top_level_function_names( VEU_DIRECTORY_PATH . '/this-file-does-not-exist.php' );
+		$unreadable = veu_template_tags_status_extract_function_names( VEU_DIRECTORY_PATH . '/this-file-does-not-exist.php' );
 		$this->assertSame( array(), $unreadable, '存在しないファイルパスの場合は空配列を返すはず（異常系）' );
 	}
 
@@ -241,38 +246,58 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 				'product' => 'VK All in One Expansion Unit',
 				'version' => '9.999.0',
 				'plugin'  => 'vk-all-in-one-expansion-unit/vkExUnit.php',
+				'path'    => '',
 			),
 			array(
 				'file'    => 'template-tags.php',
 				'product' => 'VK Post Author Display',
 				'version' => '1.2.3',
 				'plugin'  => 'vk-post-author-display/vk-post-author-display.php',
+				'path'    => '',
 			),
 			array(
 				'file'    => 'template-tags-veu.php',
-				'product' => 'Could not identify the plugin (defined in wp-includes/version.php)',
+				// 「特定できない理由」と「パス」は別々の列にする（product 列にパスを埋め込まない）。
+				// スクリプトが --format=json/csv を文字列パースし直さずに済むようにするため。
+				'product' => 'Could not identify the plugin',
 				'version' => '',
 				'plugin'  => '',
+				'path'    => 'wp-includes/version.php',
 			),
 			array(
 				'file'    => 'template-tags-veu-old.php',
 				'product' => 'Not loaded',
 				'version' => '',
 				'plugin'  => '',
+				'path'    => '',
 			),
 		);
 
-		$this->assertSame( $expected_rows, $rows, '2件の採用元を持つファイルは2行に展開され、file 列は同じ値を繰り返すはず' );
+		$this->assertSame( $expected_rows, $rows, '2件の採用元を持つファイルは2行に展開され、file 列は同じ値を繰り返すはず。特定できない場合は path 列にパスが分離して入り、product 列には理由の文言だけが入るはず' );
 	}
 
 	/**
 	 * veu_format_shared_template_tags_status_value() (used to build the Site Health "Info" tab
-	 * row) joins multiple sources with " / ", falls back to "Not loaded" when empty, and always
-	 * escapes plugin-supplied name/version before formatting.
+	 * row) joins multiple sources with " / ", falls back to "Not loaded" when empty, and passes
+	 * plugin-supplied name/version/basename through UNESCAPED.
 	 *
 	 * veu_format_shared_template_tags_status_value()（サイトヘルス「情報」タブの行を組み立てる
 	 * のに使う）が、複数の採用元を " / " で連結すること、空の場合は "Not loaded" になること、
-	 * プラグイン由来の name / version を整形前に必ずエスケープすることを検証する。
+	 * プラグイン由来の name / version / basename をエスケープせずそのまま通すことを検証する。
+	 *
+	 * This is intentional, not a gap: WordPress' Site Health "Info" tab itself calls esc_html() on
+	 * 'value' when rendering the table and outputs 'debug' completely raw for the "copy site info"
+	 * action. Escaping here too would double-escape (e.g. a plugin named "Search & Filter Pro"
+	 * would render as "Search &amp;amp; Filter Pro"), which is exactly the bug this function used
+	 * to have -- see veu_format_template_tags_source_label()'s docblock in site-health.php for the
+	 * full rationale.
+	 *
+	 * これは漏れではなく意図的な仕様である。WordPress 本体のサイトヘルス「情報」タブは、表を
+	 * 描画する際に自ら 'value' へ esc_html() をかけ、「サイト情報をコピー」操作では 'debug' を
+	 * 完全に無加工のまま出力する。ここでもエスケープすると二重エスケープになり（例:
+	 * "Search & Filter Pro" というプラグイン名が "Search &amp;amp; Filter Pro" になってしまう）、
+	 * まさにこの関数がかつて抱えていた不具合そのものになる。詳しい理由は site-health.php の
+	 * veu_format_template_tags_source_label() の docblock を参照。
 	 */
 	public function test_veu_format_shared_template_tags_status_value() {
 		$test_cases = array(
@@ -329,7 +354,11 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 				'expected'            => 'Could not identify the plugin',
 			),
 			array(
-				'test_condition_name' => 'プラグイン名に HTML を含む場合 => エスケープされて出力される（異常系・セキュリティ）',
+				// WordPress 本体の debug_information の契約は「プレーンテキストを渡し、
+				// エスケープは本体（画面表示は esc_html()、コピー出力は無加工）に委ねる」なので、
+				// ここでは HTML を含む文字列でもエスケープせずそのまま通ることを検証する
+				// （二重エスケープ防止の回帰テスト）.
+				'test_condition_name' => 'プラグイン名に HTML を含む場合 => 二重エスケープを防ぐため、ここではエスケープせずそのまま通す（異常系・セキュリティ回帰）',
 				'sources'             => array(
 					array(
 						'type'     => 'plugin',
@@ -338,7 +367,7 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 						'basename' => 'evil-plugin/evil.php',
 					),
 				),
-				'expected'            => '&lt;script&gt;alert(1)&lt;/script&gt; 1.0.0&quot;&gt;&lt;b&gt; (evil-plugin/evil.php)',
+				'expected'            => '<script>alert(1)</script> 1.0.0"><b> (evil-plugin/evil.php)',
 			),
 		);
 
@@ -374,6 +403,217 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 		foreach ( $section['fields'] as $field ) {
 			$this->assertSame( $field['value'], $field['debug'], $field['label'] . ' は value と debug が同一のプレーンテキストであるはず' );
 			$this->assertNotSame( '', trim( (string) $field['value'] ), $field['label'] . ' の value は空文字であってはいけない（書式が壊れたのか値が無いのか判断できなくなるため）' );
+		}
+	}
+
+	/**
+	 * veu_get_template_tags_source_dedupe_key() returns the same key for source descriptors that
+	 * represent the same source, and different keys for descriptors that represent different
+	 * sources -- including across types that happen to share an inner string value.
+	 *
+	 * veu_get_template_tags_source_dedupe_key() が、同じ採用元を表す記述には同じキーを、異なる
+	 * 採用元を表す記述には異なるキーを返すことを検証する（type をまたいで内部の文字列値が
+	 * 偶然一致するケースも含む）。
+	 *
+	 * veu_get_shared_template_tags_status() の重複排除ロジックはこのキーの一致判定に依存して
+	 * いるため、キー生成そのものを単体で検証する。実データでの重複排除（同じプラグインの15個の
+	 * 関数が1件にまとまること）の確認は
+	 * test_veu_get_shared_template_tags_status_detects_loaded_exunit_copy() の
+	 * assertCount( 1, ... ) を参照。
+	 */
+	public function test_veu_get_template_tags_source_dedupe_key() {
+		$plugin_source_a1            = array(
+			'type'     => 'plugin',
+			'name'     => 'VK All in One Expansion Unit',
+			'version'  => '9.122.0',
+			'basename' => 'vk-all-in-one-expansion-unit/vkExUnit.php',
+		);
+		$plugin_source_a2            = array(
+			'type'     => 'plugin',
+			// name / version が異なっていても basename が同じなら「同じ採用元」として扱われる
+			// べき（同じプラグインの別の関数から見つかった、という状況を想定）.
+			'name'     => 'VK All in One Expansion Unit (different label)',
+			'version'  => '9.999.0',
+			'basename' => 'vk-all-in-one-expansion-unit/vkExUnit.php',
+		);
+		$plugin_source_b             = array(
+			'type'     => 'plugin',
+			'name'     => 'VK Post Author Display',
+			'version'  => '1.2.3',
+			'basename' => 'vk-post-author-display/vk-post-author-display.php',
+		);
+		$unidentified_file_source_a1 = array(
+			'type'          => 'unidentified_file',
+			'relative_path' => 'wp-includes/version.php',
+		);
+		$unidentified_file_source_a2 = array(
+			'type'          => 'unidentified_file',
+			'relative_path' => 'wp-includes/version.php',
+		);
+		$unidentified_file_source_b  = array(
+			'type'          => 'unidentified_file',
+			'relative_path' => 'wp-includes/functions.php',
+		);
+		$unidentified_source_1       = array( 'type' => 'unidentified' );
+		$unidentified_source_2       = array( 'type' => 'unidentified' );
+		// basename と relative_path に、あえて同じ文字列を使う（type さえ異なれば衝突しては
+		// いけないことを確認するため）.
+		$plugin_source_collision     = array(
+			'type'     => 'plugin',
+			'name'     => 'Coincidentally Named Plugin',
+			'version'  => '1.0.0',
+			'basename' => 'wp-includes/version.php',
+		);
+		$unidentified_file_collision = array(
+			'type'          => 'unidentified_file',
+			'relative_path' => 'wp-includes/version.php',
+		);
+
+		$this->assertSame(
+			veu_get_template_tags_source_dedupe_key( $plugin_source_a1 ),
+			veu_get_template_tags_source_dedupe_key( $plugin_source_a2 ),
+			'同じ basename の plugin 採用元は同じキーになるはず（name/version が違っても同一視される）'
+		);
+		$this->assertNotSame(
+			veu_get_template_tags_source_dedupe_key( $plugin_source_a1 ),
+			veu_get_template_tags_source_dedupe_key( $plugin_source_b ),
+			'basename が異なる plugin 採用元は別のキーになるはず'
+		);
+		$this->assertSame(
+			veu_get_template_tags_source_dedupe_key( $unidentified_file_source_a1 ),
+			veu_get_template_tags_source_dedupe_key( $unidentified_file_source_a2 ),
+			'同じ relative_path の unidentified_file 採用元は同じキーになるはず'
+		);
+		$this->assertNotSame(
+			veu_get_template_tags_source_dedupe_key( $unidentified_file_source_a1 ),
+			veu_get_template_tags_source_dedupe_key( $unidentified_file_source_b ),
+			'relative_path が異なる unidentified_file 採用元は別のキーになるはず'
+		);
+		$this->assertSame(
+			veu_get_template_tags_source_dedupe_key( $unidentified_source_1 ),
+			veu_get_template_tags_source_dedupe_key( $unidentified_source_2 ),
+			'unidentified 採用元は常に同じキーになるはず（区別する情報を持たないため）'
+		);
+		$this->assertNotSame(
+			veu_get_template_tags_source_dedupe_key( $plugin_source_collision ),
+			veu_get_template_tags_source_dedupe_key( $unidentified_file_collision ),
+			'basename と relative_path が同じ文字列でも、type（plugin / unidentified_file）が異なればキーは衝突しないはず（境界値）'
+		);
+	}
+
+	/**
+	 * veu_get_shared_template_tags_files() must return exactly the files that
+	 * inc/template-tags/template-tags-config.php require_once's, in the same order.
+	 *
+	 * veu_get_shared_template_tags_files() は、inc/template-tags/template-tags-config.php が
+	 * require_once している対象と、順序も含めて完全に一致しなければならないことを検証する。
+	 *
+	 * inc/template-tags/template-tags-config.php is the source of truth here -- it is the file
+	 * that actually loads ExUnit's shared package copies. veu_get_shared_template_tags_files() is
+	 * a separately hand-written list (see its docblock in collector.php) that must be kept in
+	 * sync with it by hand. This test reads template-tags-config.php's own require_once lines
+	 * with a regex (not a hardcoded expected-files list) and compares them against
+	 * veu_get_shared_template_tags_files()'s output, so that if a shared file is ever added to or
+	 * removed from template-tags-config.php without updating
+	 * veu_get_shared_template_tags_files() to match, this test fails immediately -- catching the
+	 * exact "silently drops from the report" problem raised in the review that motivated this
+	 * test (Issue #1479), rather than only noticing it later via a missing/wrong report.
+	 *
+	 * ここでは inc/template-tags/template-tags-config.php を正とする。実際に ExUnit の共有
+	 * パッケージのコピーを読み込んでいるのはこのファイルであり、veu_get_shared_template_tags_files()
+	 * はそれとは別に手書きされた一覧（collector.php 内の docblock も参照）で、手動で追随させ
+	 * 続ける必要がある。このテストは template-tags-config.php 自身の require_once 行を
+	 * （ハードコードした期待値一覧ではなく）正規表現で読み取り、
+	 * veu_get_shared_template_tags_files() の出力と突き合わせる。これにより、
+	 * template-tags-config.php に共有ファイルが追加・削除されたのに
+	 * veu_get_shared_template_tags_files() 側の更新が漏れると、このテストが即座に失敗する。
+	 * 「レポートから静かに抜ける」問題（この issue の指摘の趣旨）を、レポートの欠落として
+	 * 事後的に気づくのではなく、その場で検知できるようにするため。
+	 *
+	 * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479#issuecomment-5394857113
+	 */
+	public function test_veu_get_shared_template_tags_files_matches_template_tags_config() {
+		$config_path = VEU_DIRECTORY_PATH . '/inc/template-tags/template-tags-config.php';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading this plugin's own local config file for static verification, not a remote URL.
+		$config_source = file_get_contents( $config_path );
+		$this->assertNotFalse( $config_source, '前提: template-tags-config.php を読み込めること' );
+
+		// template-tags-config.php 内の `require_once __DIR__ . '/xxxx';` 形式の行を、出現順に
+		// 機械的に抜き出す。期待値をハードコードするのではなく、config ファイル自体を正として
+		// 読み取る.
+		$matched_count = preg_match_all(
+			"/require_once\s+__DIR__\s*\.\s*'([^']+)'\s*;/",
+			$config_source,
+			$matches
+		);
+		$this->assertNotFalse( $matched_count, '前提: require_once の行を抽出できること' );
+		$this->assertGreaterThan( 0, $matched_count, '前提: template-tags-config.php から require_once の行を1件以上抽出できること（0件ならこのテスト自体が壊れている）' );
+
+		$expected_files = array();
+		foreach ( $matches[1] as $relative_require ) {
+			$expected_files[] = VEU_DIRECTORY_PATH . '/inc/template-tags' . $relative_require;
+		}
+
+		$actual_files = veu_get_shared_template_tags_files();
+
+		$this->assertSame(
+			$expected_files,
+			$actual_files,
+			'veu_get_shared_template_tags_files() は template-tags-config.php の require_once と対象・順序ともに完全一致するはず（config 側が正）'
+		);
+	}
+
+	/**
+	 * veu_template_tags_status_extract_function_names() correctly tracks brace depth through
+	 * three edge cases that could otherwise misclassify a class/enum method as a file-scope
+	 * function: string interpolation ("{$var}"), enum declarations (T_ENUM, PHP 8.1+), and
+	 * `Foo::class` (which also tokenizes its `class` keyword as T_CLASS).
+	 *
+	 * veu_template_tags_status_extract_function_names() が、クラス／enum のメソッドを
+	 * ファイルスコープの関数と誤認しうる3つの境界ケース（文字列内変数展開 "{$var}"、enum 宣言
+	 * （T_ENUM, PHP 8.1以降）、`Foo::class`（`class` キーワードも T_CLASS としてトークン化される
+	 * ）を正しく波括弧の深さで追跡できることを検証する。
+	 *
+	 * Uses a synthetic fixture file
+	 * (tests/fixtures/template-tags-status-bracket-tracking-fixture.php) rather than any of the
+	 * real shared files, since none of the three real shared files currently use these
+	 * constructs -- see the fixture file's own docblock for what each part covers.
+	 *
+	 * 実際の3つの共有ファイルは現状これらの書き方を使っていないため、実ファイルではなく合成
+	 * フィクスチャファイル（tests/fixtures/template-tags-status-bracket-tracking-fixture.php）を
+	 * 使う。各部分が何をカバーしているかはフィクスチャファイル自身の docblock を参照。
+	 */
+	public function test_veu_template_tags_status_extract_function_names_bracket_edge_cases() {
+		$fixture_path = __DIR__ . '/fixtures/template-tags-status-bracket-tracking-fixture.php';
+		$this->assertFileExists( $fixture_path, '前提: フィクスチャファイルが存在すること' );
+
+		$actual = veu_template_tags_status_extract_function_names( $fixture_path );
+
+		$expected_included = array(
+			'veu_bracket_fixture_before_class',
+			// `SomeClass::class` の `class` を実際のクラス宣言と誤認しなければ、この if ブロック
+			// 内の関数もファイルスコープの関数として正しく検出されるはず.
+			'veu_bracket_fixture_inside_class_const_if',
+			'veu_bracket_fixture_after_everything',
+		);
+		foreach ( $expected_included as $function_name ) {
+			$this->assertContains( $function_name, $actual, $function_name . ' はファイルスコープの関数として検出されるはず' );
+		}
+
+		$expected_excluded = array(
+			// 文字列内変数展開を含むメソッド。ここで波括弧の深さがずれると、後続の
+			// should_stay_a_method() がファイルスコープの関数として誤検出されてしまう.
+			'uses_curly_interpolation',
+			'should_stay_a_method',
+		);
+		// T_ENUM は PHP 8.1 以降にのみ存在する。それより前のランタイムでは enum 構文自体が特別
+		// 扱いされず、このケースの検証はそもそも成立しないためスキップする（本体側も T_ENUM を
+		// defined() で防御的にガードしているのと対称）.
+		if ( defined( 'T_ENUM' ) ) {
+			$expected_excluded[] = 'should_stay_an_enum_method';
+		}
+		foreach ( $expected_excluded as $function_name ) {
+			$this->assertNotContains( $function_name, $actual, $function_name . ' はクラス／enum のメソッドなので、ファイルスコープの関数として検出されてはいけない' );
 		}
 	}
 }

--- a/tests/test-template-tags-status.php
+++ b/tests/test-template-tags-status.php
@@ -83,9 +83,19 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 				'must_contain'        => array( 'vk_is_template_tags_exist', 'vk_the_taxonomy_check_list' ),
 			),
 			array(
-				'test_condition_name' => 'template-tags-veu.php => vk_get_post_type() を含む（正常系）',
+				// veu_get_common_options() は function_exists() ガードの外（ファイル直下）で宣言、
+				// veu_get_name() はガードの内側（if ( ! function_exists( ... ) ) { function ... } ）で
+				// 宣言されている。両方を含めることで、抽出処理がガードの有無に関係なく
+				// ファイルスコープの宣言を拾えていることを検証する.
+				'test_condition_name' => 'template-tags-veu.php => veu_get_common_options()（ガード外）と veu_get_name()（ガード内）を含む（正常系）',
 				'file_path'           => $package_dir . '/template-tags-veu.php',
-				'must_contain'        => array( 'vk_get_post_type' ),
+				'must_contain'        => array( 'veu_get_common_options', 'veu_get_name' ),
+			),
+			array(
+				// このファイルの関数は全て function_exists() ガードの内側で宣言されている.
+				'test_condition_name' => 'template-tags-veu-old.php => vkExUnit_get_common_options() と vkExUnit_get_name() を含む（正常系）',
+				'file_path'           => $package_dir . '/template-tags-veu-old.php',
+				'must_contain'        => array( 'vkExUnit_get_common_options', 'vkExUnit_get_name' ),
 			),
 		);
 

--- a/tests/test-template-tags-status.php
+++ b/tests/test-template-tags-status.php
@@ -502,62 +502,112 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * veu_get_shared_template_tags_files() must return exactly the files that
+	 * Shared regex-based extraction helper for template-tags-config.php-style source, used by
+	 * both test_veu_get_shared_template_tags_files_matches_template_tags_config() (against the
+	 * real file) and
+	 * test_veu_get_shared_template_tags_files_matches_template_tags_config_ignores_non_package_requires()
+	 * (against synthetic source), so both tests exercise the exact same regexes and can never
+	 * drift apart from each other.
+	 *
+	 * template-tags-config.php スタイルのソースから読み込み対象を抽出する、正規表現ベースの
+	 * 共有ヘルパー。実ファイルに対して検証する
+	 * test_veu_get_shared_template_tags_files_matches_template_tags_config() と、合成ソースに
+	 * 対して検証する
+	 * test_veu_get_shared_template_tags_files_matches_template_tags_config_ignores_non_package_requires()
+	 * の両方がこれを使うことで、2つのテストが使う正規表現が食い違うことのないようにしている。
+	 *
+	 * Both regexes are deliberately scoped to lines that load a file under a `package/`
+	 * directory. inc/template-tags/template-tags-config.php is not guaranteed to only ever
+	 * require_once the three shared package files it does today -- ExUnit-specific (non-shared)
+	 * files could be added there too (see Issue #1478, in progress on a sibling branch, which is
+	 * expected to add exactly such a line). This guard exists to catch drift in the shared
+	 * *package* file list specifically; a load of some other, non-shared file appearing in the
+	 * same config file is not a "shared file list went out of sync" bug and must not fail this
+	 * test. Do not remove the `package/` restriction to make the match "more thorough" -- doing
+	 * so would make this test count files that veu_get_shared_template_tags_files() was never
+	 * meant to list, turning legitimate, unrelated config.php edits into false failures here.
+	 *
+	 * どちらの正規表現も、`package/` ディレクトリ配下のファイルを読み込んでいる行だけに
+	 * 意図的に絞り込んでいる。inc/template-tags/template-tags-config.php が今後も現状の3つの
+	 * 共有パッケージファイルしか require_once しない保証はなく、ExUnit 固有の（共有ではない）
+	 * ファイルの読み込みが追加されることもありうる（Issue #1478 で、兄弟ブランチにて進行中。
+	 * まさにそのような行の追加が見込まれている）。このガードが検知したいのは共有*パッケージ*
+	 * ファイルの一覧のずれであって、同じ config ファイル内に共有ではない別のファイルの読み込みが
+	 * 増えたこと自体は「共有ファイル一覧がずれた」バグではなく、このテストを失敗させてはいけない。
+	 * 「より厳密にする」つもりで `package/` の絞り込みを外さないこと。外すと、
+	 * veu_get_shared_template_tags_files() が本来対象にしていないファイルまで数えてしまい、
+	 * 無関係な config.php の変更が誤ってこのテストを落とすようになる。
+	 *
+	 * @param string $config_source template-tags-config.php's source, or a synthetic equivalent.
+	 * @return array{
+	 *     broad_matched_count: int|false,
+	 *     narrow_matched_count: int|false,
+	 *     narrow_paths: string[],
+	 * }
+	 */
+	private function extract_template_tags_config_style_requires( $config_source ) {
+		// The broad regex: require/include, with or without _once, either quote style, loading
+		// any ".php" file under a "package/" directory. Used only to COUNT how many package files
+		// the source loads, regardless of exactly how each line is written.
+		// 緩い方の正規表現: require / include（_once の有無を問わない）で、シングル・ダブル
+		// どちらの引用符でも "package/" 配下の ".php" ファイルを読み込んでいる行に広く一致させ、
+		// 件数だけを数える.
+		$broad_matched_count = preg_match_all(
+			'/\b(?:require|include)(?:_once)?\b[^;]*?([\'"])([^\'"]*package\/[^\'"]+\.php)\1[^;]*;/',
+			$config_source,
+			$broad_matches
+		);
+
+		// The narrow regex: anchored to the `__DIR__ . 'path'` shape the three current lines
+		// actually use (also tolerant of require/include, _once, and quote style), restricted the
+		// same way to "package/" paths. Used to reconstruct the exact ordered file list.
+		// 厳密な方の正規表現: 現状の3行が実際に使っている `__DIR__ . 'パス'` の形に絞り込み
+		// （こちらも require/include・_once の有無・引用符の種類は許容する）、同様に "package/"
+		// 配下のパスに限定する。絶対パスの一覧を出現順に再構築するために使う.
+		$narrow_matched_count = preg_match_all(
+			'/\b(?:require|include)(?:_once)?\s*\(?\s*__DIR__\s*\.\s*([\'"])([^\'"]*package\/[^\'"]+)\1\s*\)?\s*;/',
+			$config_source,
+			$narrow_matches
+		);
+
+		return array(
+			'broad_matched_count'  => $broad_matched_count,
+			'narrow_matched_count' => $narrow_matched_count,
+			'narrow_paths'         => isset( $narrow_matches[2] ) ? $narrow_matches[2] : array(),
+		);
+	}
+
+	/**
+	 * veu_get_shared_template_tags_files() must return exactly the package files that
 	 * inc/template-tags/template-tags-config.php loads, in the same order.
 	 *
 	 * veu_get_shared_template_tags_files() は、inc/template-tags/template-tags-config.php が
-	 * 読み込んでいる対象と、順序も含めて完全に一致しなければならないことを検証する。
+	 * 読み込んでいる package ファイルと、順序も含めて完全に一致しなければならないことを検証する。
 	 *
 	 * inc/template-tags/template-tags-config.php is the source of truth here -- it is the file
 	 * that actually loads ExUnit's shared package copies. veu_get_shared_template_tags_files() is
 	 * a separately hand-written list (see its docblock in collector.php) that must be kept in
-	 * sync with it by hand. This test reads template-tags-config.php's own source with two
-	 * regexes (not a hardcoded expected-files list):
-	 *
-	 * - A broad one that matches any `require`/`include`, with or without `_once`, using either
-	 *   quote style, that loads a ".php" file -- used only to COUNT how many files the config
-	 *   actually loads, regardless of exactly how each line is written.
-	 * - A narrower one, anchored to the `__DIR__ . 'path'` shape all three current lines actually
-	 *   use (also tolerant of `require`/`include`, `_once` or not, and either quote style), used
-	 *   to reconstruct the exact list of absolute paths and compare it against
-	 *   veu_get_shared_template_tags_files()'s output for content and order.
-	 *
-	 * Both must agree with veu_get_shared_template_tags_files(): the narrow regex's reconstructed
-	 * list must match it exactly (content and order), AND the broad regex's count must match its
-	 * count. The second, seemingly redundant check exists specifically so that a shared file added
-	 * in a format the narrow regex cannot fully reconstruct a path for (e.g. a different base
-	 * constant than __DIR__) still fails this test on a plain count mismatch, rather than passing
-	 * silently because the narrow regex quietly ignored the line it could not parse. This closes
-	 * the gap an earlier, single-quote-only version of this regex had: that version matched only
-	 * the exact style the three current lines happen to use, so a fourth line added in any other
-	 * style (double quotes, `require` instead of `require_once`, etc.) would not be picked up by
-	 * it at all, and the test would keep passing at 3-vs-3 even though a real file had silently
-	 * gone unlisted.
+	 * sync with it by hand. This test reads template-tags-config.php's own source through
+	 * extract_template_tags_config_style_requires() (not a hardcoded expected-files list; see
+	 * that helper's docblock for why matching is scoped to `package/` paths and for the broad vs.
+	 * narrow regex split) and compares the result against
+	 * veu_get_shared_template_tags_files()'s output, so that if a shared package file is ever
+	 * added to or removed from template-tags-config.php without updating
+	 * veu_get_shared_template_tags_files() to match, this test fails immediately -- catching the
+	 * exact "silently drops from the report" problem raised in the review that motivated this
+	 * test (Issue #1479), rather than only noticing it later via a missing/wrong report.
 	 *
 	 * ここでは inc/template-tags/template-tags-config.php を正とする。実際に ExUnit の共有
 	 * パッケージのコピーを読み込んでいるのはこのファイルであり、veu_get_shared_template_tags_files()
 	 * はそれとは別に手書きされた一覧（collector.php 内の docblock も参照）で、手動で追随させ
 	 * 続ける必要がある。このテストは template-tags-config.php 自身のソースを
-	 * （ハードコードした期待値一覧ではなく）2つの正規表現で読み取る。
-	 *
-	 * - 緩い方: `require` / `include`（`_once` の有無を問わない）で ".php" ファイルを、
-	 *   シングル・ダブルどちらの引用符でも読み込んでいる行に広く一致する。各行が具体的に
-	 *   どう書かれているかに関わらず、config が実際に読み込んでいるファイルの「件数」だけを
-	 *   数えるために使う。
-	 * - 厳密な方: 現状の3行が実際に使っている `__DIR__ . 'パス'` という形に絞り込む（こちらも
-	 *   `require` / `include`、`_once` の有無、引用符の種類は許容する）。絶対パスの一覧を正確に
-	 *   再構築し、veu_get_shared_template_tags_files() の出力と対象・順序を突き合わせるために使う。
-	 *
-	 * どちらも veu_get_shared_template_tags_files() と一致していなければならない。厳密な方で
-	 * 再構築した一覧は対象・順序とも完全一致、かつ緩い方で数えた件数も一致すること。一見冗長な
-	 * 後者の件数チェックをあえて入れているのは、厳密な方の正規表現ではパスを再構築しきれない書式
-	 * （__DIR__ ではない別の定数を使う等）で共有ファイルが追加された場合でも、それを静かに
-	 * 無視して通過するのではなく、単純な件数不一致として確実にこのテストを落とすため。これは
-	 * 以前バージョン（シングルクォートの `require_once __DIR__ . '...'` 形にしか一致しなかった
-	 * 正規表現）が抱えていた抜け穴を塞ぐものである。以前の版では現状の3行がたまたま使っている
-	 * 書式にしか一致せず、4本目が別の書式（ダブルクォート、`require_once` ではなく `require` 等）
-	 * で追加されても抽出されず、実際にはファイルが一覧から漏れているのに 3件 対 3件 のまま
-	 * テストが通り続けてしまっていた。
+	 * extract_template_tags_config_style_requires()（ハードコードした期待値一覧ではない。
+	 * `package/` パスに絞り込んでいる理由、緩い方／厳密な方の正規表現を分けている理由は
+	 * 同ヘルパーの docblock を参照）で読み取り、veu_get_shared_template_tags_files() の出力と
+	 * 突き合わせる。これにより、共有パッケージファイルが template-tags-config.php に
+	 * 追加・削除されたのに veu_get_shared_template_tags_files() 側の更新が漏れると、このテストが
+	 * 即座に失敗する。「レポートから静かに抜ける」問題（この issue の指摘の趣旨）を、レポートの
+	 * 欠落として事後的に気づくのではなく、その場で検知できるようにするため。
 	 *
 	 * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479#issuecomment-5394857113
 	 * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479#issuecomment-5395101355
@@ -568,28 +618,14 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 		$config_source = file_get_contents( $config_path );
 		$this->assertNotFalse( $config_source, '前提: template-tags-config.php を読み込めること' );
 
-		// 緩い方の正規表現: require / include（_once の有無を問わない）で、シングル・ダブル
-		// どちらの引用符でも ".php" ファイルを読み込んでいる行に広く一致させ、件数だけを数える.
-		$broad_matched_count = preg_match_all(
-			'/\b(?:require|include)(?:_once)?\b[^;]*?([\'"])([^\'"]+\.php)\1[^;]*;/',
-			$config_source,
-			$broad_matches
-		);
-		$this->assertNotFalse( $broad_matched_count, '前提: require/include の行を抽出できること' );
-		$this->assertGreaterThan( 0, $broad_matched_count, '前提: template-tags-config.php から require/include の行を1件以上抽出できること（0件ならこのテスト自体が壊れている）' );
+		$extracted = $this->extract_template_tags_config_style_requires( $config_source );
 
-		// 厳密な方の正規表現: 現状の3行が実際に使っている `__DIR__ . 'パス'` の形に絞り込み、
-		// 出現順に絶対パスの一覧を再構築する。期待値をハードコードするのではなく、config
-		// ファイル自体を正として読み取る.
-		$narrow_matched_count = preg_match_all(
-			'/\b(?:require|include)(?:_once)?\s*\(?\s*__DIR__\s*\.\s*([\'"])([^\'"]+)\1\s*\)?\s*;/',
-			$config_source,
-			$narrow_matches
-		);
-		$this->assertNotFalse( $narrow_matched_count, '前提: __DIR__ 形式の require/include の行を抽出できること' );
+		$this->assertNotFalse( $extracted['broad_matched_count'], '前提: package/ 配下への require/include の行を抽出できること' );
+		$this->assertGreaterThan( 0, $extracted['broad_matched_count'], '前提: template-tags-config.php から package/ 配下への require/include の行を1件以上抽出できること（0件ならこのテスト自体が壊れている）' );
+		$this->assertNotFalse( $extracted['narrow_matched_count'], '前提: __DIR__ 形式で package/ 配下へ require/include している行を抽出できること' );
 
 		$expected_files = array();
-		foreach ( $narrow_matches[2] as $relative_require ) {
+		foreach ( $extracted['narrow_paths'] as $relative_require ) {
 			$expected_files[] = VEU_DIRECTORY_PATH . '/inc/template-tags' . $relative_require;
 		}
 
@@ -598,16 +634,62 @@ class TemplateTagsStatusTest extends WP_UnitTestCase {
 		$this->assertSame(
 			$expected_files,
 			$actual_files,
-			'veu_get_shared_template_tags_files() は template-tags-config.php の __DIR__ 形式の require/include と対象・順序ともに完全一致するはず（config 側が正）'
+			'veu_get_shared_template_tags_files() は template-tags-config.php の __DIR__ 形式の package/ 配下への require/include と対象・順序ともに完全一致するはず（config 側が正）'
 		);
 
-		// 緩い方の正規表現で数えた「config が実際に読み込んでいるファイルの総数」と、一覧の件数が
-		// 一致することも確認する。厳密な方の正規表現がパスを再構築しきれない書式で共有ファイルが
-		// 追加された場合でも、この件数チェックだけは検知できるようにするため（docblock 参照）.
+		// 緩い方の正規表現で数えた「config が実際に読み込んでいる package/ 配下ファイルの総数」と、
+		// 一覧の件数が一致することも確認する。厳密な方の正規表現がパスを再構築しきれない書式で
+		// 共有ファイルが追加された場合でも、この件数チェックだけは検知できるようにするため
+		// （extract_template_tags_config_style_requires() の docblock 参照）.
 		$this->assertSame(
 			count( $actual_files ),
-			$broad_matched_count,
-			'veu_get_shared_template_tags_files() の件数は、config 側で実際に require/include されているファイルの総数と一致するはず（書式に関わらず件数だけは必ず検知する保険）'
+			$extracted['broad_matched_count'],
+			'veu_get_shared_template_tags_files() の件数は、config 側で実際に require/include されている package/ 配下ファイルの総数と一致するはず（書式に関わらず件数だけは必ず検知する保険）'
+		);
+	}
+
+	/**
+	 * A non-`package/` require/include line added to template-tags-config.php (e.g. an
+	 * ExUnit-specific, non-shared file, as Issue #1478 is expected to add) must NOT be counted by
+	 * extract_template_tags_config_style_requires(), and therefore must not cause
+	 * test_veu_get_shared_template_tags_files_matches_template_tags_config() to fail.
+	 *
+	 * template-tags-config.php に `package/` 配下ではない require/include の行が追加されても
+	 * （例: Issue #1478 で追加見込みの ExUnit 固有の非共有ファイル）、
+	 * extract_template_tags_config_style_requires() がそれを数えてはいけないこと、したがって
+	 * test_veu_get_shared_template_tags_files_matches_template_tags_config() を失敗させては
+	 * いけないことを検証する。
+	 *
+	 * Uses synthetic source (not the real template-tags-config.php file) so this test does not
+	 * depend on Issue #1478's branch having landed, and keeps passing regardless of when it does.
+	 *
+	 * 実ファイルではなく合成したソースを使うため、このテストは Issue #1478 のブランチが
+	 * 取り込まれているかどうかに依存せず、いつ取り込まれても通り続ける。
+	 *
+	 * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479
+	 */
+	public function test_veu_get_shared_template_tags_files_matches_template_tags_config_ignores_non_package_requires() {
+		$synthetic_config_source = <<<'PHP'
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/package/template-tags.php';
+require_once __DIR__ . '/package/template-tags-veu.php';
+require_once __DIR__ . '/package/template-tags-veu-old.php';
+// Issue #1478 相当: 共有パッケージではない ExUnit 固有のファイルの読み込み.
+require_once __DIR__ . '/exunit-only-helper.php';
+PHP;
+
+		$extracted = $this->extract_template_tags_config_style_requires( $synthetic_config_source );
+
+		$this->assertSame( 3, $extracted['broad_matched_count'], 'package/ 配下ではない読み込み行（Issue #1478 相当）は、緩い方の件数に含めてはいけない' );
+		$this->assertSame( 3, $extracted['narrow_matched_count'], 'package/ 配下ではない読み込み行は、厳密な方の件数にも含めてはいけない' );
+		$this->assertSame(
+			array( '/package/template-tags.php', '/package/template-tags-veu.php', '/package/template-tags-veu-old.php' ),
+			$extracted['narrow_paths'],
+			'抽出されるパスは package/ 配下の3件のみで、非共有ファイルの行は含まれないはず'
 		);
 	}
 

--- a/tests/test-template-tags-status.php
+++ b/tests/test-template-tags-status.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * Class TemplateTagsStatusTest
+ *
+ * Tests for inc/template-tags-status/collector.php and inc/template-tags-status/site-health.php:
+ * the "which plugin's copy of ExUnit's shared template-tag files is currently in effect" feature.
+ *
+ * inc/template-tags-status/collector.php と inc/template-tags-status/site-health.php
+ * （「ExUnit の共有テンプレートタグファイルについて、どのプラグインのコピーが現在採用されているか」
+ * を可視化する機能）のテスト。
+ *
+ * @see https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1479
+ * @package Vk_All_In_One_Expansion_Unit
+ */
+
+class TemplateTagsStatusTest extends WP_UnitTestCase {
+
+	/**
+	 * veu_get_shared_template_tags_status() returns one entry per shared file, in the same order
+	 * inc/template-tags/template-tags-config.php require_once's them.
+	 *
+	 * veu_get_shared_template_tags_status() が、inc/template-tags/template-tags-config.php が
+	 * require_once している順序と同じ順序で、共有ファイルごとに1件のエントリを返すことを検証する。
+	 */
+	public function test_veu_get_shared_template_tags_status_order_and_count() {
+		$status = veu_get_shared_template_tags_status();
+
+		$this->assertCount( 3, $status, '共有ファイルは3件（template-tags.php / template-tags-veu.php / template-tags-veu-old.php）のはず' );
+
+		$expected_order = array( 'template-tags.php', 'template-tags-veu.php', 'template-tags-veu-old.php' );
+		$actual_order   = wp_list_pluck( $status, 'file' );
+
+		$this->assertSame( $expected_order, $actual_order, 'require_once の順序（template-tags.php → template-tags-veu.php → template-tags-veu-old.php）と一致するはず' );
+	}
+
+	/**
+	 * In this test environment only ExUnit itself is loaded (no other plugin bundles a copy of
+	 * the same shared files), so every function from every shared file should resolve to exactly
+	 * one source: ExUnit's own plugin file.
+	 *
+	 * このテスト環境では ExUnit 自身しか読み込まれていない（同じ共有ファイルを同梱する他プラグイン
+	 * が存在しない）ため、どの共有ファイルの関数も採用元は ExUnit 自身の1つだけに解決されるはず。
+	 */
+	public function test_veu_get_shared_template_tags_status_detects_loaded_exunit_copy() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$exunit_main_file  = VEU_DIRECTORY_PATH . '/vkExUnit.php';
+		$expected_basename = plugin_basename( $exunit_main_file );
+
+		$all_plugins = get_plugins();
+		$this->assertArrayHasKey( $expected_basename, $all_plugins, '前提: get_plugins() が ExUnit 自身をプラグインとして検出できていること' );
+
+		$status = veu_get_shared_template_tags_status();
+
+		foreach ( $status as $file_status ) {
+			$this->assertNotEmpty( $file_status['sources'], $file_status['file'] . ' は少なくとも1件の採用元を持つはず（何も定義されていない = Not loaded は本テスト環境では想定外）' );
+
+			foreach ( $file_status['sources'] as $source ) {
+				$this->assertSame( 'plugin', $source['type'], $file_status['file'] . ' の採用元はプラグインとして特定できるはず' );
+				$this->assertSame( $expected_basename, $source['basename'], $file_status['file'] . ' の採用元は ExUnit 自身であるはず（他プラグインが同梱コピーを読み込んでいないため）' );
+				$this->assertSame( $all_plugins[ $expected_basename ]['Name'], $source['name'] );
+				$this->assertSame( $all_plugins[ $expected_basename ]['Version'], $source['version'] );
+			}
+		}
+	}
+
+	/**
+	 * veu_extract_top_level_function_names() reads a shared file with token_get_all() (not a
+	 * hardcoded list) and returns the function names it declares at file scope.
+	 *
+	 * veu_extract_top_level_function_names() が（ハードコードした一覧ではなく）token_get_all() で
+	 * 共有ファイルを解析し、ファイルスコープで宣言している関数名を返すことを検証する。
+	 */
+	public function test_veu_extract_top_level_function_names() {
+		$package_dir = VEU_DIRECTORY_PATH . '/inc/template-tags/package';
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'template-tags.php => vk_is_template_tags_exist() と vk_the_taxonomy_check_list() を含む（正常系）',
+				'file_path'           => $package_dir . '/template-tags.php',
+				'must_contain'        => array( 'vk_is_template_tags_exist', 'vk_the_taxonomy_check_list' ),
+			),
+			array(
+				'test_condition_name' => 'template-tags-veu.php => vk_get_post_type() を含む（正常系）',
+				'file_path'           => $package_dir . '/template-tags-veu.php',
+				'must_contain'        => array( 'vk_get_post_type' ),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$actual = veu_extract_top_level_function_names( $case['file_path'] );
+
+			$this->assertIsArray( $actual, $case['test_condition_name'] );
+			foreach ( $case['must_contain'] as $expected_function_name ) {
+				$this->assertContains( $expected_function_name, $actual, $case['test_condition_name'] );
+			}
+			// 重複が排除されていることも確認する.
+			$this->assertSame( array_values( array_unique( $actual ) ), array_values( $actual ), $case['test_condition_name'] . ' / 重複のない配列であるはず' );
+		}
+
+		// 読み込めないファイルパスを渡した場合 => 空配列（境界値・異常系）.
+		$unreadable = veu_extract_top_level_function_names( VEU_DIRECTORY_PATH . '/this-file-does-not-exist.php' );
+		$this->assertSame( array(), $unreadable, '存在しないファイルパスの場合は空配列を返すはず（異常系）' );
+	}
+
+	/**
+	 * veu_identify_template_tags_source_from_file() is a pure function of its $defined_file
+	 * argument, so the "could not identify the plugin" fallback branches (which are hard to
+	 * reproduce with only real, currently-installed plugins) can be exercised directly here.
+	 *
+	 * veu_identify_template_tags_source_from_file() は $defined_file 引数だけに依存する純粋関数
+	 * のため、「どのプラグインか特定できない」場合のフォールバック分岐（実際にインストール済みの
+	 * プラグインだけでは再現しにくい）をここで直接検証できる。
+	 *
+	 * Also verifies that no branch ever leaks a server absolute path: the "unidentified_file"
+	 * branch must return an ABSPATH-relative path, and a file path located entirely outside
+	 * ABSPATH must fall back to "unidentified" rather than exposing that absolute path.
+	 *
+	 * また、どの分岐もサーバーの絶対パスを漏らさないことも検証する。「unidentified_file」分岐は
+	 * ABSPATH からの相対パスを返す必要があり、ABSPATH の外側にあるファイルパスは、その絶対パスを
+	 * 露出させるのではなく「unidentified」にフォールバックする必要がある。
+	 */
+	public function test_veu_identify_template_tags_source_from_file() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$exunit_main_file  = VEU_DIRECTORY_PATH . '/vkExUnit.php';
+		$expected_basename = plugin_basename( $exunit_main_file );
+		$all_plugins       = get_plugins();
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'ExUnit 自身のメインファイル => type: plugin として特定できる（正常系）',
+				'defined_file'        => $exunit_main_file,
+				'expected'            => array(
+					'type'     => 'plugin',
+					'name'     => $all_plugins[ $expected_basename ]['Name'],
+					'version'  => $all_plugins[ $expected_basename ]['Version'],
+					'basename' => $expected_basename,
+				),
+			),
+			array(
+				'test_condition_name' => 'ABSPATH 配下だがどのプラグインディレクトリにも属さない WordPress コア側のファイル => type: unidentified_file、relative_path は ABSPATH からの相対パス（境界値）',
+				'defined_file'        => ABSPATH . 'wp-includes/version.php',
+				'expected'            => array(
+					'type'          => 'unidentified_file',
+					'relative_path' => 'wp-includes/version.php',
+				),
+			),
+			array(
+				'test_condition_name' => 'ABSPATH の外側を指すファイルパス => 絶対パスを漏らさず type: unidentified にフォールバックする（異常系・境界値）',
+				'defined_file'        => '/this/path/is/outside/abspath/fake-file.php',
+				'expected'            => array(
+					'type' => 'unidentified',
+				),
+			),
+			array(
+				'test_condition_name' => 'ファイルパスが取得できない（false）=> type: unidentified（異常系）',
+				'defined_file'        => false,
+				'expected'            => array(
+					'type' => 'unidentified',
+				),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$actual = veu_identify_template_tags_source_from_file( $case['defined_file'] );
+
+			$this->assertSame( $case['expected'], $actual, $case['test_condition_name'] );
+
+			// どのケースでも、結果を JSON 化した文字列中にサーバーの絶対パス（ABSPATH）が
+			// 含まれないことを確認する.
+			$serialized = wp_json_encode( $actual );
+			$this->assertStringNotContainsString( rtrim( ABSPATH, '/' ), $serialized, $case['test_condition_name'] . ' / 結果にサーバーの絶対パスが含まれてはいけない' );
+		}
+	}
+
+	/**
+	 * veu_get_shared_template_tags_status_rows() normalizes the collected status into a flat,
+	 * one-row-per-source table for the WP-CLI command, accepting synthetic $status data so the
+	 * multi-source expansion can be verified deterministically (real environments installing a
+	 * second plugin that bundles the same files are not required just to test this).
+	 *
+	 * veu_get_shared_template_tags_status_rows() が、収集済み状態を WP-CLI コマンド向けの
+	 * 「1行1採用元」のフラットな表へ正規化することを検証する。合成した $status を渡せる設計により、
+	 * 複数採用元の展開を決定的に検証できる（このテストのためだけに同じファイルを同梱する2つ目の
+	 * プラグインを実際にインストールする必要はない）。
+	 */
+	public function test_veu_get_shared_template_tags_status_rows() {
+		$synthetic_status = array(
+			array(
+				'file'    => 'template-tags.php',
+				'sources' => array(
+					array(
+						'type'     => 'plugin',
+						'name'     => 'VK All in One Expansion Unit',
+						'version'  => '9.999.0',
+						'basename' => 'vk-all-in-one-expansion-unit/vkExUnit.php',
+					),
+					array(
+						'type'     => 'plugin',
+						'name'     => 'VK Post Author Display',
+						'version'  => '1.2.3',
+						'basename' => 'vk-post-author-display/vk-post-author-display.php',
+					),
+				),
+			),
+			array(
+				'file'    => 'template-tags-veu.php',
+				'sources' => array(
+					array(
+						'type'          => 'unidentified_file',
+						'relative_path' => 'wp-includes/version.php',
+					),
+				),
+			),
+			array(
+				'file'    => 'template-tags-veu-old.php',
+				'sources' => array(),
+			),
+		);
+
+		$rows = veu_get_shared_template_tags_status_rows( $synthetic_status );
+
+		$expected_rows = array(
+			array(
+				'file'    => 'template-tags.php',
+				'product' => 'VK All in One Expansion Unit',
+				'version' => '9.999.0',
+				'plugin'  => 'vk-all-in-one-expansion-unit/vkExUnit.php',
+			),
+			array(
+				'file'    => 'template-tags.php',
+				'product' => 'VK Post Author Display',
+				'version' => '1.2.3',
+				'plugin'  => 'vk-post-author-display/vk-post-author-display.php',
+			),
+			array(
+				'file'    => 'template-tags-veu.php',
+				'product' => 'Could not identify the plugin (defined in wp-includes/version.php)',
+				'version' => '',
+				'plugin'  => '',
+			),
+			array(
+				'file'    => 'template-tags-veu-old.php',
+				'product' => 'Not loaded',
+				'version' => '',
+				'plugin'  => '',
+			),
+		);
+
+		$this->assertSame( $expected_rows, $rows, '2件の採用元を持つファイルは2行に展開され、file 列は同じ値を繰り返すはず' );
+	}
+
+	/**
+	 * veu_format_shared_template_tags_status_value() (used to build the Site Health "Info" tab
+	 * row) joins multiple sources with " / ", falls back to "Not loaded" when empty, and always
+	 * escapes plugin-supplied name/version before formatting.
+	 *
+	 * veu_format_shared_template_tags_status_value()（サイトヘルス「情報」タブの行を組み立てる
+	 * のに使う）が、複数の採用元を " / " で連結すること、空の場合は "Not loaded" になること、
+	 * プラグイン由来の name / version を整形前に必ずエスケープすることを検証する。
+	 */
+	public function test_veu_format_shared_template_tags_status_value() {
+		$test_cases = array(
+			array(
+				'test_condition_name' => '採用元が0件 => "Not loaded"（境界値）',
+				'sources'             => array(),
+				'expected'            => 'Not loaded',
+			),
+			array(
+				'test_condition_name' => '採用元が1件（plugin） => "Name Version (basename)" 形式（正常系）',
+				'sources'             => array(
+					array(
+						'type'     => 'plugin',
+						'name'     => 'VK All in One Expansion Unit',
+						'version'  => '9.122.0',
+						'basename' => 'vk-all-in-one-expansion-unit/vkExUnit.php',
+					),
+				),
+				'expected'            => 'VK All in One Expansion Unit 9.122.0 (vk-all-in-one-expansion-unit/vkExUnit.php)',
+			),
+			array(
+				'test_condition_name' => '採用元が2件（plugin混在） => " / " で連結される（正常系・Issue #1479 の実測ケース相当）',
+				'sources'             => array(
+					array(
+						'type'     => 'plugin',
+						'name'     => 'VK All in One Expansion Unit',
+						'version'  => '9.122.0',
+						'basename' => 'vk-all-in-one-expansion-unit/vkExUnit.php',
+					),
+					array(
+						'type'     => 'plugin',
+						'name'     => 'VK Post Author Display',
+						'version'  => '1.2.3',
+						'basename' => 'vk-post-author-display/vk-post-author-display.php',
+					),
+				),
+				'expected'            => 'VK All in One Expansion Unit 9.122.0 (vk-all-in-one-expansion-unit/vkExUnit.php) / VK Post Author Display 1.2.3 (vk-post-author-display/vk-post-author-display.php)',
+			),
+			array(
+				'test_condition_name' => '採用元が unidentified_file => "Could not identify the plugin (defined in ...)"（正常系）',
+				'sources'             => array(
+					array(
+						'type'          => 'unidentified_file',
+						'relative_path' => 'wp-includes/version.php',
+					),
+				),
+				'expected'            => 'Could not identify the plugin (defined in wp-includes/version.php)',
+			),
+			array(
+				'test_condition_name' => '採用元が unidentified => "Could not identify the plugin"（正常系）',
+				'sources'             => array(
+					array( 'type' => 'unidentified' ),
+				),
+				'expected'            => 'Could not identify the plugin',
+			),
+			array(
+				'test_condition_name' => 'プラグイン名に HTML を含む場合 => エスケープされて出力される（異常系・セキュリティ）',
+				'sources'             => array(
+					array(
+						'type'     => 'plugin',
+						'name'     => '<script>alert(1)</script>',
+						'version'  => '1.0.0"><b>',
+						'basename' => 'evil-plugin/evil.php',
+					),
+				),
+				'expected'            => '&lt;script&gt;alert(1)&lt;/script&gt; 1.0.0&quot;&gt;&lt;b&gt; (evil-plugin/evil.php)',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$actual = veu_format_shared_template_tags_status_value( $case['sources'] );
+			$this->assertSame( $case['expected'], $actual, $case['test_condition_name'] );
+		}
+	}
+
+	/**
+	 * The Site Health "Info" tab section added by veu_add_shared_template_tags_site_health_section()
+	 * never leaks a server absolute path, and always sets 'value' and 'debug' to the same plain
+	 * text for each field (so the on-screen table and the "copy site info" output match).
+	 *
+	 * veu_add_shared_template_tags_site_health_section() が追加するサイトヘルス「情報」タブの
+	 * セクションが、サーバーの絶対パスを一切含まないこと、そして各フィールドの 'value' と 'debug'
+	 * に常に同じプレーンテキストが入っていること（画面表示と「サイト情報をコピー」の出力が
+	 * 一致すること）を検証する。
+	 */
+	public function test_veu_add_shared_template_tags_site_health_section_no_absolute_path_leak() {
+		$info = veu_add_shared_template_tags_site_health_section( array() );
+
+		$this->assertArrayHasKey( 'vk-exunit-shared-template-tags', $info );
+
+		$section = $info['vk-exunit-shared-template-tags'];
+		$this->assertNotEmpty( $section['label'] );
+		$this->assertNotEmpty( $section['description'] );
+		$this->assertCount( 3, $section['fields'], 'ファイル3件分のフィールドがあるはず' );
+
+		$serialized_section = wp_json_encode( $section );
+		$this->assertStringNotContainsString( rtrim( ABSPATH, '/' ), $serialized_section, 'サイトヘルスのセクション全体にサーバーの絶対パス（ABSPATH）が含まれてはいけない' );
+
+		foreach ( $section['fields'] as $field ) {
+			$this->assertSame( $field['value'], $field['debug'], $field['label'] . ' は value と debug が同一のプレーンテキストであるはず' );
+			$this->assertNotSame( '', trim( (string) $field['value'] ), $field['label'] . ' の value は空文字であってはいけない（書式が壊れたのか値が無いのか判断できなくなるため）' );
+		}
+	}
+}


### PR DESCRIPTION
@coderabbitai ignore

Closes #1479
親 issue: https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1476

## 概要

ExUnit と他の Vektor 製プラグイン（VK Post Author Display など）は、`vk_` で始まる補助関数をまとめた**同じ共通ファイルをそれぞれ自分の中に同梱**しています。ファイル内の各関数は「同じ名前の関数がまだ無ければ定義する」というガードで囲まれているため、**先に読み込まれた側の実装が採用され、後から読み込まれた側は無視されます**。

そのため「ExUnit で直したはずの不具合が、あるサイトでは再現し続ける」という状況が起こります。しかも**どのプラグインのコピーが実際に使われているかを確認する手段がなく**、コードを読みに行くまで原因を切り分けられませんでした。実例が #1450 です。

この PR で、**WordPress 標準のサイトヘルスの「情報」タブと WP-CLI（コマンドラインから WordPress を操作するツール）から、共通ファイルごとにどの製品のコピーが採用されているかを確認できるようにします。**

サイトヘルスの「情報」タブを置き場所に選んだのは、**「サポートに問い合わせるときに、この内容をコピーして送る」という使われ方が既に定着している**ためです。新しい操作を覚えてもらう必要がなく、一般のサイト管理者が普段開く場所でもありません。

## 何が変わるか

### サイトヘルス「情報」タブ

`Shared Template-Tag Files (ExUnit)` というセクションが増えます。共通ファイル3本それぞれについて、採用元の製品名・バージョン・プラグインの識別子を1行で表示します。

```
template-tags.php          VK All in One Expansion Unit 9.122.1 (vk-all-in-one-expansion-unit/vkExUnit.php)
template-tags-veu.php      VK All in One Expansion Unit 9.122.1 (vk-all-in-one-expansion-unit/vkExUnit.php)
template-tags-veu-old.php  VK All in One Expansion Unit 9.122.1 (vk-all-in-one-expansion-unit/vkExUnit.php)
```

1つのファイルの中で関数ごとに採用元が分かれている場合は、同じ書式を ` / ` で並べます。これは実際に起きている状態です（#1476 の実測を参照）。

```
template-tags.php          VK All in One Expansion Unit 9.122.1 (vk-all-in-one-expansion-unit/vkExUnit.php) / VK Post Author Display 1.x.x (vk-post-author-display/vk-post-author-display.php)
```

### WP-CLI コマンド

`wp exunit template-tags status` で同じ事実を取得できます。`--format=table|json|csv|yaml` に対応し、採用元が複数ある場合は**1行1採用元に展開**します（スクリプトから扱いやすくするため、画面側のように1つの文字列へ結合しません）。

## 設計上の判断

| 決めたこと | 理由 |
|---|---|
| **粒度はファイル単位**。関数ごとの一覧は出さない | 関数が増えるたびに行が伸び、サポートへ送ってもらう情報として扱いにくくなるため |
| **判定・警告はしない。事実だけを出す** | 「問題のある組み合わせを検知して警告する」形にすると、その判定条件の見落としが、この issue が問題にしている「気づかないうちに古い実装が使われる」のと同じ、新しい見えない分岐を生むため |
| **一般のサイト管理者向けの警告は出さない**。色・アイコン・チェックマークも使わない | プラグインをすべて最新にしていても起こりうる問題で、「更新してください」という対処すら当てはまらない場面が多く、行動につながらない警告になるため。色だけで意味を伝える作りはアクセシビリティ上も避けるべきため |
| **サーバー上の絶対パスは出さない** | サーバーのディレクトリ構成が露出するため。プラグインを特定できない場合も WordPress ルートからの相対パスに変換し、それも不可能な場合は情報を落とす |
| **製品名・バージョンはプラグイン本体ファイルのヘッダから取る** | ExUnit 内部の表示名を返す関数はサイト側から書き換えられるため、事実を出す用途には使えないため |
| **対象の関数一覧はハードコードしない** | 共通ファイル自体を解析して機械的に取り出す。一覧を手で書くと、関数を足したときに更新が漏れ、この機能自身が「更新漏れに気づけない」という同じ問題を作ってしまうため |
| **画面表示用の値を事前にエスケープしない** | WordPress 本体が画面表示時にエスケープし、「サイト情報をコピー」の出力はコピー用の値をそのまま扱うため。事前にエスケープすると `&` を含むプラグイン名が画面でもコピー結果でも壊れ、この機能の主目的が成立しなくなる |

## 変更ファイル

| ファイル | 役割 |
|---|---|
| `inc/template-tags-status/collector.php` | 事実の収集。表示用の整形は行わない。画面側とコマンド側の共通の土台 |
| `inc/template-tags-status/site-health.php` | サイトヘルス「情報」タブへの表示 |
| `inc/template-tags-status/wp-cli.php` | WP-CLI 実行時のみコマンドを登録する薄い入口 |
| `inc/template-tags-status/package/class-veu-cli-template-tags-command.php` | `wp exunit template-tags status` の実体 |
| `inc/template-tags-status/template-tags-status-config.php` | 上記の読み込み |
| `initialize.php` | 上記の読み込みを1行追加 |
| `readme.txt` | changelog を1行追加 |
| `tests/test-template-tags-status.php` | PHPUnit テスト |
| `tests/fixtures/template-tags-status-bracket-tracking-fixture.php` | 解析処理の回帰テスト用のファイル |

## 確認手順

### 前提

- ExUnit を有効化した WordPress
- **併用確認用に VK Post Author Display**（ローカルの `wp-content/plugins/vk-post-author-display` が使えます）

### 1. サイトヘルスに表示されること（ExUnit 単体）

1. VK Post Author Display を**無効化**した状態にする
2. 管理画面で `ツール > サイトヘルス` を開き、`情報` タブをクリックする
3. `Shared Template-Tag Files (ExUnit)` という項目を探してクリックし、展開する

→ セクションが表示され、次の3行が **この順で** 並ぶ
- `template-tags.php`
- `template-tags-veu.php`
- `template-tags-veu-old.php`

→ 3行とも値が `VK All in One Expansion Unit <バージョン> (vk-all-in-one-expansion-unit/vkExUnit.php)` になっている

→ **警告・注意喚起の文言、色分け、アイコン、チェックマークが一切表示されていない**

→ **サーバーの絶対パス（`/var/www/...` や `/Users/...` など）がどこにも出ていない**

📸 **この状態のスクリーンショットを添付してください**（展開したセクション全体）

### 2. 併用時に採用元が並ぶこと（この機能の本来の使いどころ）

1. VK Post Author Display を**有効化**する
2. `ツール > サイトヘルス > 情報` を開き直し、同じセクションを展開する

→ `template-tags.php` の行に、**2つの製品が ` / ` で並んで** 表示される
（例: `VK All in One Expansion Unit 9.122.1 (vk-all-in-one-expansion-unit/vkExUnit.php) / VK Post Author Display 1.x.x (vk-post-author-display/vk-post-author-display.php)`）

→ 混在していることを示す専用のラベル・色・アイコンは**付いていない**（他の行と同じ見た目で、項目が2つ並ぶだけ）

📸 **この状態のスクリーンショットを添付してください**（Before / After として 1. と並べてください）

### 3. コピーした内容が画面表示と一致すること

1. `情報` タブの上部にある「サイト情報をクリップボードにコピー」ボタンを押す
2. テキストエディタなどに貼り付ける
3. `Shared Template-Tag Files (ExUnit)` の部分を探す

→ 画面に表示されていた内容と**同じ文字列**が貼り付けられている

→ プラグイン名に `&` が含まれる場合（例: `Search & Filter Pro` のようなプラグインを有効化している場合）、`&amp;` や `&amp;amp;` のように**壊れていない**

### 4. WP-CLI コマンド

```
wp exunit template-tags status
```

→ `file` / `product` / `version` / `plugin` / `path` の列を持つ表が出る

→ VK Post Author Display を有効化している場合、`template-tags.php` が**2行に分かれ**、`file` 列に同じ値が繰り返される

```
wp exunit template-tags status --format=json
```

→ 同じ内容が JSON で出る

→ 出力のどこにもサーバーの絶対パスが含まれていない

### 5. デグレ確認

→ `ツール > サイトヘルス` の `状態` タブが従来どおり表示される

→ `情報` タブの既存のセクション（`使用中のプラグイン` など）が従来どおり表示される

→ ExUnit の各設定画面が従来どおり動作する

## テスト

- PHPUnit: **全 PASS（156 tests / 1166 assertions）** を先頭コミット `bdded627` で確認済み
- 追加したテスト:
  - 共通ファイル3本分のエントリが、読み込み順で返ること
  - 読み込まれている ExUnit のコピーが採用元として検出されること
  - **同じ採用元が複数の関数から来ても1件にまとまること**（重複排除）
  - 採用元を特定できない場合のフォールバック表示
  - **出力にサーバーの絶対パスが含まれないこと**
  - 画面表示用の値とコピー用の値が一致すること
  - 解析処理が、文字列内の変数展開・列挙型・`::class` の書き方に惑わされないこと（回帰テスト用のファイルを使用）
  - **収集側が持つ共通ファイルの一覧が、実際に読み込んでいる側と一致すること**（片方だけ増えたら落ちる）

## レビュー

- 保（コードレビュー / セキュリティ）: **PASS**
- 植草（UX レビュー）: **PASS**

いずれも指摘は PR 内で対応済みです。経緯は #1479 のコメントに記録しています。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/825