### PR TITLE
[ 不具合修正 ] vektor-inc/font-awesome-versions を 0.7.5 から 0.7.6 に更新

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
-            "version": "0.7.5",
+            "version": "0.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/font-awesome-versions.git",
-                "reference": "0f13392629e0af4b6595c5dca59c65d9e854780c"
+                "reference": "3c48955fe9d1d76756e729224341164d085a7e09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/0f13392629e0af4b6595c5dca59c65d9e854780c",
-                "reference": "0f13392629e0af4b6595c5dca59c65d9e854780c",
+                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/3c48955fe9d1d76756e729224341164d085a7e09",
+                "reference": "3c48955fe9d1d76756e729224341164d085a7e09",
                 "shasum": ""
             },
             "require": {
@@ -54,9 +54,9 @@
             "description": "Font Awesome",
             "support": {
                 "issues": "https://github.com/vektor-inc/font-awesome-versions/issues",
-                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.5"
+                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.6"
             },
-            "time": "2026-07-08T05:37:47+00:00"
+            "time": "2026-08-24T13:52:23+00:00"
         },
         {
             "name": "vektor-inc/vk-admin",
@@ -2919,5 +2919,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 == Changelog ==
 
 [ New Feature ] Added a "Shared Template-Tag Files (ExUnit)" section to Site Health > Info and a `wp exunit template-tags status` WP-CLI command, showing which plugin's bundled copy of ExUnit's shared template-tag files is currently in effect.
-[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.5 to 0.7.6
+[ Bug Fix ] Update vektor-inc/font-awesome-versions from 0.7.5 to 0.7.6, fixing Font Awesome icons not displaying in some server environments (e.g. AWS Bitnami)
 [ Bug Fix ] Fixed the post type and taxonomy checklists in the settings screens showing only labels, making identically labeled items indistinguishable and easy to check by mistake. The slug is now shown next to the label.
 [ Bug Fix ][ Template Tags ] Fixed already-fixed bugs (such as PHP warnings) silently reappearing when used together with another Vektor plugin that bundles an older copy of the shared template tag functions and happens to load first.
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 == Changelog ==
 
 [ New Feature ] Added a "Shared Template-Tag Files (ExUnit)" section to Site Health > Info and a `wp exunit template-tags status` WP-CLI command, showing which plugin's bundled copy of ExUnit's shared template-tag files is currently in effect.
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.5 to 0.7.6
 [ Bug Fix ] Fixed the post type and taxonomy checklists in the settings screens showing only labels, making identically labeled items indistinguishable and easy to check by mistake. The slug is now shown next to the label.
 [ Bug Fix ][ Template Tags ] Fixed already-fixed bugs (such as PHP warnings) silently reappearing when used together with another Vektor plugin that bundles an older copy of the shared template tag functions and happens to load first.
 


### PR DESCRIPTION
## 概要

AWS（Bitnami）環境で Font Awesome アイコンが表示されない不具合が、依存ライブラリ `vektor-inc/font-awesome-versions` 側で修正されています（vektor-inc/font-awesome-versions#56）。本 PR では composer.lock を更新し、その修正版（0.7.6）を取り込みます。

composer.json の指定（`^0.7.5`）は変更していません。差分は composer.lock のみです。

親issue: https://github.com/vektor-inc/multi-repo-tasks/issues/36

## 変更内容

- `composer update vektor-inc/font-awesome-versions` を実行し、composer.lock の font-awesome-versions を 0.7.5 → 0.7.6 に更新
- readme.txt の changelog（未リリース領域）にエントリを追加

## 確認手順

1. `composer.lock` を開き、`vektor-inc/font-awesome-versions` のバージョンが `0.7.6` になっていることを確認する
   → `"name": "vektor-inc/font-awesome-versions"` の `"version"` が `0.7.6`
2. `composer.json` に差分がないことを確認する（`git diff composer.json`）
   → 差分なし
3. AWS（Bitnami）環境固有の不具合のため、本 PR 単体でのローカル動作確認は不要（依存ライブラリ側の修正取り込みのみ）

## デグレ確認

- composer.json の依存指定（`^0.7.5`）は変更していないため、他のバージョン制約に影響なし


@coderabbitai ignore
