### PR TITLE
[ その他 ] 子ページリストウィジェットの wp_list_pages() 呼び出しをクエリ文字列から配列引数に変更

### DIFF
--- a/inc/other-widget/widget-side-child-page-list.php
+++ b/inc/other-widget/widget-side-child-page-list.php
@@ -49,7 +49,7 @@ class WP_Widget_vkExUnit_ChildPageList extends WP_Widget {
 					echo $args['before_widget'];
 					echo '<div class="veu_childPages widget_link_list">';
 					echo $args['before_title'];
-					echo '<a href="' . get_the_permalink( $post_id ) . '">';
+					echo '<a href="' . esc_url( get_the_permalink( $post_id ) ) . '">';
 					echo get_the_title( $post_id );
 					echo '</a>';
 					echo $args['after_title'];

--- a/inc/other-widget/widget-side-child-page-list.php
+++ b/inc/other-widget/widget-side-child-page-list.php
@@ -38,7 +38,13 @@ class WP_Widget_vkExUnit_ChildPageList extends WP_Widget {
 				$post_id = $post->ID;
 			}
 			if ( $post_id ) {
-				$children = wp_list_pages( 'title_li=&child_of=' . $post_id . '&echo=0' );
+				$children = wp_list_pages(
+					array(
+						'title_li' => '',
+						'child_of' => $post_id,
+						'echo'     => false,
+					)
+				);
 				if ( $children ) {
 					echo $args['before_widget'];
 					echo '<div class="veu_childPages widget_link_list">';

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,7 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
-[ Other ] Changed the child page list widget to call `wp_list_pages()` with array arguments instead of a query string, with no change in output, avoiding a future WordPress core compatibility warning.
+[ Other ] Changed the child page list widget to pass array arguments to `wp_list_pages()` for compatibility with future WordPress versions.
 
 = 9.123.0 =
 [ New Feature ] Added a "Shared Template-Tag Files (ExUnit)" section to Site Health > Info and a `wp exunit template-tags status` WP-CLI command, showing which plugin's bundled copy of ExUnit's shared template-tag files is currently in effect.

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,8 @@ Full license texts are included in LICENSE-THIRD-PARTY.txt, bundled with this pl
 
 == Changelog ==
 
+[ Other ] Changed the child page list widget to call `wp_list_pages()` with array arguments instead of a query string, with no change in output, avoiding a future WordPress core compatibility warning.
+
 = 9.123.0 =
 [ New Feature ] Added a "Shared Template-Tag Files (ExUnit)" section to Site Health > Info and a `wp exunit template-tags status` WP-CLI command, showing which plugin's bundled copy of ExUnit's shared template-tag files is currently in effect.
 [ Bug Fix ] Update vektor-inc/font-awesome-versions from 0.7.5 to 0.7.6, fixing Font Awesome icons not displaying in some server environments (e.g. AWS Bitnami)


### PR DESCRIPTION
## 概要

「子ページリスト」ウィジェット（固定ページのサイドバーに、そのページが属する最上位の親ページ配下の子ページ一覧を出すウィジェット）の内部で、WordPress の子ページ一覧を出力する関数 `wp_list_pages()` に渡す引数の書き方を変更しました。

この関数は引数を「配列」でも「クエリ文字列」（URL の `?` の後ろと同じ `key=value&key=value` という形式の文字列）でも受け付けます。これまではクエリ文字列で渡していましたが、これを配列に書き換えました。**画面に出る内容は変わりません。**

```php
// 変更前
$children = wp_list_pages( 'title_li=&child_of=' . $post_id . '&echo=0' );

// 変更後
$children = wp_list_pages(
	array(
		'title_li' => '',
		'child_of' => $post_id,
		'echo'     => false,
	)
);
```

### なぜ変えるのか

WordPress コアの Trac（WordPress コアの不具合・提案を管理する掲示板）のチケット [#66049](https://core.trac.wordpress.org/ticket/66049) で、クエリ文字列で引数を渡す書き方に対して `_doing_it_wrong()`（開発者向けに「この使い方は推奨されない」と通知する仕組み。デバッグ表示を有効にしていると画面やログに出る）を出す案が挙がっています。そのチケットの調査結果で、今もクエリ文字列形式を使っているプラグインとして VK All in One Expansion Unit が名指しされていました。

コアがこの通知を入れると、ExUnit を使っているサイトでデバッグ表示を有効にしたとき、このウィジェットを置いたページで通知が出るようになります。書き換えは機械的で挙動も変わらないため、先に直しておくものです。

### 挙動が変わらない根拠

| 引数 | 変更前（クエリ文字列） | 変更後（配列） | 判定 |
|---|---|---|---|
| `title_li`（一覧の先頭に出す見出し行の文言） | `title_li=` → 空文字列 | `''` | 同一。コア側は値があるかどうか（truthy 判定）だけを見るため、どちらでも見出し行 `<li class="pagenav">` は出力されない |
| `child_of`（どのページの子を出すか） | `'123'`（文字列） | `123`（整数） | 同一。コア側の `get_pages()` が数値として扱い、型まで一致を求める比較（厳密比較）は行っていない |
| `echo`（その場で出力するか、文字列として返すか） | `'0'`（文字列） | `false`（真偽値） | 同一。コア側は truthy 判定のみで、`'0'` も `false` もどちらも「出力せず文字列を返す」側に落ちる。戻り値の型は文字列のまま |

出力を組み立てている部分には一切触れていないため、生成される HTML は完全に同一です。

## あわせて対応したこと

コードレビュー（安藤）で、同じウィジェットの見出しリンクにエスケープ（出力する値を安全な文字に変換する処理）が掛かっていない箇所が見つかったため、1 行だけ追加しました。

```php
// 変更前
echo '<a href="' . get_the_permalink( $post_id ) . '">';

// 変更後
echo '<a href="' . esc_url( get_the_permalink( $post_id ) ) . '">';
```

`esc_url()` は URL を出力するときに使う WordPress の関数で、通常のパーマリンク（記事・固定ページの URL）に対しては文字列が変わりません。そのため「出力は変わらない」という本 PR の前提は保たれます。

## この PR で対応しなかったこと（レビューで挙がった指摘）

いずれもレビューで挙がりましたが、本 PR のスコープ（出力を変えない書き換え）から外れるため見送っています。

| 指摘 | 見送る理由 |
|---|---|
| 同じ節の `echo get_the_title( $post_id );` にエスケープが無い（安藤: LOW） | `esc_html()` を掛けると、`<em>` などの HTML を含むページタイトルの見え方が変わりうるため。出力不変という本 PR の前提を外れる |
| `'echo' => false` と `inc/page-list-ancestor/page-list-ancestor.php` の `'echo' => 0` で表記がゆれている（安藤: LOW） | 動作は同一。揃えるには本 issue の対象外である別ファイルの変更が必要になるため |
| この経路の PHPUnit テスト（コードを自動で検証するテスト）が無い（安藤: LOW） | 挙動が変わらないリファクタリングであり、レビュー担当も必須としていないため |

## 確認手順

### 前提

- 固定ページを 2 階層以上作る（例: 親ページ「会社案内」の子として「沿革」「アクセス」）
- 「外観 > ウィジェット」で、サイドバーに **「ExUnit 子ページリスト」** ウィジェットを配置する

### After（この PR の状態で確認）

1. 子ページを持つ固定ページ（例: 親の「会社案内」、または子の「沿革」）をフロント側で開く
   → サイドバーに子ページリストが表示される。見出し部分は親ページ「会社案内」へのリンクになっている
2. 表示された一覧を確認する
   → 子ページ「沿革」「アクセス」がリンクとして並ぶ。一覧の先頭に `<li class="pagenav">`（「固定ページ」などの見出し行）が入っていないこと
3. ブラウザの開発者ツールで、ウィジェット部分の HTML を確認する
   → `<div class="veu_childPages widget_link_list">` の中に `<ul class="localNavi">` があり、その中に子ページの `<li>` が並ぶ
4. 見出し部分のリンク（`<a href="...">会社案内</a>`）の `href` を確認する
   → 親ページの通常のパーマリンクがそのまま入っている（`esc_url()` を通しても変化しない）
5. 子ページを 1 つも持たない固定ページを開く
   → ウィジェットの枠（`before_widget` / `after_widget` を含む箱）自体が出力されない
6. 投稿（ブログ記事）やアーカイブページ（カテゴリー一覧など）を開く
   → ウィジェットは何も出力しない

### Before との比較

master ブランチに切り替えて 1〜6 を同じ条件で実施し、**出力される HTML が一致すること**を確認してください（差が出るとすれば手順 4 の `href` ですが、通常のパーマリンク構造では `esc_url()` を通しても文字列は変わりません）。

### スクリーンショット

表示に影響のない内部処理の変更のため省略します。

## 関連

- WordPress Trac [#66049](https://core.trac.wordpress.org/ticket/66049)（クエリ文字列形式の引数に対する PHPStan 拡張の提案。VK All in One Expansion Unit・Lightning が調査結果に名指しされている）
- vektor-inc/lightning#1438（Lightning のサイドバーで同じ書き換えを行う issue）

Closes #1487

@coderabbitai ignore

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/863